### PR TITLE
Initialize the Script with the first browser tab

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -44,7 +44,7 @@ class Client extends EventEmitter {
      */
     async initialize() {
         const browser = await puppeteer.launch(this.options.puppeteer);
-        const page = await browser.newPage();
+        const page = (await browser.pages())[0];
         page.setUserAgent(UserAgent);
 
         if (this.options.session) {


### PR DESCRIPTION
Suggestion for the script to start under the first tab of the browser, in order to reduce memory consumption.