### PR TITLE
Added "restartOnAuthFail" as an option

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -75,7 +75,11 @@ class Client extends EventEmitter {
                      */
                     this.emit(Events.AUTHENTICATION_FAILURE, 'Unable to log in. Are the session details valid?');
                     browser.close();
-
+                    if (this.options.restartOnAuthFail) {
+                        // session restore failed so try again but without session to force new authentication
+                        this.options.session = null;
+                        this.initialize(this.options);
+                    }
                     return;
                 }
 


### PR DESCRIPTION
- When true, the sessions passed is discarded when reinitialized.

Addresses this issue: https://github.com/pedroslopez/whatsapp-web.js/issues/109