### PR TITLE
Fix for inconsistent MediaKey.

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -18,6 +18,13 @@ class Message extends Base {
 
     _patch(data) {
         /**
+         * MediaKey that represents the sticker 'ID'
+         * @type {string}
+         */
+        this.mediaKey = data.mediaKey;
+
+
+        /**
          * ID that represents the message
          * @type {object}
          */

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -18,7 +18,13 @@ class Message extends Base {
 
     _patch(data) {
         /**
-         * MediaKey that represents the sticker 'ID'
+         * ClientUrl is a representation of the download link of the media. Can be used for stickers.
+         * @type {string}
+         */
+        this.clientUrl = data.clientUrl;
+        
+        /**
+         * MediaKey that represents the key to decode the clientUrl
          * @type {string}
          */
         this.mediaKey = data.mediaKey;


### PR DESCRIPTION
As of my old PR, where I thought MediaKey would be consistent. It broke a sober 30 minutes ago.
Looking into the MediaKey and reverse engineering Whatsapp Web. It happens that the end-to-end encryption resets every session, thus changing the MediaKey. The ClientUrl, however, should be consistent at all times.