### PR TITLE
Fix link previews for receiveres

### DIFF
--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -82,8 +82,8 @@ exports.LoadUtils = () => {
             if (link) {
                 const preview = await window.Store.Wap.queryLinkPreview(link.url);
                 preview.preview = true;
-                preview.subtype = "url";
-                options = { ...options, ...preview};
+                preview.subtype = 'url';
+                options = { ...options, ...preview };
             }
         }
 

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -81,9 +81,9 @@ exports.LoadUtils = () => {
             const link = window.Store.Validators.findLink(content);
             if (link) {
                 const preview = await window.Store.Wap.queryLinkPreview(link.url);
-                if (!preview.status) {
-                    options = { ...options, ...preview};
-                }
+                preview.preview = true;
+                preview.subtype = "url";
+                options = { ...options, ...preview};
             }
         }
 


### PR DESCRIPTION
it's necessary improve your method, i fix solution by myself, if you're trying to send with actual code only sender can see object build on his browser but user(receiver) on phone never see that, it's necessary to add an paramether and remove one IF