### PR TITLE
Added check for null in Message constructor

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -64,7 +64,7 @@ class Message extends Base {
          * ID for the Chat that this message was sent to, except if the message was sent by the current user.
          * @type {string}
          */
-        this.from = (typeof (data.from) === 'object' && data.author !== null) ? data.from._serialized : data.from;
+        this.from = (typeof (data.from) === 'object' && data.from !== null) ? data.from._serialized : data.from;
 
         /**
          * ID for who this message is for.
@@ -73,7 +73,7 @@ class Message extends Base {
          * If the message is sent by another user, it will be the ID for the current user. 
          * @type {string}
          */
-        this.to = (typeof (data.to) === 'object' && data.author !== null) ? data.to._serialized : data.to;
+        this.to = (typeof (data.to) === 'object' && data.to !== null) ? data.to._serialized : data.to;
 
         /**
          * If the message was sent to a group, this field will contain the user that sent the message.

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -64,7 +64,7 @@ class Message extends Base {
          * ID for the Chat that this message was sent to, except if the message was sent by the current user.
          * @type {string}
          */
-        this.from = typeof (data.from) === 'object' ? data.from._serialized : data.from;
+        this.from = (typeof (data.from) === 'object' && data.author !== null) ? data.from._serialized : data.from;
 
         /**
          * ID for who this message is for.
@@ -73,7 +73,7 @@ class Message extends Base {
          * If the message is sent by another user, it will be the ID for the current user. 
          * @type {string}
          */
-        this.to = typeof (data.to) === 'object' ? data.to._serialized : data.to;
+        this.to = (typeof (data.to) === 'object' && data.author !== null) ? data.to._serialized : data.to;
 
         /**
          * If the message was sent to a group, this field will contain the user that sent the message.

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -79,7 +79,7 @@ class Message extends Base {
          * If the message was sent to a group, this field will contain the user that sent the message.
          * @type {string}
          */
-        this.author = typeof (data.author) === 'object' ? data.author._serialized : data.author;
+        this.author = (typeof (data.author) === 'object' && data.author !== null) ? data.author._serialized : data.author;
 
         /**
          * Indicates if the message was forwarded


### PR DESCRIPTION
As I described in my issue, that I opened a few days ago, you get an error when you want to create a new message when the author is null, which happens quite frequently. The problem lies in the typeof check because null is an object. I fixed the issue by adding an additional check for null in the constructor for all the fields that previously only checked for typeof === object. This should fix the errors.

Resolves #250 