### PR TITLE
fix: Constants export in index.js

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -298,6 +298,12 @@ declare namespace WAWebJS {
 
   }
 
+  /** whatsapp web url */
+  export const WhatsWebURL: string
+  
+  /** default client options */
+  export const DefaultOptions: ClientOptions
+
   /** Chat types */
   export enum ChatTypes {
     SOLO = 'solo',

--- a/index.js
+++ b/index.js
@@ -18,5 +18,5 @@ module.exports = {
     PrivateContact: require('./src/structures/PrivateContact'),
     BusinessContact: require('./src/structures/BusinessContact'),
     ClientInfo: require('./src/structures/ClientInfo'),
-    Location: require('./src/structures/Location'),
+    Location: require('./src/structures/Location')
 };

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 const Constants = require('./src/util/Constants');
 
 module.exports = {
-    ...Constants,
     Client: require('./src/Client'),
     
     version: require('./package.json').version,
@@ -18,5 +17,7 @@ module.exports = {
     PrivateContact: require('./src/structures/PrivateContact'),
     BusinessContact: require('./src/structures/BusinessContact'),
     ClientInfo: require('./src/structures/ClientInfo'),
-    Location: require('./src/structures/Location')
+    Location: require('./src/structures/Location'),
+    
+    ...Constants
 };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 'use strict';
 
+const Constants = require('./src/util/Constants');
+
 module.exports = {
+    ...Constants,
     Client: require('./src/Client'),
     
     version: require('./package.json').version,
@@ -15,5 +18,5 @@ module.exports = {
     PrivateContact: require('./src/structures/PrivateContact'),
     BusinessContact: require('./src/structures/BusinessContact'),
     ClientInfo: require('./src/structures/ClientInfo'),
-    Location: require('./src/structures/Location')
+    Location: require('./src/structures/Location'),
 };


### PR DESCRIPTION
I came across an error while trying to use the enums present in index.d.ts; Example:
```typescript
import WhatsappWeb = require('whatsapp-web.js')
if (messageType === WhatsappWeb.MessageType.TEXT) // Error: cannot read property 'TEXT' of undefined
```

I found out that even though MessageType is defined in index.d.ts, it should also be exported in index.js, in order for it to be present at runtime.
This PR exports all the Constants in index.js and fixes the issue.

Note: I used the spread operator to export all the constants at once. If you think it should be better to export them individually, please let me know and I can try doing that also.
