### PR TITLE
Chat mute expiration

### DIFF
--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -58,7 +58,7 @@ class Chat extends Base {
         this.archived = data.archive;
 
         /**
-         * Timestamp for when the mute expiration
+         * Unix timestamp for when the mute expires
          * @type {number}
          */
         this.muteExpiration = data.muteExpiration;

--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -57,6 +57,12 @@ class Chat extends Base {
          */
         this.archived = data.archive;
 
+        /**
+         * Timestamp for when the mute expiration
+         * @type {number}
+         */
+        this.muteExpiration = data.muteExpiration;
+
         return super._patch(data);
     }
 


### PR DESCRIPTION
The lib provides the mute () and unmute () methods, but there is no property in Chat that indicates whether the conversation is already mutated. I took a look and this property is just for that.