### PR TITLE
feat: Get the registered chat id in whatsapp

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,6 +65,9 @@ declare namespace WAWebJS {
         /** Check if a given ID is registered in whatsapp */
         isRegisteredUser(contactId: string): Promise<boolean>
 
+        /** Get the registered chat id in whatsapp */
+        getRegisteredChatId(chatId: string): Promise<string>
+
         /**
          * Mutes the Chat until a specified date
          * @param chatId ID of the chat that will be muted

--- a/index.d.ts
+++ b/index.d.ts
@@ -65,8 +65,8 @@ declare namespace WAWebJS {
         /** Check if a given ID is registered in whatsapp */
         isRegisteredUser(contactId: string): Promise<boolean>
 
-        /** Get the registered chat id in whatsapp */
-        getRegisteredChatId(chatId: string): Promise<string>
+        /** Get the registered number id in whatsapp */
+        getNumberId(chatId: string): Promise<object>
 
         /**
          * Mutes the Chat until a specified date

--- a/src/Client.js
+++ b/src/Client.js
@@ -713,15 +713,13 @@ class Client extends EventEmitter {
     }
 
     /**
-     * Get the registered chat id in whatsapp
+     * Get the registered number id in whatsapp
      * @param {string} id the whatsapp user's ID
      * @returns {Promise<object>}
      */
-    async getRegisteredChatId(id) {
-        return await this.pupPage.evaluate(async (id) => {
-            let result = await window.Store.Wap.queryExist(id);
-            if( result.jid === undefined ) throw 'The number provided is not a registered whatsapp user';
-            return result.jid._serialized;
+    async getNumberId(id) {
+        return await this.pupPage.evaluate(async numberId => {
+            return await window.WWebJS.getNumberId(numberId);
         }, id);
     }
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -713,6 +713,19 @@ class Client extends EventEmitter {
     }
 
     /**
+     * Get the registered chat id in whatsapp
+     * @param {string} id the whatsapp user's ID
+     * @returns {Promise<object>}
+     */
+    async getRegisteredChatId(id) {
+        return await this.pupPage.evaluate(async (id) => {
+            let result = await window.Store.Wap.queryExist(id);
+            if( result.jid === undefined ) throw 'The number provided is not a registered whatsapp user';
+            return result.jid._serialized;
+        }, id);
+    }
+
+    /**
      * Create a new group
      * @param {string} name group title
      * @param {Array<Contact|string>} participants an array of Contacts or contact IDs to add to the group


### PR DESCRIPTION
Get the registered chat id in whatsapp.

**Reason?**
- In Brazil, after change the rule for cell numbers, WhatsApp didn't change they database for the already registered numbers, just to the new ones, so here we have to get what's the chatId registered in WhatsApp before send the messages.

I'll show it in codes:

Using my phone number, the actual `client.isRegisteredUser()` return true for the valid and the invalid chatId, you guys can check there:
```
> npm run shell
wwebjs> client.isRegisteredUser("5548991581407@c.us").then(result => { console.log(`isRegistered: ${result}`); });
Promise { <pending> }
wwebjs> isRegistered: true
wwebjs> client.isRegisteredUser("554891581407@c.us").then(result => { console.log(`isRegistered: ${result}`); });
Promise { <pending> }
wwebjs> isRegistered: true
```

The numbers are different, the 5548**9**91581407 is the new rule, but in WhatsApp it doesn't exists, so I have to send the message to the old one, without this additional 9.

So, to keep the compability and resolve this problem, with some help from @Guicuton I created this function at client.js:

```
> npm run shell
wwebjs> client.getRegisteredChatId("5548991581407@c.us").then(result => { console.log(`Registered chatId: ${result}`); });
Promise { <pending> }
wwebjs> Registered chatId: 554891581407@c.us
```

I dont know if other countries has this problem, but in Brazil we have, and it prevent from future problems to another countries too.