### PR TITLE
Fixed bug when msgs length is smaller than limit.

### DIFF
--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -184,7 +184,8 @@ class Chat extends Base {
             }
 
             msgs.sort((a, b) => (a.t > b.t) ? 1 : -1);
-            return msgs.splice(msgs.length - limit).map(m => window.WWebJS.getMessageModel(m));
+            if (msgs.length > limit) msgs = msgs.splice(msgs.length - limit);
+            return msgs.map(m => window.WWebJS.getMessageModel(m));
 
         }, this.id._serialized, searchOptions.limit);
 


### PR DESCRIPTION
Fixed bug when msgs array length is smaller than limit option.

if the chat has less messages than than the total, (in my case, was a 17 messages chat with 20 messages filter), the code was returning only the last 3 messages (the splice method was receiving the '-3' parameter, causing it to return only the last 3 messages)