### PR TITLE
feat: getIdByNumber function added to check the real phone number

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -66,7 +66,7 @@ declare namespace WAWebJS {
         isRegisteredUser(contactId: string): Promise<boolean>
 
         /** Returns real id registered in whatsapp of given phone number */
-        getIdByNumber(contactId: string): Promise<string>
+        getIdByNumber(contactId: string): Promise<string | null>
 
         /**
          * Mutes the Chat until a specified date

--- a/index.d.ts
+++ b/index.d.ts
@@ -65,6 +65,9 @@ declare namespace WAWebJS {
         /** Check if a given ID is registered in whatsapp */
         isRegisteredUser(contactId: string): Promise<boolean>
 
+        /** Returns real id registered in whatsapp of given phone number */
+        getIdByNumber(contactId: string): Promise<string>
+
         /**
          * Mutes the Chat until a specified date
          * @param chatId ID of the chat that will be muted

--- a/src/Client.js
+++ b/src/Client.js
@@ -713,6 +713,18 @@ class Client extends EventEmitter {
     }
 
     /**
+     * Returns a real id registered in whatsapp
+     * @param {string} id the whatsapp user's ID
+     * @returns {Promise<string>}
+     */
+    async getIdByNumber(id) {
+        return await this.pupPage.evaluate(async (id) => {
+            let result = await window.Store.Wap.queryExist(id);
+            return result.status === 200 ? result.jid._serialized : undefined;
+        }, id);
+    }
+
+    /**
      * Create a new group
      * @param {string} name group title
      * @param {Array<Contact|string>} participants an array of Contacts or contact IDs to add to the group

--- a/src/Client.js
+++ b/src/Client.js
@@ -720,7 +720,7 @@ class Client extends EventEmitter {
     async getIdByNumber(id) {
         return await this.pupPage.evaluate(async (id) => {
             let result = await window.Store.Wap.queryExist(id);
-            return result.status === 200 ? result.jid._serialized : undefined;
+            return result.status === 200 ? result.jid._serialized : null;
         }, id);
     }
 


### PR DESCRIPTION
Here in Brazil we have a problem with some phone numbers that doesn't have the number "9" in front the phone number, because some years ago, all phone numbers of the country received an additional number "9". So when you try to send a message for one of these old numbers with the new pattern (with "9"), whatsapp thinks that's a different number and starts a new chat.
With this function, we can send the number always with the "9" digit and if it is an old number, this function will return the right number (without "9").