### PR TITLE
feat: check if the message has been revoked

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -504,6 +504,10 @@ declare namespace WAWebJS {
          * Forwards this message to another chat
          */
         forward: (chat: Chat | string) => Promise<void>,
+        /**
+         * Checks if the message has been revoked
+         */
+        checkRevoked: () => Promise<boolean>
     }
 
     /** ID that represents a message */

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -272,6 +272,16 @@ class Message extends Base {
             return window.Store.Cmd.sendDeleteMsgs(msg.chat, [msg], true);
         }, this.id._serialized, everyone);
     }
+
+    /**
+     * Checks if the message has been revoked
+     * @returns {Promise<boolean>}
+     */
+    async checkRevoked() {
+        return await this.client.pupPage.evaluate((msgId) => {
+            return !window.Store.Msg.get(msgId);
+        }, this.id._serialized);
+    }
 }
 
 module.exports = Message;


### PR DESCRIPTION
Adds the ability to check whether a message has been revoked or not.

This may help those who want to do something with the original ID of a revoked message and can't do it because `message_revoke_everyone` gives a different ID for revoked message other than the original message ID  (#427) .

Exemple of usage: 
```javascript
client.on('message', async msg => {
  if (checkBadWord(msg.body)) {
    await msg.reply(
      'This kind of message is not allowed in this group, please delete it'
    );
  
    setTimeout(async () => {
      const revoked = await msg.checkRevoked();
      if (!revoked) {
          banUser(msg.from, msg.author);
      }
    }, 15000);
  }
});
```