### PR TITLE
feat: send media as document

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -526,6 +526,8 @@ declare namespace WAWebJS {
         linkPreview?: boolean
         /** Send audio as voice message */
         sendAudioAsVoice?: boolean
+        /** Send media as document */
+        sendMediaAsDocument?: boolean
         /** Automatically parse vCards and send them as contacts */
         parseVCards?: boolean
         /** Image or videos caption */

--- a/src/Client.js
+++ b/src/Client.js
@@ -440,6 +440,7 @@ class Client extends EventEmitter {
         let internalOptions = {
             linkPreview: options.linkPreview === false ? undefined : true,
             sendAudioAsVoice: options.sendAudioAsVoice,
+            sendMediaAsDocument: options.sendMediaAsDocument,
             caption: options.caption,
             quotedMessageId: options.quotedMessageId,
             parseVCards: options.parseVCards === false ? false : true,

--- a/src/Client.js
+++ b/src/Client.js
@@ -420,6 +420,7 @@ class Client extends EventEmitter {
      * @typedef {Object} MessageSendOptions
      * @property {boolean} [linkPreview=true] - Show links preview
      * @property {boolean} [sendAudioAsVoice=false] - Send audio as voice message
+     * @property {boolean} [sendMediaAsDocument=false] = Send media as a document
      * @property {boolean} [parseVCards=true] - Automatically parse vCards and send them as contacts
      * @property {string} [caption] - Image or video caption
      * @property {string} [quotedMessageId] - Id of the message that is being quoted (or replied to)

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -52,7 +52,10 @@ exports.LoadUtils = () => {
     window.WWebJS.sendMessage = async (chat, content, options = {}) => {
         let attOptions = {};
         if (options.attachment) {
-            attOptions = await window.WWebJS.processMediaData(options.attachment, options.sendAudioAsVoice);
+            attOptions = await window.WWebJS.processMediaData(options.attachment, { 
+                forceVoice: options.sendAudioAsVoice, 
+                forceDocument: options.sendMediaAsDocument 
+            });
             content = attOptions.preview;
             delete options.attachment;
         }
@@ -153,10 +156,10 @@ exports.LoadUtils = () => {
         return window.Store.Msg.get(newMsgId._serialized);
     };
 
-    window.WWebJS.processMediaData = async (mediaInfo, forceVoice) => {
+    window.WWebJS.processMediaData = async (mediaInfo, { forceVoice, forceDocument }) => {
         const file = window.WWebJS.mediaInfoToFile(mediaInfo);
         const mData = await window.Store.OpaqueData.createFromData(file, file.type);
-        const mediaPrep = window.Store.MediaPrep.prepRawMedia(mData, {});
+        const mediaPrep = window.Store.MediaPrep.prepRawMedia(mData, { asDocument: forceDocument });
         const mediaData = await mediaPrep.waitForPrep();
         const mediaObject = window.Store.MediaObject.getOrCreateMediaObject(mediaData.filehash);
 
@@ -167,6 +170,10 @@ exports.LoadUtils = () => {
 
         if (forceVoice && mediaData.type === 'audio') {
             mediaData.type = 'ptt';
+        }
+
+        if (forceDocument) {
+            mediaData.type = 'document';
         }
 
         if (!(mediaData.mediaBlob instanceof window.Store.OpaqueData)) {


### PR DESCRIPTION
Adds option in `client.sendMessage` to allow sending media as document without compression loss.

Usage:

```javascript
const media = MessageMedia.fromFilePath('909641.png');
client.sendMessage('xxxxxxxxxx@c.us', media, { sendMediaAsDocument: true });
```

Result:
![image](https://user-images.githubusercontent.com/20830847/102837390-759bac00-43da-11eb-9f5c-e733cd133180.png)


closes #428 