### PR TITLE
Garbage Collector / Memory Optimization

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -201,10 +201,10 @@ class Client extends EventEmitter {
         if (this.options.memoryLogPath) {
             setInterval(async ()=>{
                 let memoryLine = await page.evaluate(() => {
-                    return Math.floor(Date.now() / 1000) + "," + window.performance.memory.totalJSHeapSize + "," + window.performance.memory.usedJSHeapSize + "\n";
+                    return Math.floor(Date.now() / 1000) + ',' + window.performance.memory.totalJSHeapSize + ',' + window.performance.memory.usedJSHeapSize + '\n';
                 });
                 Util.appendToLog(this.options.memoryLogPath,memoryLine); //this needs to be on Util because fs isn't here
-                }, 60000); // lets do each minute
+            }, 60000); // lets do each minute
         }
         
         // Check window.Store Injection

--- a/src/Client.js
+++ b/src/Client.js
@@ -199,13 +199,13 @@ class Client extends EventEmitter {
 
         //Fire memory log interval
         if (this.options.memoryLogPath) {
-            Util.appendToLog(this.options.memoryLogPath,Math.floor(Date.now() / 1000) + ",0,0\n"); //so we can know when the client Authenticated
+            Util.appendToLog(this.options.memoryLogPath,Math.floor(Date.now() / 1000) + ',0,0\n'); //so we can know when the client Authenticated
             setInterval(async ()=>{
                 let memoryLine = await page.evaluate(() => {
-                    return Math.floor(Date.now() / 1000) + "," + window.performance.memory.totalJSHeapSize + "," + window.performance.memory.usedJSHeapSize + "\n";
+                    return Math.floor(Date.now() / 1000) + ',' + window.performance.memory.totalJSHeapSize + ',' + window.performance.memory.usedJSHeapSize + '\n';
                 });
                 Util.appendToLog(this.options.memoryLogPath,memoryLine); //this needs to be on Util because fs isn't here
-                }, 10000); // lets do each ten seconds for more precise info
+            }, 10000); // lets do each ten seconds for more precise info
         }
         
         // Check window.Store Injection
@@ -934,7 +934,7 @@ class Client extends EventEmitter {
      */
     async garbageCollect(){
         await Promise.all([this.pupPage.evaluate('window.Store.Chat.delete();'), this.pupPage.evaluate('window.Store.Msg.delete();'), this.pupPage.evaluate('window.gc();')]).catch((err) =>{throw err;});
-        //console.log("gc");
+        //console.log('gc');
         return true;
     }
 }

--- a/src/Client.js
+++ b/src/Client.js
@@ -933,9 +933,9 @@ class Client extends EventEmitter {
      */
     async garbageCollect(){
         try {
-            await this.pupPage.evaluate("window.Store.Chat.delete();");
-            await this.pupPage.evaluate("window.Store.Msg.delete();");
-            await this.pupPage.evaluate("gc();");
+            await this.pupPage.evaluate('window.Store.Chat.delete();');
+            await this.pupPage.evaluate('window.Store.Msg.delete();');
+            await this.pupPage.evaluate('gc();');
             //await this.pupPage.evaluate("console.clear()");
             return true;
         }catch(err){

--- a/src/Client.js
+++ b/src/Client.js
@@ -199,12 +199,13 @@ class Client extends EventEmitter {
 
         //Fire memory log interval
         if (this.options.memoryLogPath) {
+            Util.appendToLog(this.options.memoryLogPath,Math.floor(Date.now() / 1000) + ",0,0\n"); //so we can know when the client Authenticated
             setInterval(async ()=>{
                 let memoryLine = await page.evaluate(() => {
-                    return Math.floor(Date.now() / 1000) + ',' + window.performance.memory.totalJSHeapSize + ',' + window.performance.memory.usedJSHeapSize + '\n';
+                    return Math.floor(Date.now() / 1000) + "," + window.performance.memory.totalJSHeapSize + "," + window.performance.memory.usedJSHeapSize + "\n";
                 });
                 Util.appendToLog(this.options.memoryLogPath,memoryLine); //this needs to be on Util because fs isn't here
-            }, 60000); // lets do each minute
+                }, 10000); // lets do each ten seconds for more precise info
         }
         
         // Check window.Store Injection
@@ -932,16 +933,9 @@ class Client extends EventEmitter {
      * @returns {Boolean}
      */
     async garbageCollect(){
-        try {
-            await this.pupPage.evaluate('window.Store.Chat.delete();');
-            await this.pupPage.evaluate('window.Store.Msg.delete();');
-            await this.pupPage.evaluate('gc();');
-            //await this.pupPage.evaluate("console.clear()");
-            return true;
-        }catch(err){
-            throw err;
-        }
-        return false;
+        await Promise.all([this.pupPage.evaluate('window.Store.Chat.delete();'), this.pupPage.evaluate('window.Store.Msg.delete();'), this.pupPage.evaluate('window.gc();')]).catch((err) =>{throw err;});
+        //console.log("gc");
+        return true;
     }
 }
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -13,6 +13,7 @@ exports.DefaultOptions = {
     authTimeoutMs: 45000,
     takeoverOnConflict: false,
     takeoverTimeoutMs: 0,
+    memoryOptimizationMs: 0,
     userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Safari/537.36',
     ffmpegPath: 'ffmpeg',
     bypassCSP: false

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -14,6 +14,7 @@ exports.DefaultOptions = {
     takeoverOnConflict: false,
     takeoverTimeoutMs: 0,
     memoryOptimizationMs: 0,
+    memoryLogPath: false,
     userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Safari/537.36',
     ffmpegPath: 'ffmpeg',
     bypassCSP: false

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -198,6 +198,15 @@ class Util {
     static setFfmpegPath(path) {
         ffmpeg.setFfmpegPath(path);
     }
+    
+    /**
+     * Append log to file
+     * @param {string} logFile
+     * @param {string} logLine
+     */
+    static async appendToLog(logFile, logLine) {
+        await fs.appendFile(logFile, logLine, function (err) { if (err) throw err;});
+    }
 }
 
 module.exports = Util;


### PR DESCRIPTION
Add method to collect garbage from waweb, trying to optimize ram consuptions. This leads to a CPU and Network overhead.
Maybe change .delete() to .deleteMsgsOlderThan(ts)

Pros:
Better Ram Consumption

Cons:
Cpu and Network overhead
Any Select queries will have aditional overhead ( Like fetching messages from a chat )
This enables a race condition ( When you process a message and fires GC at the same time )

It needs futher testing, any comments are welcome.