### PR TITLE
fix "TimeoutError: waiting for selector `canvas` failed:..."

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -120,25 +120,29 @@ class Client extends EventEmitter {
 
         } else {
             const getQrCode = async () => {
-                // Check if retry button is present
-                var QR_RETRY_SELECTOR = 'div[data-ref] > span > button';
-                var qrRetry = await page.$(QR_RETRY_SELECTOR);
-                if (qrRetry) {
-                    await qrRetry.click();
-                }
+                try {
+                    // Check if retry button is present
+                    var QR_RETRY_SELECTOR = 'div[data-ref] > span > button';
+                    var qrRetry = await page.$(QR_RETRY_SELECTOR);
+                    if (qrRetry) {
+                        await qrRetry.click();
+                    }
 
-                // Wait for QR Code
-                const QR_CANVAS_SELECTOR = 'canvas';
-                await page.waitForSelector(QR_CANVAS_SELECTOR, { timeout: this.options.qrTimeoutMs });
-                const qrImgData = await page.$eval(QR_CANVAS_SELECTOR, canvas => [].slice.call(canvas.getContext('2d').getImageData(0, 0, 264, 264).data));
-                const qr = jsQR(qrImgData, 264, 264).data;
-                
-                /**
-                * Emitted when the QR code is received
-                * @event Client#qr
-                * @param {string} qr QR Code
-                */
-                this.emit(Events.QR_RECEIVED, qr);
+                    // Wait for QR Code
+                    const QR_CANVAS_SELECTOR = 'canvas';
+                    await page.waitForSelector(QR_CANVAS_SELECTOR, { timeout: this.options.qrTimeoutMs });
+                    const qrImgData = await page.$eval(QR_CANVAS_SELECTOR, canvas => [].slice.call(canvas.getContext('2d').getImageData(0, 0, 264, 264).data));
+                    const qr = jsQR(qrImgData, 264, 264).data;
+
+                    /**
+                    * Emitted when the QR code is received
+                    * @event Client#qr
+                    * @param {string} qr QR Code
+                    */
+                    this.emit(Events.QR_RECEIVED, qr);
+                } catch(e) {
+                    if (err.name === 'TimeoutError') return;
+                }
             };
             getQrCode();
             this._qrRefreshInterval = setInterval(getQrCode, this.options.qrRefreshIntervalMs);

--- a/src/Client.js
+++ b/src/Client.js
@@ -140,7 +140,7 @@ class Client extends EventEmitter {
                     * @param {string} qr QR Code
                     */
                     this.emit(Events.QR_RECEIVED, qr);
-                } catch(e) {
+                } catch(err) {
                     if (err.name === 'TimeoutError') return;
                 }
             };


### PR DESCRIPTION
fixed "TimeoutError: waiting for selector `canvas` failed: timeout 45000ms exceeded"

explanation: in node, loops as setTimeout or setInterval runs by default on the global scope, so you can't catch exceptions easily.
this catches and ignores the timeout exception