### PR TITLE
Update node-webpmux 2.x syntax to 3.x (support upstream breaking change)

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -183,9 +183,9 @@ class Util {
             let jsonBuffer = Buffer.from(JSON.stringify(json), 'utf8');
             let exif = Buffer.concat([exifAttr, jsonBuffer]);
             exif.writeUIntLE(jsonBuffer.length, 14, 4);
-            await img.loadBuffer(Buffer.from(webpMedia.data, 'base64'));
+            await img.load(Buffer.from(webpMedia.data, 'base64'));
             img.exif = exif;
-            webpMedia.data = (await img.saveBuffer()).toString('base64');
+            webpMedia.data = (await img.save(null)).toString('base64');
         }
 
         return webpMedia;


### PR DESCRIPTION
dependabot bumped you to 3.0.0 apparently ignoring that major version bumps _may_ contain breaking changes. In this case, it did. This _should_ be the last breaking change I make to node-webpmux for quite some time.