### PR TITLE
fix: Use correct type for puppeteer launch options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -278,7 +278,7 @@ declare namespace WAWebJS {
          * @default 45000 */
         authTimeoutMs?: number,
         /** Puppeteer launch options. View docs here: https://github.com/puppeteer/puppeteer/ */
-        puppeteer?: puppeteer.LaunchOptions
+        puppeteer?: puppeteer.LaunchOptions & puppeteer.BrowserLaunchArgumentOptions & puppeteer.BrowserConnectOptions
         /** Refresh interval for qr code (how much time to wait before checking if the qr code has changed)
          * @default 20000 */
         qrRefreshIntervalMs?: number


### PR DESCRIPTION
On typescript is not possible to pass `puppeteer: { headless: false }` on the `Client`constructor