### PR TITLE
fix Error: GROUP_JID: invalid jid type: Not an instance of WID issue

### DIFF
--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -358,11 +358,8 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.getChat = async chatId => {
-        console.log(chatId)
         const chatWid = window.Store.WidFactory.createWid(chatId);
-        console.log(chatWid)
         const chat = await window.Store.Chat.find(chatWid);
-        console.log(chat)
         return await window.WWebJS.getChatModel(chat);
     };
 

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -338,13 +338,15 @@ exports.LoadUtils = () => {
 
 
     window.WWebJS.getChatModel = async chat => {
+        
         let res = chat.serialize();
         res.isGroup = chat.isGroup;
         res.formattedTitle = chat.formattedTitle;
         res.isMuted = chat.mute && chat.mute.isMuted;
 
         if (chat.groupMetadata) {
-            await window.Store.GroupMetadata.update(chat.id._serialized);
+            const chatWid = window.Store.WidFactory.createWid((chat.id._serialized));
+            await window.Store.GroupMetadata.update(chatWid);
             res.groupMetadata = chat.groupMetadata.serialize();
         }
 
@@ -356,15 +358,18 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.getChat = async chatId => {
+        console.log(chatId)
         const chatWid = window.Store.WidFactory.createWid(chatId);
+        console.log(chatWid)
         const chat = await window.Store.Chat.find(chatWid);
+        console.log(chat)
         return await window.WWebJS.getChatModel(chat);
     };
 
     window.WWebJS.getChats = async () => {
         const chats = window.Store.Chat.models;
 
-        const chatPromises = chats.map(chat => window.WWebJS.getChatModel(chat));
+        const chatPromises = chats.map(chat => window.WWebJS.getChatModel(chat));        
         return await Promise.all(chatPromises);
     };
 


### PR DESCRIPTION
Fix issue when client.getChats() try to get model for a GroupChat because method window.Store.GroupMetadata.update expect a wid instead a serialized id