### PR TITLE
Adding media placeholder for images and videos

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -521,6 +521,8 @@ declare namespace WAWebJS {
         author?: string,
         /** Message content */
         body: string,
+        /** Media Placeholder */
+        mediaPlaceholder: string;
         /** Indicates if the message was a broadcast */
         broadcast: boolean,
         /** Indicates if the message was a status update */

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -50,6 +50,14 @@ class Message extends Base {
          */
         this.body = this.hasMedia ? data.caption || '' : data.body || '';
 
+        /**
+         * Media Placeholder for Image and Video types
+         * @type {string}
+         */
+        if(this.hasMedia && (data.type == MessageTypes.IMAGE || data.type == MessageTypes.VIDEO)) {
+            this.mediaPlaceholder = data.body;
+        }
+        
         /** 
          * Message type
          * @type {MessageTypes}


### PR DESCRIPTION
Sometimes we need placeholder for Images and Video like the original **Whatsapp** first it just show blurry image and after you click on download button it start downloading media and show the clear one. This media placeholder is missing in the **Whatsapp-web.js** I just add it.