### PR TITLE
Fix groupMetadata for old group string pattern

### DIFF
--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -348,7 +348,7 @@ exports.LoadUtils = () => {
         res.isMuted = chat.mute && chat.mute.isMuted;
 
         if (chat.groupMetadata) {
-            await window.Store.GroupMetadata.update(chat.id._serialized);
+            await window.Store.GroupMetadata.update((window.Store.WidFactory.createWid(chat.id._serialized)));
             res.groupMetadata = chat.groupMetadata.serialize();
         }
 


### PR DESCRIPTION
Without this fix we can't get old groups metadata ( numberOfWhoCreated+"-"+timestampOfCreation+"@g.us")
The new pattern is: Numbers(size:18)+"@g.us";

Ex: 
120363040000930000@g.us //new
5511999999999-1479161315@g.us //old


TESTS NEEDED:
So apparently the old method is working (and the new method too), so we need to see if whatsapp will "fix" this or not

Edit timestamp: 1639624625
