### PR TITLE
add tests for `takeoverOnConflict` 

### DIFF
--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -8,7 +8,6 @@ exports.ExposeStore = (moduleRaidStr) => {
     window.Store = Object.assign({}, window.mR.findModule(m => m.default && m.default.Chat)[0].default);
     window.Store.AppState = window.mR.findModule('STREAM')[0].Socket;
     window.Store.Conn = window.mR.findModule('Conn')[0].Conn;
-    window.Store.CryptoLib = window.mR.findModule('decryptE2EMedia')[0];
     window.Store.Wap = window.mR.findModule('queryLinkPreview')[0].default;
     window.Store.SendSeen = window.mR.findModule('sendSeen')[0];
     window.Store.SendClear = window.mR.findModule('sendClear')[0];

--- a/tests/client.js
+++ b/tests/client.js
@@ -211,46 +211,46 @@ describe('Client', function() {
     
             it('exposes all required WhatsApp Web internal models', async function() {
                 const expectedModules = [
-                    'Chat',
-                    'Msg',
-                    'Contact',
-                    'Conn', 
                     'AppState',
-                    'CryptoLib', 
-                    'Wap', 
-                    'SendSeen', 
-                    'SendClear', 
-                    'SendDelete', 
-                    'genId', 
-                    'SendMessage', 
-                    'MsgKey', 
-                    'Invite', 
-                    'OpaqueData', 
-                    'MediaPrep', 
-                    'MediaObject', 
-                    'MediaUpload',
-                    'Cmd',
-                    'MediaTypes',
-                    'VCard',
-                    'UserConstructor',
-                    'Validators',
-                    'WidFactory',
                     'BlockContact',
-                    'GroupMetadata',
-                    'Sticker',
-                    'UploadUtils',
-                    'Label',
+                    'Call',
+                    'Chat',
+                    'Cmd',
+                    'Conn',
+                    'Contact',
+                    'DownloadManager',
                     'Features',
+                    'GroupMetadata',
+                    'Invite',
+                    'Label',
+                    'MediaObject',
+                    'MediaPrep',
+                    'MediaTypes',
+                    'MediaUpload',
+                    'Msg',
+                    'MsgKey',
+                    'OpaqueData',
                     'QueryOrder',
                     'QueryProduct',
-                    'DownloadManager'
-                ];  
+                    'SendClear',
+                    'SendDelete',
+                    'SendMessage',
+                    'SendSeen',
+                    'Sticker',
+                    'UploadUtils',
+                    'UserConstructor',
+                    'VCard',
+                    'Validators',
+                    'Wap',
+                    'WidFactory',
+                    'genId'
+                ];
               
-                const loadedModules = await client.pupPage.evaluate(() => {
-                    return Object.keys(window.Store);
-                });
+                const loadedModules = await client.pupPage.evaluate((expectedModules) => {
+                    return expectedModules.filter(m => Boolean(window.Store[m]));
+                }, expectedModules);
     
-                expect(loadedModules).to.include.members(expectedModules);
+                expect(loadedModules).to.have.members(expectedModules);
             });
         });
     


### PR DESCRIPTION
GitHub was [drunk](https://www.githubstatus.com/incidents/vvthhf8gxt80) when #1169 was merged and did not include the second commit with tests that was on the same branch.
Also realized the test for checking if all modules were exposed was considering `undefined` values as passing, which shouldn't be the case.