### PR TITLE
fix: dont cause redirect loop due to session restore

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -165,8 +165,8 @@ declare namespace WAWebJS {
 
         /** Emitted when the client has been disconnected */
         on(event: 'disconnected', listener: (
-            /** state that caused the disconnect */
-            reason: WAState
+            /** reason that caused the disconnect */
+            reason: WAState | "NAVIGATION"
         ) => void): this
 
         /** Emitted when a user joins the chat via invite link or is added by an admin */

--- a/index.d.ts
+++ b/index.d.ts
@@ -166,7 +166,7 @@ declare namespace WAWebJS {
         /** Emitted when the client has been disconnected */
         on(event: 'disconnected', listener: (
             /** reason that caused the disconnect */
-            reason: WAState | "NAVIGATED"
+            reason: WAState
         ) => void): this
 
         /** Emitted when a user joins the chat via invite link or is added by an admin */

--- a/index.d.ts
+++ b/index.d.ts
@@ -165,7 +165,7 @@ declare namespace WAWebJS {
 
         /** Emitted when the client has been disconnected */
         on(event: 'disconnected', listener: (
-            /** reason that caused the disconnect */
+            /** state that caused the disconnect */
             reason: WAState
         ) => void): this
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -114,7 +114,7 @@ class Client extends EventEmitter {
         if (this.options.session) {
             // Check if session restore was successful
             try {
-                await page.waitForSelector(KEEP_PHONE_CONNECTED_IMG_SELECTOR, { timeout: 0 });
+                await page.waitForSelector(KEEP_PHONE_CONNECTED_IMG_SELECTOR, { timeout: this.options.authTimeoutMs });
             } catch (err) {
                 if (err.name === 'TimeoutError') {
                     /**
@@ -385,7 +385,7 @@ class Client extends EventEmitter {
                 /**
                  * Emitted when the client has been disconnected
                  * @event Client#disconnected
-                 * @param {WAState} reason state that caused the disconnect
+                 * @param {WAState|"NAVIGATION"} reason reason that caused the disconnect
                  */
                 this.emit(Events.DISCONNECTED, state);
                 this.destroy();
@@ -458,7 +458,6 @@ class Client extends EventEmitter {
             if(!appState || appState === WAState.PAIRING) {
                 this.emit(Events.DISCONNECTED, 'NAVIGATION');
                 await this.destroy();
-                console.log('WOULD DESTROY bc nav');
             }
         });
     }

--- a/src/Client.js
+++ b/src/Client.js
@@ -388,7 +388,7 @@ class Client extends EventEmitter {
                 /**
                  * Emitted when the client has been disconnected
                  * @event Client#disconnected
-                 * @param {WAState} reason reason that caused the disconnect
+                 * @param {WAState} reason state that caused the disconnect
                  */
                 this.emit(Events.DISCONNECTED, state);
                 this.destroy();

--- a/src/Client.js
+++ b/src/Client.js
@@ -389,7 +389,6 @@ class Client extends EventEmitter {
                  */
                 this.emit(Events.DISCONNECTED, state);
                 this.destroy();
-                // console.log('would destroy');
             }
         });
 
@@ -452,6 +451,16 @@ class Client extends EventEmitter {
          * @event Client#ready
          */
         this.emit(Events.READY);
+
+        // Disconnect when navigating away when in PAIRING state (detect logout)
+        this.pupPage.on('framenavigated', async () => {
+            const appState = await this.getState();
+            if(!appState || appState === WAState.PAIRING) {
+                this.emit(Events.DISCONNECTED, 'NAVIGATION');
+                await this.destroy();
+                console.log('WOULD DESTROY bc nav');
+            }
+        });
     }
 
     /**
@@ -722,6 +731,7 @@ class Client extends EventEmitter {
      */
     async getState() {
         return await this.pupPage.evaluate(() => {
+            if(!window.Store) return null;
             return window.Store.AppState.state;
         });
     }


### PR DESCRIPTION
The redirect loop was caused because WhatsApp Web was clearing the session from local storage, but we were always adding it back with `evaluateOnNewDocument`. This ensures it only happens the first time.

The `UNPAIRED` state being emitted when logging out seems to be inconsistent, so checking for frame navigation still seems to be the most reliable way to detect a logout. This also should fix #1179 by returning `null` when checking state if the Store isn't available.