### PR TITLE
Getting PID of running browser

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -75,6 +75,14 @@ class Client extends EventEmitter {
             browser = await puppeteer.launch(this.options.puppeteer);
             page = (await browser.pages())[0];
         }
+        if (browser && page){
+            try{
+                const _pid = browser.process().pid;
+                this.emit(Events.BROWSER_INIT, _pid);
+            } catch (e){
+                this.emit(Events.BROWSER_INIT, null, e)
+            }
+        }
         
         await page.setUserAgent(this.options.userAgent);
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -38,6 +38,7 @@ exports.Status = {
 exports.Events = {
     AUTHENTICATED: 'authenticated',
     AUTHENTICATION_FAILURE: 'auth_failure',
+    BROWSER_INIT: 'browser_init',
     READY: 'ready',
     MESSAGE_RECEIVED: 'message',
     MESSAGE_CREATE: 'message_create',


### PR DESCRIPTION
in some cases, PID is useful. Setting priority, core affinity, an so on. I just have put an event just after browser initializing.

This event return PID or error if could not get PID with the function `browser.process()`

I use this event, like:
```JavaScript
client.on("browser_init", (pid, err) =>{
    if (err) {
        console.error("Process could not be running", e);
        return;
    }
    console.log("browser is running with the pid:", pid);
});
```