### PR TITLE
Auth Strategies

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,7 +1,7 @@
-const { Client, Location, List, Buttons } = require('./index');
+const { Client, Location, List, Buttons, LocalAuth } = require('./index');
 
 const client = new Client({ 
-    clientId: 'example',
+    authStrategy: new LocalAuth({ clientId: 'example' }),
     puppeteer: { headless: false }
 });
 

--- a/index.js
+++ b/index.js
@@ -21,5 +21,10 @@ module.exports = {
     ProductMetadata: require('./src/structures/ProductMetadata'),
     List: require('./src/structures/List'),
     Buttons: require('./src/structures/Buttons'),
+    
+    // Auth Strategies
+    LocalAuth: require('./src/authStrategies/LocalAuth'),
+    LegacySessionAuth: require('./src/authStrategies/LegacySessionAuth'),
+    
     ...Constants
 };

--- a/src/Client.js
+++ b/src/Client.js
@@ -12,7 +12,7 @@ const ChatFactory = require('./factories/ChatFactory');
 const ContactFactory = require('./factories/ContactFactory');
 const { ClientInfo, Message, MessageMedia, Contact, Location, GroupNotification, Label, Call, Buttons, List } = require('./structures');
 const LegacySessionAuth = require('./authStrategies/LegacySessionAuth');
-const LocalAuth = require('./authStrategies/LocalAuth');
+const NoAuth = require('./authStrategies/NoAuth');
 
 /**
  * Starting point for interacting with the WhatsApp Web API
@@ -64,8 +64,7 @@ class Client extends EventEmitter {
                     session: this.options.session
                 });
             } else {
-                // should this default to NoAuth?
-                this.authStrategy = new LocalAuth();
+                this.authStrategy = new NoAuth();
             }
         } else {
             this.authStrategy = this.options.authStrategy;

--- a/src/Client.js
+++ b/src/Client.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const path = require('path');
-const fs = require('fs');
 const EventEmitter = require('events');
 const puppeteer = require('puppeteer');
 const moduleRaid = require('@pedroslopez/moduleraid/moduleraid');
@@ -13,23 +11,24 @@ const { ExposeStore, LoadUtils } = require('./util/Injected');
 const ChatFactory = require('./factories/ChatFactory');
 const ContactFactory = require('./factories/ContactFactory');
 const { ClientInfo, Message, MessageMedia, Contact, Location, GroupNotification, Label, Call, Buttons, List } = require('./structures');
+const LegacySessionAuth = require('./authStrategies/LegacySessionAuth');
+const LocalAuth = require('./authStrategies/LocalAuth');
+
 /**
  * Starting point for interacting with the WhatsApp Web API
  * @extends {EventEmitter}
  * @param {object} options - Client options
+ * @param {AuthStrategy} options.authStrategy - Determines how to save and restore sessions. Will default to LegacySessionAuth if options.session is set. Otherwise, LocalAuth will be used.
  * @param {number} options.authTimeoutMs - Timeout for authentication selector in puppeteer
  * @param {object} options.puppeteer - Puppeteer launch options. View docs here: https://github.com/puppeteer/puppeteer/
  * @param {number} options.qrMaxRetries - How many times should the qrcode be refreshed before giving up
  * @param {string} options.restartOnAuthFail  - Restart client with a new session (i.e. use null 'session' var) if authentication fails
- * @param {boolean} options.useDeprecatedSessionAuth - Enable JSON-based authentication. This is deprecated due to not being supported by MultiDevice, and will be removed in a future version.
- * @param {object} options.session - This is deprecated due to not being supported by MultiDevice, and will be removed in a future version.
+ * @param {object} options.session - Only here for backwards-compatibility. You should move to using LocalAuth, or set the authStrategy to LegacySessionAuth explicitly.
  * @param {number} options.takeoverOnConflict - If another whatsapp web session is detected (another browser), take over the session in the current browser
  * @param {number} options.takeoverTimeoutMs - How much time to wait before taking over the session
- * @param {string} options.dataPath - Change the default path for saving session files, default is: "./WWebJS/"
  * @param {string} options.userAgent - User agent to use in puppeteer
  * @param {string} options.ffmpegPath - Ffmpeg path to use when formating videos to webp while sending stickers 
  * @param {boolean} options.bypassCSP - Sets bypassing of page's Content-Security-Policy.
- * @param {string} options.clientId - Client id to distinguish instances if you are using multiple, otherwise keep null if you are using only one instance
  * 
  * @fires Client#qr
  * @fires Client#authenticated
@@ -52,19 +51,27 @@ class Client extends EventEmitter {
         super();
 
         this.options = Util.mergeDefault(DefaultOptions, options);
+        
+        if(!this.options.authStrategy) {
+            if(this.options.session) {
+                process.emitWarning(
+                    'options.session is deprecated and will be removed in a future release due to incompatibility with multi-device. ' +
+                    'Use the LocalAuth authStrategy, don\'t pass in a session as an option, or suppress this warning by using the LegacySessionAuth strategy explicitly.',
+                    'DeprecationWarning'
+                );
 
-        this.id = this.options.clientId;
-
-        // eslint-disable-next-line no-useless-escape
-        const foldernameRegex = /^(?!.{256,})(?!(aux|clock\$|con|nul|prn|com[1-9]|lpt[1-9])(?:$|\.))[^ ][ \.\w-$()+=[\];#@~,&amp;']+[^\. ]$/i;
-        if (this.id && !foldernameRegex.test(this.id)) throw Error('Invalid client ID. Make sure you abide by the folder naming rules of your operating system.');
-
-        if (!this.options.useDeprecatedSessionAuth) {
-            this.dataDir = this.options.puppeteer.userDataDir;
-            const dirPath = path.join(process.cwd(), this.options.dataPath, this.id ? 'session-' + this.id : 'session');
-            if (!this.dataDir) this.dataDir = dirPath;
-            fs.mkdirSync(this.dataDir, { recursive: true });
+                this.authStrategy = new LegacySessionAuth({
+                    session: this.options.session
+                });
+            } else {
+                // should this default to NoAuth?
+                this.authStrategy = new LocalAuth();
+            }
+        } else {
+            this.authStrategy = this.options.authStrategy;
         }
+
+        this.authStrategy.setup(this);
 
         this.pupBrowser = null;
         this.pupPage = null;
@@ -78,10 +85,7 @@ class Client extends EventEmitter {
     async initialize() {
         let [browser, page] = [null, null];
 
-        const puppeteerOpts = {
-            ...this.options.puppeteer,
-            userDataDir: this.options.useDeprecatedSessionAuth ? undefined : this.dataDir
-        };
+        const puppeteerOpts = this.options.puppeteer;
         if (puppeteerOpts && puppeteerOpts.browserWSEndpoint) {
             browser = await puppeteer.connect(puppeteerOpts);
             page = await browser.newPage();
@@ -95,19 +99,7 @@ class Client extends EventEmitter {
         this.pupBrowser = browser;
         this.pupPage = page;
 
-        if (this.options.useDeprecatedSessionAuth && this.options.session) {
-            await page.evaluateOnNewDocument(session => {
-                if (document.referrer === 'https://whatsapp.com/') {
-                    localStorage.clear();
-                    localStorage.setItem('WABrowserId', session.WABrowserId);
-                    localStorage.setItem('WASecretBundle', session.WASecretBundle);
-                    localStorage.setItem('WAToken1', session.WAToken1);
-                    localStorage.setItem('WAToken2', session.WAToken2);
-                }
-
-                localStorage.setItem('remember-me', 'true');
-            }, this.options.session);
-        }
+        await this.authStrategy.initialize();
 
         if (this.options.bypassCSP) {
             await page.setBypassCSP(true);
@@ -141,18 +133,17 @@ class Client extends EventEmitter {
 
         // Scan-qrcode selector was found. Needs authentication
         if (needAuthentication) {
-            if(this.options.session) {
+            const { failed, failureEventPayload, restart } = await this.authStrategy.onAuthenticationNeeded();
+            if(failed) {
                 /**
                  * Emitted when there has been an error while trying to restore an existing session
                  * @event Client#auth_failure
                  * @param {string} message
-                 * @deprecated
                  */
-                this.emit(Events.AUTHENTICATION_FAILURE, 'Unable to log in. Are the session details valid?');
+                this.emit(Events.AUTHENTICATION_FAILURE, failureEventPayload);
                 await this.destroy();
-                if (this.options.restartOnAuthFail) {
+                if (restart && this.options.restartOnAuthFail) {
                     // session restore failed so try again but without session to force new authentication
-                    this.options.session = null;
                     return this.initialize();
                 }
                 return;
@@ -224,20 +215,7 @@ class Client extends EventEmitter {
         }
 
         await page.evaluate(ExposeStore, moduleRaid.toString());
-        let authEventPayload = undefined;
-        if (this.options.useDeprecatedSessionAuth) {
-            // Get session tokens
-            const localStorage = JSON.parse(await page.evaluate(() => {
-                return JSON.stringify(window.localStorage);
-            }));
-
-            authEventPayload = {
-                WABrowserId: localStorage.WABrowserId,
-                WASecretBundle: localStorage.WASecretBundle,
-                WAToken1: localStorage.WAToken1,
-                WAToken2: localStorage.WAToken2
-            };
-        }
+        const authEventPayload = await this.authStrategy.getAuthEventPayload();
 
         /**
          * Emitted when authentication is successful
@@ -248,22 +226,13 @@ class Client extends EventEmitter {
         // Check window.Store Injection
         await page.waitForFunction('window.Store != undefined');
 
-        const isMD = await page.evaluate(() => {
-            return window.Store.Features.features.MD_BACKEND;
-        });
-
         await page.evaluate(async () => {
             // safely unregister service workers
             const registrations = await navigator.serviceWorker.getRegistrations();
             for (let registration of registrations) {
                 registration.unregister();
             }
-
         });
-
-        if (this.options.useDeprecatedSessionAuth && isMD) {
-            throw new Error('Authenticating via JSON session is not supported for MultiDevice-enabled WhatsApp accounts.');
-        }
 
         //Load util functions (serializers, helper functions)
         await page.evaluate(LoadUtils);
@@ -518,9 +487,7 @@ class Client extends EventEmitter {
             return window.Store.AppState.logout();
         });
 
-        if (this.dataDir) {
-            return (fs.rmSync ? fs.rmSync : fs.rmdirSync).call(this.dataDir, { recursive: true });
-        }
+        await this.authStrategy.logout();
     }
 
     /**

--- a/src/authStrategies/AuthStrategy.js
+++ b/src/authStrategies/AuthStrategy.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/**
+ * Base class which all authentication strategies extend
+ */
+class AuthStrategy {
+    constructor() {}
+    setup(client) {
+        this.client = client;
+    }
+    async initialize() {}
+    async onAuthenticationNeeded() {
+        return {
+            failed: false,
+            restart: false,
+            failureEventPayload: undefined
+        };
+    }
+    async getAuthEventPayload() {}
+    async logout() {}
+}
+
+module.exports = AuthStrategy;

--- a/src/authStrategies/LegacySessionAuth.js
+++ b/src/authStrategies/LegacySessionAuth.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const AuthStrategy = require('./AuthStrategy');
+
+/**
+ * Legacy session auth strategy
+ * Not compatible with multi-device accounts.
+ * @deprecated
+ * @param {object} options - options
+ * @param {object} options.session - Whatsapp session to restore. If not set, will start a new session
+ * @param {string} options.session.WABrowserId
+ * @param {string} options.session.WASecretBundle
+ * @param {string} options.session.WAToken1
+ * @param {string} options.session.WAToken2
+ */
+class LegacySessionAuth extends AuthStrategy {
+    constructor({ session }) {
+        super();
+        this.session = session;
+    }
+
+    async initialize() {
+        if(this.session) {
+            await this.client.pupPage.evaluateOnNewDocument(session => {
+                if (document.referrer === 'https://whatsapp.com/') {
+                    localStorage.clear();
+                    localStorage.setItem('WABrowserId', session.WABrowserId);
+                    localStorage.setItem('WASecretBundle', session.WASecretBundle);
+                    localStorage.setItem('WAToken1', session.WAToken1);
+                    localStorage.setItem('WAToken2', session.WAToken2);
+                }
+  
+                localStorage.setItem('remember-me', 'true');
+            }, this.session);
+        }
+    }
+
+    async onAuthenticationNeeded() {
+        if(this.session) {
+            this.session = null;
+            return {
+                failed: true,
+                failureEventPayload: 'Unable to log in. Are the session details valid?'
+            };
+        }
+
+        return { failed: false };
+    }
+
+    async getAuthEventPayload() {
+        const isMD = await this.client.pupPage.evaluate(() => {
+            return window.Store.Features.features.MD_BACKEND;
+        });
+
+        if(isMD) throw new Error('Authenticating via JSON session is not supported for MultiDevice-enabled WhatsApp accounts.');
+
+        const localStorage = JSON.parse(await this.client.pupPage.evaluate(() => {
+            return JSON.stringify(window.localStorage);
+        }));
+
+        return {
+            WABrowserId: localStorage.WABrowserId,
+            WASecretBundle: localStorage.WASecretBundle,
+            WAToken1: localStorage.WAToken1,
+            WAToken2: localStorage.WAToken2
+        };
+    }
+}
+
+module.exports = LegacySessionAuth;

--- a/src/authStrategies/LegacySessionAuth.js
+++ b/src/authStrategies/LegacySessionAuth.js
@@ -5,7 +5,6 @@ const AuthStrategy = require('./AuthStrategy');
 /**
  * Legacy session auth strategy
  * Not compatible with multi-device accounts.
- * @deprecated
  * @param {object} options - options
  * @param {object} options.session - Whatsapp session to restore. If not set, will start a new session
  * @param {string} options.session.WABrowserId

--- a/src/authStrategies/LocalAuth.js
+++ b/src/authStrategies/LocalAuth.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const AuthStrategy = require('./AuthStrategy');
+
+/**
+ * Local directory-based authentication
+ * @param {object} options - options
+ * @param {string} options.clientId - Client id to distinguish instances if you are using multiple, otherwise keep null if you are using only one instance
+ * @param {string} options.dataPath - Change the default path for saving session files, default is: "./WWebJS/" 
+*/
+class LocalAuth extends AuthStrategy {
+    constructor({ clientId, dataPath }={}) {
+        super();
+        this.id = clientId;
+        this.dataPath = dataPath || './WWebJS/';
+    }
+
+    setup(client) {
+        super.setup(client);
+
+        // eslint-disable-next-line no-useless-escape
+        const foldernameRegex = /^(?!.{256,})(?!(aux|clock\$|con|nul|prn|com[1-9]|lpt[1-9])(?:$|\.))[^ ][ \.\w-$()+=[\];#@~,&amp;']+[^\. ]$/i;
+        if (this.id && !foldernameRegex.test(this.id)) throw Error('Invalid client ID. Make sure you abide by the folder naming rules of your operating system.');
+
+        this.dataDir = client.options.puppeteer.userDataDir;
+        const dirPath = path.join(process.cwd(), this.dataPath, this.id ? 'session-' + this.id : 'session');
+        if (!this.dataDir) this.dataDir = dirPath;
+        fs.mkdirSync(this.dataDir, { recursive: true });
+
+        client.options.puppeteer = {
+            ...client.options.puppeteer,
+            userDataDir: this.dataDir
+        };
+    }
+
+    async logout() {
+        if (this.dataDir) {
+            return (fs.rmSync ? fs.rmSync : fs.rmdirSync).call(this.dataDir, { recursive: true });
+        }
+    }
+
+}
+
+module.exports = LocalAuth;

--- a/src/authStrategies/NoAuth.js
+++ b/src/authStrategies/NoAuth.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const AuthStrategy = require('./AuthStrategy');
+
+/**
+ * No session restoring functionality
+ * Will need to authenticate via QR code every time
+*/
+class NoAuth extends AuthStrategy { }
+
+
+module.exports = NoAuth;

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -7,8 +7,6 @@ exports.DefaultOptions = {
         headless: true,
         defaultViewport: null
     },
-    dataPath: './WWebJS/',
-    useDeprecatedSessionAuth: false,
     authTimeoutMs: 0,
     qrMaxRetries: 0,
     takeoverOnConflict: false,


### PR DESCRIPTION
Cleans up the new local file storage and legacy auth into separate Auth Strategies.

This concept could be used later to add something like `S3Auth`, for example. It also means users can develop their own auth strategies.

## Usage

### `LocalAuth` - Filesystem-based auth that uses puppeteer's userDataDir to persist browser data
Used by default if no `session` option is passed to the client.
```js
const client = new Client();
```

To customize clientId or dataPath, pass as options to the auth strategy:
```js
const client = new Client({
    authStrategy: new LocalAuth({
        clientId: "example",
        dataPath: "./some/path"
    })
});
```

### `LegacySessionAuth` - traditional method that pulls tokens from local storage
Not available for MD.
Used by default if a `session` option is passed to the client, but this is only for backwards compatibility.

```js
const client = new Client({
    session: { } // session data here from wherever you get it from
});
```

Should be used explicitly to be able to get the payload in the auth event without passing a session:
```js
const client = new Client({
    authStrategy: new LegacySessionAuth({
        session: { } // session data here from wherever you get it from
    })
});
```

### `NoAuth` - does not provide any auth saving
```js
const client = new Client({
    authStrategy: new NoAuth()
});
