### PR TITLE
Fix: Validation not exist socket in stream module ( store.AppState )

### DIFF
--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -6,7 +6,7 @@ exports.ExposeStore = (moduleRaidStr) => {
     // eslint-disable-next-line no-undef
     window.mR = moduleRaid();
     window.Store = Object.assign({}, window.mR.findModule(m => m.default && m.default.Chat)[0].default);
-    window.Store.AppState = window.mR.findModule('STREAM')[0].Socket;
+    window.Store.AppState = window.mR.findModule('STREAM')[0]?.Socket;
     window.Store.Conn = window.mR.findModule('Conn')[0].Conn;
     window.Store.BlockContact = window.mR.findModule('blockContact')[0];
     window.Store.Call = window.mR.findModule('CallCollection')[0].CallCollection;


### PR DESCRIPTION
small validation in the stream, where the valid socket attribute was added, if it doesn't exist, it continues running the authentication in the normal way.