### PR TITLE
fix: Cannot destructure property 'session' of 'undefined' as it is un…

### DIFF
--- a/src/authStrategies/LegacySessionAuth.js
+++ b/src/authStrategies/LegacySessionAuth.js
@@ -14,7 +14,7 @@ const BaseAuthStrategy = require('./BaseAuthStrategy');
  * @param {string} options.session.WAToken2
  */
 class LegacySessionAuth extends BaseAuthStrategy {
-    constructor({ session, restartOnAuthFail }) {
+    constructor({ session, restartOnAuthFail }={}) {
         super();
         this.session = session;
         this.restartOnAuthFail = restartOnAuthFail;


### PR DESCRIPTION
at this example, app breaks. Because options is empty: `undefined`

```JavaScript
const client = new Client({
    authStrategy: new LegacySessionAuth()
});
```

Error: `Cannot destructure property 'session' of 'undefined' as it is undefined.`

so, I have just added `{}` in constructor args
```JavaScript
constructor({ session, restartOnAuthFail }={}) {
```