### PR TITLE
getProfilePicture Fix: Evaluation failed: Error: Comms::sendIq called before startComms

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -875,12 +875,19 @@ class Client extends EventEmitter {
      * @param {string} contactId the whatsapp user's ID
      * @returns {Promise<string>}
      */
-    async getProfilePicUrl(contactId) {
-        const profilePic = await this.pupPage.evaluate((contactId) => {
+     async getProfilePicUrl(contactId) {
+        const profilePic = await this.pupPage.evaluate(async contactId => {
             const chatWid = window.Store.WidFactory.createWid(contactId);
-            return window.Store.getProfilePicFull(chatWid);
+            let asyncPic = await window.Store.getProfilePicFull(chatWid).catch(e => {
+                return undefined;
+            });
+            if (!asyncPic) {
+                asyncPic = await window.Store.Wap.profilePicFind(contactId).catch(e => {
+                    return undefined;
+                });
+            }
+            return asyncPic;
         }, contactId);
-
         return profilePic ? profilePic.eurl : undefined;
     }
 


### PR DESCRIPTION
Fix for getProfilePicture thworing error for non-MD devices:

Error: Evaluation failed: Error: Comms::sendIq called before startComms
    at N (https://web.whatsapp.com/bootstrap_qr.faeb72dc2a3a441a20d1.js:6:118757)
    at R.i (https://web.whatsapp.com/bootstrap_qr.faeb72dc2a3a441a20d1.js:6:117648)
    at Y (https://web.whatsapp.com/bootstrap_qr.faeb72dc2a3a441a20d1.js:5:243670)
    at new y (https://web.whatsapp.com/bootstrap_qr.faeb72dc2a3a441a20d1.js:5:236237)
    at https://web.whatsapp.com/bootstrap_qr.faeb72dc2a3a441a20d1.js:6:117623
    at Generator.next (<anonymous>)
    at t (https://web.whatsapp.com/vendor1~bootstrap_qr.947b18aebaee33ade8af.js:2:63784)
    at s (https://web.whatsapp.com/vendor1~bootstrap_qr.947b18aebaee33ade8af.js:2:63995)
    at https://web.whatsapp.com/vendor1~bootstrap_qr.947b18aebaee33ade8af.js:2:64054
    at Y (https://web.whatsapp.com/bootstrap_qr.faeb72dc2a3a441a20d1.js:5:243670)

    