### PR TITLE
Fix logout method

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -525,7 +525,7 @@ class Client extends EventEmitter {
         });
 
         if (this.dataDir) {
-            return (fs.rmSync ? fs.rmSync : fs.rmdirSync).call(this.dataDir, { recursive: true });
+            return (fs.rmSync ? fs.rmSync : fs.rmdirSync).call(this, this.dataDir, { recursive: true });
         }
     }
 


### PR DESCRIPTION
The logout method was trying to use a function call passing the "dataDir" as the "this" reference