### PR TITLE
fix: group chat create

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -999,7 +999,7 @@ class Client extends EventEmitter {
 
         const createRes = await this.pupPage.evaluate(async (name, participantIds) => {
             const participantWIDs = participantIds.map(p => window.Store.WidFactory.createWid(p));
-            const id = window.Store.genId();
+            const id = window.Store.MsgKey.newId();
             const res = await window.Store.GroupUtils.sendCreateGroup(name, participantWIDs, undefined, id);
             return res;
         }, name, participants);


### PR DESCRIPTION
Cannot create group chat after updating to v1.16.4 due to window.Store.genId() is removed on commit:

https://github.com/pedroslopez/whatsapp-web.js/commit/2718c1328c636d0acecd8cc2910592a693e899b6