### PR TITLE
fix:  fetchMessages infinite loop & memory leak

### DIFF
--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -184,7 +184,7 @@ class Chat extends Base {
             if (searchOptions && searchOptions.limit > 0) {
                 while (msgs.length < searchOptions.limit) {
                     const loadedMessages = await chat.loadEarlierMsgs();
-                    if (!loadedMessages) break;
+                    if (!loadedMessages || loadedMessages == 0) break;
                     msgs = [...loadedMessages.filter(msgFilter), ...msgs];
                 }
                 


### PR DESCRIPTION
`await chat.loadEarlierMsgs()` used on line#186 of `Chat.js` may return values `undefined` or `"0"`.  

Both scenarios should break the while loop due that it causes memory leak on server/cloud applicaitons.
Memory leak issue & infinite loop have disappeared on my cloud server after this. 