### PR TITLE
fix: set user agent as a launch arg for usage in serviceworker

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -92,7 +92,12 @@ class Client extends EventEmitter {
             browser = await puppeteer.connect(puppeteerOpts);
             page = await browser.newPage();
         } else {
-            browser = await puppeteer.launch(puppeteerOpts);
+            const browserArgs = [...(puppeteerOpts.args || [])];
+            if(!browserArgs.find(arg => arg.includes('--user-agent'))) {
+                browserArgs.push(`--user-agent=${this.options.userAgent}`);
+            }
+
+            browser = await puppeteer.launch({...puppeteerOpts, args: browserArgs});
             page = (await browser.pages())[0];
         }
       

--- a/tests/client.js
+++ b/tests/client.js
@@ -9,7 +9,7 @@ const Message = require('../src/structures/Message');
 const MessageMedia = require('../src/structures/MessageMedia');
 const Location = require('../src/structures/Location');
 const LegacySessionAuth = require('../src/authStrategies/LegacySessionAuth');
-const { MessageTypes, WAState } = require('../src/util/Constants');
+const { MessageTypes, WAState, DefaultOptions } = require('../src/util/Constants');
 
 const expect = chai.expect;
 chai.use(chaiAsPromised);
@@ -18,6 +18,74 @@ const remoteId = helper.remoteId;
 const isMD = helper.isMD();
 
 describe('Client', function() {
+    describe('User Agent', function () {
+        it('should set user agent on browser', async function () {
+            this.timeout(25000);
+
+            const client = helper.createClient();
+            client.initialize();
+
+            await helper.sleep(20000);
+
+            const browserUA = await client.pupBrowser.userAgent();
+            expect(browserUA).to.equal(DefaultOptions.userAgent);
+
+            const pageUA = await client.pupPage.evaluate(() => window.navigator.userAgent);
+            expect(pageUA).to.equal(DefaultOptions.userAgent);
+
+            await client.destroy();
+        });
+
+        it('should set custom user agent on browser', async function () {
+            this.timeout(25000);
+            const customUA = DefaultOptions.userAgent.replace(/Chrome\/.* /, 'Chrome/99.9.9999.999 ');
+
+            const client = helper.createClient({
+                options: {
+                    userAgent: customUA
+                }
+            });
+
+            client.initialize();
+            await helper.sleep(20000);
+
+            const browserUA = await client.pupBrowser.userAgent();
+            expect(browserUA).to.equal(customUA);
+            expect(browserUA.includes('Chrome/99.9.9999.999')).to.equal(true);
+
+            const pageUA = await client.pupPage.evaluate(() => window.navigator.userAgent);
+            expect(pageUA).to.equal(customUA);
+
+            await client.destroy();
+        });
+
+        it('should respect an existing user agent arg', async function () {
+            this.timeout(25000);
+
+            const customUA = DefaultOptions.userAgent.replace(/Chrome\/.* /, 'Chrome/99.9.9999.999 ');
+
+            const client = helper.createClient({
+                options: {
+                    puppeteer: {
+                        args: [`--user-agent=${customUA}`]
+                    }
+                }
+            });
+
+            client.initialize();
+            await helper.sleep(20000);
+
+            const browserUA = await client.pupBrowser.userAgent();
+            expect(browserUA).to.equal(customUA);
+            expect(browserUA.includes('Chrome/99.9.9999.999')).to.equal(true);
+
+            const pageUA = await client.pupPage.evaluate(() => window.navigator.userAgent);
+            expect(pageUA).to.equal(DefaultOptions.userAgent);
+
+            await client.destroy();
+        });
+    });
+
     describe('Authentication', function() {
         it('should emit QR code if not authenticated', async function() {
             this.timeout(25000);


### PR DESCRIPTION
We are currently only setting the userAgent for the current WhatsApp Web page via `page.setUserAgent`. This has worked ok in the past, but WhatsApp is becoming an issue now that WhatsApp is doing more on the service worker, which does not get the user agent set.

Instead of setting the user agent for the page, set it on the browser instance by passing a launch arg. Any other page and more importantly service workers will now get the user agent set properly.

This should resolve issues people are having with stuck behavior or restoring sessions when closing quickly after first launch, as well as the dreaded "WhatsApp works with Google Chrome 60+" screen.

<img width="1103" alt="image" src="https://user-images.githubusercontent.com/4368928/173492178-fb06a114-c461-45aa-90e8-9ea636f65547.png">

fixes #1463
fixes #1339
fixes #1462