### PR TITLE
fix: Error: Evaluation failed: TypeError: msg.chat.sendStarMsgs is not a function

### DIFF
--- a/docs/structures_Message.js.html
+++ b/docs/structures_Message.js.html
@@ -480,7 +480,7 @@ class Message extends Base {
             let msg &#x3D; window.Store.Msg.get(msgId);
 
             if (msg.canStar()) {
-                return msg.chat.sendStarMsgs([msg], true);
+                return window.Store.Cmd.sendStarMsgs(msg.chat, [msg], false);
             }
         }, this.id._serialized);
     }
@@ -493,7 +493,7 @@ class Message extends Base {
             let msg &#x3D; window.Store.Msg.get(msgId);
 
             if (msg.canStar()) {
-                return msg.chat.sendStarMsgs([msg], false);
+                return window.Store.Cmd.sendUnstarMsgs(msg.chat, [msg], false);
             }
         }, this.id._serialized);
     }

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -449,7 +449,7 @@ class Message extends Base {
             let msg = window.Store.Msg.get(msgId);
 
             if (msg.canStar()) {
-                return msg.chat.sendStarMsgs([msg], true);
+                return window.Store.Cmd.sendStarMsgs(msg.chat, [msg], false);
             }
         }, this.id._serialized);
     }
@@ -462,7 +462,7 @@ class Message extends Base {
             let msg = window.Store.Msg.get(msgId);
 
             if (msg.canStar()) {
-                return msg.chat.sendStarMsgs([msg], false);
+                return window.Store.Cmd.sendUnstarMsgs(msg.chat, [msg], false);
             }
         }, this.id._serialized);
     }


### PR DESCRIPTION
This PR addresses issue #1594 
Fix for `Error: Evaluation failed: TypeError: msg.chat.sendStarMsgs is not a function` on star