### PR TITLE
Fix: Cannot read properties of undefined (reading 'id')

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -342,6 +342,8 @@ class Message extends Base {
      */
     async react(reaction){
         await this.client.pupPage.evaluate(async (messageId, reaction) => {
+            if (!messageId) { return undefined; }
+            
             const msg = await window.Store.Msg.get(messageId);
             await window.Store.sendReactionToMsg(msg, reaction);
         }, this.id._serialized, reaction);


### PR DESCRIPTION
This change fix `react` evaluation on `client.ready` event:

```
Error: Evaluation failed: TypeError: Cannot read properties of undefined (reading 'id')
    at Object.<anonymous> (https://web.whatsapp.com/bootstrap_main.44dc3fdf06d9bb8b053d.js:2:103021)
    at Generator.next (<anonymous>)
    at t (https://web.whatsapp.com/vendor1~bootstrap_qr.5922e52928d864c0918c.js:2:66483)
    at s (https://web.whatsapp.com/vendor1~bootstrap_qr.5922e52928d864c0918c.js:2:66694)
    at https://web.whatsapp.com/vendor1~bootstrap_qr.5922e52928d864c0918c.js:2:66753
    at Y (https://web.whatsapp.com/bootstrap_qr.f74b98c729dd38392a5f.js:37:128505)
    at new y (https://web.whatsapp.com/bootstrap_qr.f74b98c729dd38392a5f.js:37:121072)
    at Object.<anonymous> (https://web.whatsapp.com/vendor1~bootstrap_qr.5922e52928d864c0918c.js:2:66634)
    at Object.k (https://web.whatsapp.com/bootstrap_main.44dc3fdf06d9bb8b053d.js:2:105511)
    at Object.t.sendReactionToMsg (https://web.whatsapp.com/bootstrap_main.44dc3fdf06d9bb8b053d.js:2:102647)
    at ExecutionContext._evaluateInternal (/app/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:221:19)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async ExecutionContext.evaluate (/app/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:110:16)
    at async Message.react (/app/node_modules/whatsapp-web.js/src/structures/Message.js:344:9)
```