### PR TITLE
updating forward documentation.

### DIFF
--- a/docs/Message.html
+++ b/docs/Message.html
@@ -420,7 +420,7 @@
               </dl>
               <div class="symbol-detail-labels"><span class="label label-async">async</span></div>
               <h3 id="forward"><span class="symbol-name">forward</span><span class="signature"><span class="signature-params">(chat)</span>&nbsp;&rarr; <span class="signature-returns"> Promise</span></span></h3>
-              <p>Forwards this message to another chat</p>
+              <p>Forwards this message to another chat (that you chatted before, otherwise it will fail)</p>
               <section>
                 <h4>Parameter</h4>
                 <table class="jsdoc-details-table">

--- a/docs/Message.html
+++ b/docs/Message.html
@@ -420,7 +420,7 @@
               </dl>
               <div class="symbol-detail-labels"><span class="label label-async">async</span></div>
               <h3 id="forward"><span class="symbol-name">forward</span><span class="signature"><span class="signature-params">(chat)</span>&nbsp;&rarr; <span class="signature-returns"> Promise</span></span></h3>
-              <p>Forwards this message to another chat (that you chatted before, otherwise it will fail)</p>
+              <p>Forwards this message to another chat</p>
               <section>
                 <h4>Parameter</h4>
                 <table class="jsdoc-details-table">

--- a/index.d.ts
+++ b/index.d.ts
@@ -708,7 +708,7 @@ declare namespace WAWebJS {
         /** React to this message with an emoji*/
         react: (reaction: string) => Promise<void>,
         /** 
-         * Forwards this message to another chat
+         * Forwards this message to another chat (that you chatted before, otherwise it will fail)
          */
         forward: (chat: Chat | string) => Promise<void>,
         /** Star this message */

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -356,7 +356,7 @@ class Message extends Base {
     }
 
     /**
-     * Forwards this message to another chat
+     * Forwards this message to another chat (that you chatted before, otherwise it will fail)
      *
      * @param {string|Chat} chat Chat model or chat ID to which the message will be forwarded
      * @returns {Promise}


### PR DESCRIPTION
This PR addresses issue https://github.com/pedroslopez/whatsapp-web.js/issues/728
Basicaly `Message.forward` method will fail if you never talked with the contact that you will forward the message before.
I don't think that this is a issue to be adressed by wa-web.js since it's probably some anti-spam security from WhatsApp but at least it  _should be documented._