### PR TITLE
Use JSON parse and stringify instead of serialize

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -693,7 +693,7 @@ class Client extends EventEmitter {
             }
 
             const msg = await window.WWebJS.sendMessage(chat, message, options, sendSeen);
-            return msg.serialize();
+            return JSON.parse(JSON.stringify(msg));
         }, chatId, content, internalOptions, sendSeen);
 
         return new Message(this, newMessage);


### PR DESCRIPTION
When puppeteer try to return serialized message with buttons, we get undefined instead of the message object, because the message serialized is not a JSON compatible (because of the buttons class)