### PR TITLE
fix: EPERM: operation not permitted, rmdir => Windows & RemoteAuth compatibility

### DIFF
--- a/src/authStrategies/RemoteAuth.js
+++ b/src/authStrategies/RemoteAuth.js
@@ -178,9 +178,9 @@ class RemoteAuth extends BaseAuthStrategy {
                         await fs.promises.rm(dirElement, {
                             recursive: true,
                             force: true
-                        });
+                        }).catch(() => {});
                     } else {
-                        await fs.promises.unlink(dirElement);
+                        await fs.promises.unlink(dirElement).catch(() => {});
                     }
                 }
             }


### PR DESCRIPTION
For Windows users, RemoteAuth was occasionally throwing error `EPERM: operation not permitted, rmdir` on `deleteMetadata` when executing backup Syncs to the database.

Adding these catch blocks will avoid the process to crash and the session will be synced correctly without issues. 