### PR TITLE
Allow the deletion of others' messages

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -430,14 +430,14 @@ class Message extends Base {
 
     /**
      * Deletes a message from the chat
-     * @param {?boolean} everyone If true and the message is sent by the current user, will delete it for everyone in the chat.
+     * @param {?boolean} everyone If true and the message is sent by the current user or the user is an admin, will delete it for everyone in the chat.
      */
     async delete(everyone) {
         await this.client.pupPage.evaluate((msgId, everyone) => {
             let msg = window.Store.Msg.get(msgId);
 
             if (everyone && msg._canRevoke()) {
-                return window.Store.Cmd.sendRevokeMsgs(msg.chat, [msg], {type: 'Sender'});
+                return window.Store.Cmd.sendRevokeMsgs(msg.chat, [msg], { type: msg.id.fromMe ? 'Sender' : 'Admin' });
             }
 
             return window.Store.Cmd.sendDeleteMsgs(msg.chat, [msg], true);

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -436,7 +436,7 @@ class Message extends Base {
         await this.client.pupPage.evaluate((msgId, everyone) => {
             let msg = window.Store.Msg.get(msgId);
 
-            if (everyone && msg.id.fromMe && msg._canRevoke()) {
+            if (everyone && msg._canRevoke()) {
                 return window.Store.Cmd.sendRevokeMsgs(msg.chat, [msg], {type: 'Sender'});
             }
 


### PR DESCRIPTION
Removing the fromMe check in the `message#delete` method does the job

I have tested it and it does indeed work

Does not show in WhatsApp desktop UWP though, because it's not supported there yet

fixes #1683 