### PR TITLE
fix: set ephemeral fields and get links from messages

### DIFF
--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -363,7 +363,7 @@ exports.LoadUtils = () => {
 
         msg.isEphemeral = message.isEphemeral;
         msg.isStatusV3 = message.isStatusV3;
-        msg.links = (message.getLinks()).map(link => ({
+        msg.links = (message.getRawLinks()).map(link => ({
             link: link.href,
             isSuspicious: Boolean(link.suspiciousCharacters && link.suspiciousCharacters.size)
         }));

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -51,6 +51,7 @@ exports.ExposeStore = (moduleRaidStr) => {
     window.Store.ConversationMsgs = window.mR.findModule('loadEarlierMsgs')[0];
     window.Store.sendReactionToMsg = window.mR.findModule('sendReactionToMsg')[0].sendReactionToMsg;
     window.Store.createOrUpdateReactionsModule = window.mR.findModule('createOrUpdateReactions')[0];
+    window.Store.EphemeralFields = window.mR.findModule('getEphemeralFields')[0];
     window.Store.StickerTools = {
         ...window.mR.findModule('toWebpSticker')[0],
         ...window.mR.findModule('addWebpMetadata')[0]
@@ -227,11 +228,7 @@ exports.LoadUtils = () => {
         const extraOptions = options.extraOptions || {};
         delete options.extraOptions;
 
-        const ephemeralSettings = {
-            ephemeralDuration: chat.isEphemeralSettingOn() ? chat.getEphemeralSetting() : undefined,
-            ephemeralSettingTimestamp: chat.getEphemeralSettingTimestamp() || undefined,
-            disappearingModeInitiator: chat.getDisappearingModeInitiator() || undefined,
-        };
+        const ephemeralFields = window.Store.EphemeralFields.getEphemeralFields(chat);
 
         const message = {
             ...options,
@@ -245,7 +242,7 @@ exports.LoadUtils = () => {
             t: parseInt(new Date().getTime() / 1000),
             isNewMsg: true,
             type: 'chat',
-            ...ephemeralSettings,
+            ...ephemeralFields,
             ...locationOptions,
             ...attOptions,
             ...quotedMsgOptions,

--- a/tests/client.js
+++ b/tests/client.js
@@ -313,6 +313,7 @@ describe('Client', function() {
                     'Conn',
                     'Contact',
                     'DownloadManager',
+                    'EphemeralFields',
                     'Features',
                     'GroupMetadata',
                     'GroupParticipants',


### PR DESCRIPTION
## Description

Fixes compatibility with WhatsApp Web v2.2240.7

Takes some inspiration from #1744 #1743, but these were not compatible with older versions of NodeJS.
Instead, use WhatsApp's built-in method for getting ephemeral fields.

## Related Issue

close #1748 
