### PR TITLE
fix method downloadMedia when not found msg

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -386,7 +386,9 @@ class Message extends Base {
 
         const result = await this.client.pupPage.evaluate(async (msgId) => {
             const msg = window.Store.Msg.get(msgId);
-
+            if (!msg) {
+                return undefined;
+            }
             if (msg.mediaData.mediaStage != 'RESOLVED') {
                 // try to resolve media
                 await msg.downloadMedia({


### PR DESCRIPTION
# PR Details
Fix issue when loading media if message itself is not found

## Description

Found a problem in the old group, where one message with a quote per file. But the quoted message is not loaded on the whatsapp web



![image](https://user-images.githubusercontent.com/6928045/204784472-f4718c0d-0c21-4312-8adc-ef2be1a2b351.png)

