### PR TITLE
fix: invalid wid error

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1042,10 +1042,14 @@ class Client extends EventEmitter {
         }
 
         return await this.pupPage.evaluate(async number => {
-            const wid = window.Store.WidFactory.createWid(number);
-            const result = await window.Store.QueryExist(wid);
-            if (!result || result.wid === undefined) return null;
-            return result.wid;
+            try {
+                const wid = window.Store.WidFactory.createWid(number);
+                const result = await window.Store.QueryExist(wid);
+                if (!result || result.wid === undefined) return null;
+                return result.wid;
+            } catch {
+                return null;
+            }
         }, number);
     }
 


### PR DESCRIPTION
# PR Details

Fixed invalid wid error when trying to get the id of some numbers.

## Description

When calling the window.Store.WidFactory.createWid function, you may get an error "Error: Evaluation failed: Error: wid error: invalid wid" on some numbers

To fix this, this block of code was placed in a try catch container

## How Has This Been Tested

Several hundred attempts to obtain the id number have been tested

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [] I have updated the documentation accordingly (index.d.ts).



