### PR TITLE
feat: Implement Call Rejection + Introduction of Socket API

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1326,6 +1326,9 @@ declare namespace WAWebJS {
         webClientShouldHandle: boolean,
         /** Object with participants */
         participants: object
+
+        /** Reject the call */
+        reject: () => Promise<void>
     }
 
     /** Message type List */

--- a/src/structures/Call.js
+++ b/src/structures/Call.js
@@ -62,7 +62,15 @@ class Call extends Base {
         
         return super._patch(data);
     }
-    
+
+    /**
+     * Reject the call
+    */
+    async reject() {
+        return this.client.pupPage.evaluate((peerJid, id) => {
+            return window.WWebJS.rejectCall(peerJid, id);
+        }, this.from, this.id)
+    }
 }
 
 module.exports = Call;

--- a/src/structures/Call.js
+++ b/src/structures/Call.js
@@ -69,7 +69,7 @@ class Call extends Base {
     async reject() {
         return this.client.pupPage.evaluate((peerJid, id) => {
             return window.WWebJS.rejectCall(peerJid, id);
-        }, this.from, this.id)
+        }, this.from, this.id);
     }
 }
 

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -54,7 +54,7 @@ exports.ExposeStore = (moduleRaidStr) => {
     window.Store.MsgActionChecks = window.mR.findModule('canSenderRevokeMsg')[0];
     window.Store.QuotedMsg = window.mR.findModule('getQuotedMsgObj')[0];
     window.Store.Socket = window.mR.findModule('deprecatedSendIq')[0];
-    window.Store.Wap = window.mR.findModule('wap')[0];
+    window.Store.SocketWap = window.mR.findModule('wap')[0];
     window.Store.StickerTools = {
         ...window.mR.findModule('toWebpSticker')[0],
         ...window.mR.findModule('addWebpMetadata')[0]
@@ -73,6 +73,12 @@ exports.ExposeStore = (moduleRaidStr) => {
                 id: e
             });
         };
+    }
+
+    // TODO remove these once everybody has been updated to WWebJS with legacy sessions removed
+    const _linkPreview = window.mR.findModule('queryLinkPreview');
+    if (_linkPreview && _linkPreview[0] && _linkPreview[0].default) {
+        window.Store.Wap = _linkPreview[0].default;
     }
 
     const _isMDBackend = window.mR.findModule('isMDBackend');
@@ -602,14 +608,14 @@ exports.LoadUtils = () => {
     window.WWebJS.rejectCall = async (peerJid, id) => {
         peerJid = peerJid.split('@')[0] + '@s.whatsapp.net';
         let userId = window.Store.User.getMaybeMeUser().user + '@s.whatsapp.net';
-        const stanza = window.Store.Wap.wap('call', {
-            id: window.Store.Wap.generateId(),
-            from: window.Store.Wap.USER_JID(userId),
-            to: window.Store.Wap.USER_JID(peerJid),
+        const stanza = window.Store.SocketWap.wap('call', {
+            id: window.Store.SocketWap.generateId(),
+            from: window.Store.SocketWap.USER_JID(userId),
+            to: window.Store.SocketWap.USER_JID(peerJid),
         }, [
-            window.Store.Wap.wap('reject', {
+            window.Store.SocketWap.wap('reject', {
                 'call-id': id,
-                'call-creator': window.Store.Wap.USER_JID(peerJid),
+                'call-creator': window.Store.SocketWap.USER_JID(peerJid),
                 count: '0',
             })
         ]);

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -601,7 +601,7 @@ exports.LoadUtils = () => {
 
     window.WWebJS.rejectCall = async (peerJid, id) => {
         peerJid = peerJid.split('@')[0] + '@s.whatsapp.net';
-        let userId = window.Store.User.getMaybeMeUser().user + '@s.whatsapp.net'
+        let userId = window.Store.User.getMaybeMeUser().user + '@s.whatsapp.net';
         const stanza = window.Store.Wap.wap('call', {
             id: window.Store.Wap.generateId(),
             from: window.Store.Wap.USER_JID(userId),
@@ -609,10 +609,10 @@ exports.LoadUtils = () => {
         }, [
             window.Store.Wap.wap('reject', {
                 'call-id': id,
-                'call-creator': Wap.USER_JID(peerJid),
+                'call-creator': window.Store.Wap.USER_JID(peerJid),
                 count: '0',
             })
         ]);
         await window.Store.Socket.deprecatedCastStanza(stanza);
-    }
+    };
 };


### PR DESCRIPTION
# PR Details

This PR implements the internal functions to send messages to the socket & as an example of how this tech can be used, I've implemented call rejection via the socket (the same exact message sent from the Desktop app when rejecting a call). 

## Description

I've added the Socket & Wap (not to be confused with the old Wap) to the Store.
I've added a reject method to the call class.

## Related Issue
None.

## Motivation and Context

It allows for the versatility of having both high-level WhatsApp code access and the underlying Socket protocol. This allows us to do things the Web version of the app couldn't, for example things that the Desktop app can.

## How Has This Been Tested

I've spent a few hours testing the stability of everything and it is OK.

## Types of changes

- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).



