### PR TITLE
fix: Fix call event listener name + Added Call example

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,5 +1,8 @@
 const { Client, Location, List, Buttons, LocalAuth} = require('./index');
 
+// Change to false if you don't want to reject incoming calls
+let rejectCalls = true;
+
 const client = new Client({
     authStrategy: new LocalAuth(),
     puppeteer: { headless: false }
@@ -255,6 +258,12 @@ client.on('group_update', (notification) => {
 
 client.on('change_state', state => {
     console.log('CHANGE STATE', state );
+});
+
+client.on('call', async (call) => {
+    console.log('Call received, rejecting.', call);
+    if (rejectCalls) await call.reject();
+    await client.sendMessage(call.from, `[${call.fromMe ? 'Outgoing' : 'Incoming'}] Phone call from ${call.from}, type ${call.isGroup ? 'group' : ''} ${call.isVideo ? 'video' : 'audio'} call. ${rejectCalls ? 'This call was automatically rejected by the script.' : ''}`);
 });
 
 client.on('disconnected', (reason) => {

--- a/example.js
+++ b/example.js
@@ -1,8 +1,5 @@
 const { Client, Location, List, Buttons, LocalAuth} = require('./index');
 
-// Change to false if you don't want to reject incoming calls
-let rejectCalls = true;
-
 const client = new Client({
     authStrategy: new LocalAuth(),
     puppeteer: { headless: false }
@@ -260,8 +257,11 @@ client.on('change_state', state => {
     console.log('CHANGE STATE', state );
 });
 
+// Change to false if you don't want to reject incoming calls
+let rejectCalls = true;
+
 client.on('call', async (call) => {
-    console.log('Call received, rejecting.', call);
+    console.log('Call received, rejecting. GOTO Line 261 to disable', call);
     if (rejectCalls) await call.reject();
     await client.sendMessage(call.from, `[${call.fromMe ? 'Outgoing' : 'Incoming'}] Phone call from ${call.from}, type ${call.isGroup ? 'group' : ''} ${call.isVideo ? 'video' : 'audio'} call. ${rejectCalls ? 'This call was automatically rejected by the script.' : ''}`);
 });

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -51,7 +51,7 @@ exports.Events = {
     DISCONNECTED: 'disconnected',
     STATE_CHANGED: 'change_state',
     BATTERY_CHANGED: 'change_battery',
-    INCOMING_CALL: 'incoming_call',
+    INCOMING_CALL: 'call',
     REMOTE_SESSION_SAVED: 'remote_session_saved'
 };
 


### PR DESCRIPTION
# PR Details

The event listener `'onIncomingCall'` was incorrectly sending to `'incoming_call'` rather than  `'call'`. 
And I've also added an example to help understand the feature. 

## Motivation and Context

It will allow for a more uniform typing, as the TS declaration uses `'call'`

## How Has This Been Tested

I have tested this fix locally on my fork of the project.

## Types of changes

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).



