### PR TITLE
fix: Fix client-side message rendering issue when sending attachements through the library

### DIFF
--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -267,6 +267,7 @@ exports.LoadUtils = () => {
             ...ephemeralFields,
             ...locationOptions,
             ...attOptions,
+            ...(Object.keys(attOptions).length > 0 ? attOptions.toJSON() : {}),
             ...quotedMsgOptions,
             ...vcardOptions,
             ...buttonOptions,


### PR DESCRIPTION
# PR Details

This PR aims to fix the issues with rendering an attachement sent through WWebJS in the GUI after the reload/restart of the client.

![image](https://user-images.githubusercontent.com/46201100/201647163-afb7693d-ddd5-4807-a0bc-febeabec0213.png)

## Description

It seems the issue was that the mediaData prop was not getting properly serialized and added to the message object, which has been reflected & changed in MD. Now in MD, (in the code) the prop is also serialized and appended to the msg object in WhatsApp Web code. I have tested all types of attachments and this seems to work properly

## Motivation and Context

This fix will make the UI more enjoyable and appropriate. The issue was in how the message type `"chat"` was not affected after the concatenation of the attachment options, and so on reload the body (the thumbnail) was eventually just rendered as text rather than an image. This change was needed to make the library a better experience overall to people who use the GUI in co-ordinance with the library. This also fixes other issues like the instability of message type after sending a message with attachments.

## How Has This Been Tested

Fully tested on a session with normal WhatsApp on Android. Please try this pull request and help us assure it is fully functioning, it should be though as it now mimics 1:1 how it is sent in WA.

## Types of changes

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).



