### PR TITLE
fix: compatibility with LegacyPhoneFeatures in latest WhatsApp Web version

### DIFF
--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -13,7 +13,6 @@ exports.ExposeStore = (moduleRaidStr) => {
     window.Store.Cmd = window.mR.findModule('Cmd')[0].Cmd;
     window.Store.CryptoLib = window.mR.findModule('decryptE2EMedia')[0];
     window.Store.DownloadManager = window.mR.findModule('downloadManager')[0].downloadManager;
-    window.Store.Features = window.mR.findModule('FEATURE_CHANGE_EVENT')[0].LegacyPhoneFeatures;
     window.Store.GroupMetadata = window.mR.findModule('GroupMetadata')[0].default.GroupMetadata;
     window.Store.Invite = window.mR.findModule('sendJoinGroupViaInvite')[0];
     window.Store.InviteInfo = window.mR.findModule('sendQueryGroupInvite')[0];
@@ -86,6 +85,11 @@ exports.ExposeStore = (moduleRaidStr) => {
         window.Store.MDBackend = _isMDBackend[0].isMDBackend();
     } else {
         window.Store.MDBackend = true;
+    }
+
+    const _features = window.mR.findModule('FEATURE_CHANGE_EVENT')[0];
+    if(_features) {
+        window.Store.Features = _features.LegacyPhoneFeatures;
     }
 };
 

--- a/src/util/InterfaceController.js
+++ b/src/util/InterfaceController.js
@@ -79,6 +79,7 @@ class InterfaceController {
      */
     async getFeatures() {
         return await this.pupPage.evaluate(() => {
+            if(!window.Store.Features) throw new Error('This version of Whatsapp Web does not support features');
             return window.Store.Features.F;
         });
     }
@@ -89,6 +90,7 @@ class InterfaceController {
      */
     async checkFeatureStatus(feature) {
         return await this.pupPage.evaluate((feature) => {
+            if(!window.Store.Features) throw new Error('This version of Whatsapp Web does not support features');
             return window.Store.Features.supportsFeature(feature);
         }, feature);
     }
@@ -99,6 +101,7 @@ class InterfaceController {
      */
     async enableFeatures(features) {
         await this.pupPage.evaluate((features) => {
+            if(!window.Store.Features) throw new Error('This version of Whatsapp Web does not support features');
             for (const feature in features) {
                 window.Store.Features.setFeature(features[feature], true);
             }
@@ -111,6 +114,7 @@ class InterfaceController {
      */
     async disableFeatures(features) {
         await this.pupPage.evaluate((features) => {
+            if(!window.Store.Features) throw new Error('This version of Whatsapp Web does not support features');
             for (const feature in features) {
                 window.Store.Features.setFeature(features[feature], false);
             }


### PR DESCRIPTION
## Description

The latest version of WhatsApp Web removed feature support, crashing the client initialization. This fixes the issue and throws an error relating to the removal when calling feature-related functions.

close #1913

