### PR TITLE
Revert "fix: Fix client-side message rendering issue when sending attachements through the library"

### DIFF
--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -271,7 +271,6 @@ exports.LoadUtils = () => {
             ...ephemeralFields,
             ...locationOptions,
             ...attOptions,
-            ...(Object.keys(attOptions).length > 0 ? attOptions.toJSON() : {}),
             ...quotedMsgOptions,
             ...vcardOptions,
             ...buttonOptions,


### PR DESCRIPTION
Reverts pedroslopez/whatsapp-web.js#1905

This was causing an issue:

`Error: Evaluation failed: TypeError: attOptions.toJSON is not a function`
