### PR TITLE
Set Group Picture

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "jsdoc": "^3.6.4",
     "jsdoc-baseline": "^0.1.5",
     "mocha": "^9.0.2",
-    "sinon": "^13.0.1"
+    "sinon": "^13.0.1",
+    "sharp": "^0.31.3"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/src/Client.js
+++ b/src/Client.js
@@ -837,6 +837,22 @@ class Client extends EventEmitter {
         return couldSet;
     }
     
+	/**
+     * Sets group's or current user's picture.
+     * @param {string} chatId
+     * @param {MessageMedia} picture
+     * @return {Promise<string>}
+     */
+    async setPicture(chatId, picture){
+        const buffer = Buffer.from(picture.data, 'base64');
+        const cropped = await Util.generateProfilePicture(buffer);
+        const res = await this.pupPage.evaluate(async (chatId, img, preview) => {
+            const wid = window.Store.WidFactory.createWid(chatId);
+            return await window.Store.SendSetPicture(wid, preview, img);
+        }, chatId, cropped.img, cropped.preview);
+        return res.eurl;
+    }
+	
     /**
      * Gets the current connection state for the client
      * @returns {WAState} 

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -190,6 +190,15 @@ class GroupChat extends Chat {
         return true;
     }
 
+	/**
+     * Sets group's or current user's picture.
+     * @param {MessageMedia} picture
+     * @return {Promise<string>}
+     */
+    async setPicture(picture){
+        return await this.client.setPicture(this.id._serialized, picture);
+    }
+
     /**
      * Updates the group settings to only allow admins to edit group info (title, description, photo).
      * @param {boolean} [adminsOnly=true] Enable or disable this option 

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -45,6 +45,7 @@ exports.ExposeStore = (moduleRaidStr) => {
     window.Store.JoinInviteV4 = window.mR.findModule('sendJoinGroupViaInviteV4')[0];
     window.Store.findCommonGroups = window.mR.findModule('findCommonGroups')[0].findCommonGroups;
     window.Store.StatusUtils = window.mR.findModule('setMyStatus')[0];
+    window.Store.SendSetPicture = window.mR.findModule('sendSetPicture')[0].sendSetPicture;
     window.Store.ConversationMsgs = window.mR.findModule('loadEarlierMsgs')[0];
     window.Store.sendReactionToMsg = window.mR.findModule('sendReactionToMsg')[0].sendReactionToMsg;
     window.Store.createOrUpdateReactionsModule = window.mR.findModule('createOrUpdateReactions')[0];


### PR DESCRIPTION
# PR Details

Added the needed functions to set picture of group

## Description

Changed Client.js, GroupChat.js, util.js, Injected.js to support this

## Related Issue

<!--- Optional --->
<!--- If there is an issue link it here: -->
[Issue 1365](https://github.com/pedroslopez/whatsapp-web.js/pull/1365)

## Motivation and Context

<!--- Optional --->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

const media = await MessageMedia.fromUrl(img);
await client.setPicture(group.id._serialized, media);

as far as I know, works only for squared images, jpg, 300x300 at max.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Dependency change
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
