### PR TITLE
Fix: message.getInfo

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -494,7 +494,7 @@ class Message extends Base {
             const msg = window.Store.Msg.get(msgId);
             if (!msg) return null;
 
-            return await window.Store.MessageInfo.sendQueryMsgInfo(msg);
+            return await window.Store.MessageInfo.sendQueryMsgInfo(msg.id);
         }, this.id._serialized);
 
         return info;


### PR DESCRIPTION
window.Store.MessageInfo.sendQueryMsgInfo now needs msg.id instead of msg

# PR Details

Fix the message.getInfo method

## Description

window.Store.MessageInfo.sendQueryMsgInfo was need the msg object, and now it's need the message's id object

## Related Issue

<!--- Optional --->
<!--- If there is an issue link it here: -->

## Motivation and Context

<!--- Optional --->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).



