### PR TITLE
Automaticaly format audio to ogg/opus

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -683,7 +683,7 @@ class Client extends EventEmitter {
             );
         }
 
-        if (internalOptions.attachment.mimetype.startsWith('audio')) {
+        if (internalOptions.sendAudioAsVoice && internalOptions.attachment.mimetype.startsWith('audio')) {
             internalOptions.attachment = await Util.formatToOpusAudio(internalOptions.attachment);
         }
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -683,6 +683,10 @@ class Client extends EventEmitter {
             );
         }
 
+        if (internalOptions.attachment.mimetype.startsWith('audio')) {
+            internalOptions.attachment = await Util.formatToOpusAudio(internalOptions.attachment)
+        }
+
         const newMessage = await this.pupPage.evaluate(async (chatId, message, options, sendSeen) => {
             const chatWid = window.Store.WidFactory.createWid(chatId);
             const chat = await window.Store.Chat.find(chatWid);

--- a/src/Client.js
+++ b/src/Client.js
@@ -684,7 +684,7 @@ class Client extends EventEmitter {
         }
 
         if (internalOptions.attachment.mimetype.startsWith('audio')) {
-            internalOptions.attachment = await Util.formatToOpusAudio(internalOptions.attachment)
+            internalOptions.attachment = await Util.formatToOpusAudio(internalOptions.attachment);
         }
 
         const newMessage = await this.pupPage.evaluate(async (chatId, message, options, sendSeen) => {


### PR DESCRIPTION
# PR Details

Re-creation of PR #1907
Sending audio through wwebjs is not very reliable, as WhatsApp needs a very specific format

## Description

Added ffmpeg conversion in the Util class and automatic detection of mime for efficient conversion in sendMessage()

## Related Issue

#1625 
#1584 
#1813 

## Motivation and Context

I wanted to seamlessly send an audio via wwebjs like it happens with Stickers.
I am using ffmpeg to convert an mp3 file into ogg/opus and it works.
Wanted everyone to benefit from it, too.

## How Has This Been Tested

I have not tested the code I sent you, but I have done the conversion in a similar fashion in my code, essentially proxying all the Audio and PTT messages through it. It works.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



