### PR TITLE
adding no sandbox to browser options

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -96,6 +96,9 @@ class Client extends EventEmitter {
             if(!browserArgs.find(arg => arg.includes('--user-agent'))) {
                 browserArgs.push(`--user-agent=${this.options.userAgent}`);
             }
+            if(!browserArgs.find(arg => arg.includes('--no-sandox'))){
+                browserArgs.push('--no-sandox');
+            }
 
             browser = await puppeteer.launch({...puppeteerOpts, args: browserArgs});
             page = (await browser.pages())[0];

--- a/src/Client.js
+++ b/src/Client.js
@@ -96,8 +96,8 @@ class Client extends EventEmitter {
             if(!browserArgs.find(arg => arg.includes('--user-agent'))) {
                 browserArgs.push(`--user-agent=${this.options.userAgent}`);
             }
-            if(!browserArgs.find(arg => arg.includes('--no-sandox'))){
-                browserArgs.push('--no-sandox');
+            if(!browserArgs.find(arg => arg.includes('--no-sandbox'))){
+                browserArgs.push('--no-sandbox');
             }
 
             browser = await puppeteer.launch({...puppeteerOpts, args: browserArgs});


### PR DESCRIPTION
this fix the error => [0330/035517.543395:FATAL:zygote_host_impl_linux.cc(117)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox. when try to use puppeteer buildpack on heroku.

# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
adding --no-sandbox to browser args

## Related Issue

<!--- Optional --->
<!--- If there is an issue link it here: -->

## Motivation and Context

<!--- Optional --->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
I get this error when try to run on heroku, then i downloaded the core code form github and make my own changes and uploaded my own version to npm. finally I tested and its worked!
<!--- Include details of your testing environment, and the tests you ran to -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).



