### PR TITLE
FIX #2101 - only process supported images

### DIFF
--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -324,10 +324,20 @@ exports.LoadUtils = () => {
         return stickerInfo;
     };
 
+    window.WWebJS.supportedImages = [
+        'image/jpeg',
+        'image/x-png',
+        'image/gif'
+    ];
+
+    window.WWebJS.isUnsupportedImage = function (mimeType) {
+        return mimeType.startsWith('image/') && !window.WWebJS.supportedImages.includes(mimeType);
+    }
+
     window.WWebJS.processMediaData = async (mediaInfo, { forceVoice, forceDocument, forceGif }) => {
         const file = window.WWebJS.mediaInfoToFile(mediaInfo);
         const mData = await window.Store.OpaqueData.createFromData(file, file.type);
-        const mediaPrep = window.Store.MediaPrep.prepRawMedia(mData, { asDocument: forceDocument });
+        const mediaPrep = window.Store.MediaPrep.prepRawMedia(mData, { asDocument: forceDocument || window.WWebJS.isUnsupportedImage(file.type) });
         const mediaData = await mediaPrep.waitForPrep();
         const mediaObject = window.Store.MediaObject.getOrCreateMediaObject(mediaData.filehash);
 


### PR DESCRIPTION
# PR Details

When sending files with an `image/*` mime type, treat it as an image only if it have supported image format.

## Description

Added a small function and supported formats list and changed to treat any unsupported image as a document.

## Related Issue

This fixes #2101 issue

## Motivation and Context

Problem when sending files such as autodesk autocad (dwg) the file doesn't get sent.

## How Has This Been Tested

Tested using the same approach to replicate the problem detailed in the issue.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly (index.d.ts).

(really didn't updated index.d.ts because I think it is unnecessary, please inform if I'm wrong)



