### PR TITLE
fix: msg.chat

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -459,11 +459,11 @@ class Message extends Base {
      * Stars this message
      */
     async star() {
-        await this.client.pupPage.evaluate((msgId) => {
+        await this.client.pupPage.evaluate(async (msgId) => {
             let msg = window.Store.Msg.get(msgId);
-
             if (window.Store.MsgActionChecks.canStarMsg(msg)) {
-                return window.Store.Cmd.sendStarMsgs(msg.chat, [msg], false);
+                let chat = await window.Store.Chat.find(msg.id.remote);
+                return window.Store.Cmd.sendStarMsgs(chat, [msg], false);
             }
         }, this.id._serialized);
     }
@@ -472,11 +472,12 @@ class Message extends Base {
      * Unstars this message
      */
     async unstar() {
-        await this.client.pupPage.evaluate((msgId) => {
+        await this.client.pupPage.evaluate(async (msgId) => {
             let msg = window.Store.Msg.get(msgId);
 
             if (window.Store.MsgActionChecks.canStarMsg(msg)) {
-                return window.Store.Cmd.sendUnstarMsgs(msg.chat, [msg], false);
+                let chat = await window.Store.Chat.find(msg.id.remote);
+                return window.Store.Cmd.sendUnstarMsgs(chat, [msg], false);
             }
         }, this.id._serialized);
     }

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -55,6 +55,7 @@ exports.ExposeStore = (moduleRaidStr) => {
     window.Store.Socket = window.mR.findModule('deprecatedSendIq')[0];
     window.Store.SocketWap = window.mR.findModule('wap')[0];
     window.Store.SearchContext = window.mR.findModule('getSearchContext')[0].getSearchContext;
+    window.Store.DrawerManager = window.mR.findModule('DrawerManager')[0].DrawerManager;
     window.Store.StickerTools = {
         ...window.mR.findModule('toWebpSticker')[0],
         ...window.mR.findModule('addWebpMetadata')[0]

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -54,6 +54,7 @@ exports.ExposeStore = (moduleRaidStr) => {
     window.Store.QuotedMsg = window.mR.findModule('getQuotedMsgObj')[0];
     window.Store.Socket = window.mR.findModule('deprecatedSendIq')[0];
     window.Store.SocketWap = window.mR.findModule('wap')[0];
+    window.Store.SearchContext = window.mR.findModule('getSearchContext')[0].getSearchContext;
     window.Store.StickerTools = {
         ...window.mR.findModule('toWebpSticker')[0],
         ...window.mR.findModule('addWebpMetadata')[0]

--- a/src/util/InterfaceController.js
+++ b/src/util/InterfaceController.js
@@ -50,7 +50,9 @@ class InterfaceController {
     async openChatWindowAt(msgId) {
         await this.pupPage.evaluate(async msgId => {
             let msg = await window.Store.Msg.get(msgId);
-            await window.Store.Cmd.openChatAt(msg.chat, msg.chat.getSearchContext(msg));
+            let chat = await window.Store.Chat.find(msg.id.remote);
+            let searchContext = await window.Store.SearchContext(chat,msg);
+            await window.Store.Cmd.openChatAt(chat, searchContext);
         }, msgId);
     }
 

--- a/src/util/InterfaceController.js
+++ b/src/util/InterfaceController.js
@@ -72,7 +72,7 @@ class InterfaceController {
      */
     async closeRightDrawer() {
         await this.pupPage.evaluate(async () => {
-            await window.Store.Cmd.closeDrawerRight();
+            await window.Store.DrawerManager.closeDrawerRight();
         });
     }
 


### PR DESCRIPTION
# PR Details

The latest version of WhatsApp 2.2315.6 has removed the chat information in the message itself. 

## Description

Went through the code and corrected such methods in the message
message.unstar
message.star
message.delete (Added new parameter as in the original WA clearMedia: true )

And also some InterfaceController functions, though who uses them? 
openChatWindowAt
closeRightDrawer


Instructions  Install the branch:
    NPM:  ``` npm i github:tofers/whatsapp-web.js#fix-msg-chat ```
     Yarn:  ```yarn add github:tofers/whatsapp-web.js#fix-msg-chat```


## Motivation and Context
Customers began to have trouble deleting the message.  Also inspired by https://github.com/pedroslopez/whatsapp-web.js/pull/2116, but let's correct all dependent problems.

## How Has This Been Tested
I tested on Web WhatsApp in windows 11
I also tested the methods on Centos 7

## Types of changes

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



