### PR TITLE
fix: location type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -731,7 +731,7 @@ declare namespace WAWebJS {
         /** Indicates if the message was starred */
         isStarred: boolean,
         /** Location information contained in the message, if the message is type "location" */
-        location: Location,
+        location?: Location,
         /** List of vCards contained in the message */
         vCards: string[],
         /** Invite v4 info */
@@ -835,8 +835,8 @@ declare namespace WAWebJS {
     /** Location information */
     export class Location {
         description?: string | null
-        latitude: string
-        longitude: string
+        latitude: number
+        longitude: number
         
         constructor(latitude: number, longitude: number, description?: string)
     }


### PR DESCRIPTION
# PR Details

- Update the type of `latitude` and `longitude` properties in the `Location` class from `string` to `number`.
- Update the type of `location` property in the `Message` interface to be optional

## Description

This pull request fixes the type of the `latitude` and `longitude` properties in the `Location` class by updating their type from `string` to `number`, as they are intended to represent numeric values. Additionally, in the `Message` interface, the `location` property is made optional, as it is not always required for all message types.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
As the changes are related to the types, I have tested the updated code in the IDE and verified that it returns the expected type
<!--- Include details of your testing environment, and the tests you ran to -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



