### PR TITLE
hotfix: newId  and deviceType

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -89,8 +89,7 @@ class Message extends Base {
          * String that represents from which device type the message was sent
          * @type {string}
          */
-        this.deviceType = data.id.id.length > 21 ? 'android' : data.id.id.substring(0, 2) == '3A' ? 'ios' : 'web';
-
+        this.deviceType = typeof data.id.id === 'string' && data.id.id.length > 21 ? 'android' : typeof data.id.id === 'string' && data.id.id.substring(0, 2) === '3A' ? 'ios' : 'web';
         /**
          * Indicates if the message was forwarded
          * @type {boolean}

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -245,12 +245,12 @@ exports.LoadUtils = () => {
 
         const meUser = window.Store.User.getMaybeMeUser();
         const isMD = window.Store.MDBackend;
-        const newIdV2 = await window.Store.MsgKey.newIdV2();
+        const newId = await window.Store.MsgKey.newId();
         
         const newMsgId = new window.Store.MsgKey({
             from: meUser,
             to: chat.id,
-            id: newIdV2,
+            id: newId,
             participant: isMD && chat.id.isGroup() ? meUser : undefined,
             selfDir: 'out',
         });

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -245,11 +245,12 @@ exports.LoadUtils = () => {
 
         const meUser = window.Store.User.getMaybeMeUser();
         const isMD = window.Store.MDBackend;
-
+        const newIdV2 = await window.Store.MsgKey.newIdV2();
+        
         const newMsgId = new window.Store.MsgKey({
             from: meUser,
             to: chat.id,
-            id: window.Store.MsgKey.newId(),
+            id: newIdV2,
             participant: isMD && chat.id.isGroup() ? meUser : undefined,
             selfDir: 'out',
         });


### PR DESCRIPTION
# PR Details

Update the method of message id generation 

## Related Issue

So far, I haven't noticed any complaints in the community.   

Only one customer complained that after sending a message WhatsApp immediately deleted it (but I'm not sure what that has to do with).


Instructions Install the branch:
```
NPM: npm i github:tofers/whatsapp-web.js#upd-newIdV2
Yarn: yarn add github:tofers/whatsapp-web.js#upd-newIdV2
```

## Motivation and Context

I noticed that WhatsApp has changed the method of message id generation.

It uses the web_sha256_message_key encryption method
When the old method was just md5 - web_md5_message_key

I think we need to update that as well

## How Has This Been Tested

VERSION
I tested on WhatsApp version "2.2320.10"

## Types of changes

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



