### PR TITLE
Upgraded puppeteer version to 19.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mime": "^3.0.0",
     "node-fetch": "^2.6.5",
     "node-webpmux": "^3.1.0",
-    "puppeteer": "^13.0.0"
+    "puppeteer": "^19.11.1"
   },
   "devDependencies": {
     "@types/node-fetch": "^2.5.12",

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -4,7 +4,7 @@ exports.WhatsWebURL = 'https://web.whatsapp.com/';
 
 exports.DefaultOptions = {
     puppeteer: {
-        headless: true,
+        headless: 'new',
         defaultViewport: null
     },
     authTimeoutMs: 0,


### PR DESCRIPTION
# PR Details

Upgraded Puppeteer version to 19.11.1
Solves `deprecated puppeteer@13.7.0: < 18.1.0 is no longer supported`

## Related Issue

https://github.com/pedroslopez/whatsapp-web.js/issues/1900

## Motivation and Context

Puppeteer has deprecated version 13, there are some known memory leak issues which resolved in newer versions.

## How Has This Been Tested

1. I connected a device using shell to initiate a session
2. I updated `.env` file
3. Run `npm run test`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



