### PR TITLE
feat: Edit message

### DIFF
--- a/example.js
+++ b/example.js
@@ -207,7 +207,7 @@ client.on('message', async msg => {
             if (quotedMsg.fromMe) {
                 quotedMsg.edit(msg.body.replace('!edit', ''));
             } else {
-                msg.reply('I can only delete my own messages');
+                msg.reply('I can only edit my own messages');
             }
         }
     }

--- a/example.js
+++ b/example.js
@@ -201,6 +201,15 @@ client.on('message', async msg => {
         client.sendMessage(msg.from, list);
     } else if (msg.body === '!reaction') {
         msg.react('👍');
+    } else if (msg.body === '!edit') {
+        if (msg.hasQuotedMsg) {
+            const quotedMsg = await msg.getQuotedMessage();
+            if (quotedMsg.fromMe) {
+                quotedMsg.edit(msg.body.replace('!edit', ''));
+            } else {
+                msg.reply('I can only delete my own messages');
+            }
+        }
     }
 });
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -846,6 +846,8 @@ declare namespace WAWebJS {
          * Gets the reactions associated with the given message
          */
         getReactions: () => Promise<ReactionList[]>,
+        /** Edits the current message */
+        edit: (content: MessageContent, options?: MessageSendOptions) => Promise<Message>,
     }
 
     /** ID that represents a message */

--- a/index.d.ts
+++ b/index.d.ts
@@ -242,6 +242,16 @@ declare namespace WAWebJS {
             ack: MessageAck
         ) => void): this
         
+        /** Emitted when an ack event occurrs on message type */
+        on(event: 'message_edit', listener: (
+            /** The message that was affected */
+            message: Message,
+            /** New text message */
+            newBody: String,
+            /** Prev text message */
+            prevBody: String
+        ) => void): this
+        
         /** Emitted when a chat unread count changes */
         on(event: 'unread_count', listener: (
             /** The chat that was affected */
@@ -567,6 +577,7 @@ declare namespace WAWebJS {
         MESSAGE_REVOKED_EVERYONE = 'message_revoke_everyone',
         MESSAGE_REVOKED_ME = 'message_revoke_me',
         MESSAGE_ACK = 'message_ack',
+        MESSAGE_EDIT = 'message_edit',
         MEDIA_UPLOADED = 'media_uploaded',
         CONTACT_CHANGED = 'contact_changed',
         GROUP_JOIN = 'group_join',
@@ -789,6 +800,10 @@ declare namespace WAWebJS {
         businessOwnerJid?: string,
         /** Product JID */
         productId?: string,
+        /** Last edit time */
+        latestEditSenderTimestampMs?: number,
+        /** Last edit message author */
+        latestEditMsgKey?: MessageId,
         /** Message buttons */
         dynamicReplyButtons?: object,
         /** Selected button ID */

--- a/index.d.ts
+++ b/index.d.ts
@@ -847,7 +847,7 @@ declare namespace WAWebJS {
          */
         getReactions: () => Promise<ReactionList[]>,
         /** Edits the current message */
-        edit: (content: MessageContent, options?: MessageSendOptions) => Promise<Message>,
+        edit: (content: MessageContent, options?: MessageSendOptions) => Promise<Message | null>,
     }
 
     /** ID that represents a message */

--- a/index.d.ts
+++ b/index.d.ts
@@ -862,7 +862,7 @@ declare namespace WAWebJS {
          */
         getReactions: () => Promise<ReactionList[]>,
         /** Edits the current message */
-        edit: (content: MessageContent, options?: MessageSendOptions) => Promise<Message | null>,
+        edit: (content: MessageContent, options?: MessageEditOptions) => Promise<Message | null>,
     }
 
     /** ID that represents a message */
@@ -926,6 +926,16 @@ declare namespace WAWebJS {
         stickerAuthor?: string
         /** Sticker categories, if sendMediaAsSticker is true */
         stickerCategories?: string[]
+    }
+
+    /** Options for editing a message */
+    export interface MessageEditOptions {
+        /** Show links preview. Has no effect on multi-device accounts. */
+        linkPreview?: boolean
+        /** Contacts that are being mentioned in the message */
+        mentions?: Contact[]
+        /** Extra options */
+        extra?: any
     }
 
     export interface MediaFromURLOptions {

--- a/src/Client.js
+++ b/src/Client.js
@@ -585,6 +585,10 @@ class Client extends EventEmitter {
         });
 
         await page.exposeFunction('onEditMessageEvent', (msg, newBody, prevBody) => {
+            
+            if(msg.type === 'revoked'){
+                return;
+            }
             /**
              * Emitted when messages are edited
              * @event Client#message_edit

--- a/src/Client.js
+++ b/src/Client.js
@@ -584,12 +584,24 @@ class Client extends EventEmitter {
             this.emit(Events.CHAT_ARCHIVED, new Chat(this, chat), currState, prevState);
         });
 
+        await page.exposeFunction('onEditMessageEvent', (msg, newBody, prevBody) => {
+            /**
+             * Emitted when messages are edited
+             * @event Client#message_edit
+             * @param {Message} message
+             * @param {string} newBody
+             * @param {string} prevBody
+             */
+            this.emit(Events.MESSAGE_EDIT, new Message(this, msg), newBody, prevBody);
+        });
+
         await page.evaluate(() => {
             window.Store.Msg.on('change', (msg) => { window.onChangeMessageEvent(window.WWebJS.getMessageModel(msg)); });
             window.Store.Msg.on('change:type', (msg) => { window.onChangeMessageTypeEvent(window.WWebJS.getMessageModel(msg)); });
             window.Store.Msg.on('change:ack', (msg, ack) => { window.onMessageAckEvent(window.WWebJS.getMessageModel(msg), ack); });
             window.Store.Msg.on('change:isUnsentMedia', (msg, unsent) => { if (msg.id.fromMe && !unsent) window.onMessageMediaUploadedEvent(window.WWebJS.getMessageModel(msg)); });
             window.Store.Msg.on('remove', (msg) => { if (msg.isNewMsg) window.onRemoveMessageEvent(window.WWebJS.getMessageModel(msg)); });
+            window.Store.Msg.on('change:body', (msg, newBody, prevBody) => { window.onEditMessageEvent(window.WWebJS.getMessageModel(msg), newBody, prevBody)});
             window.Store.AppState.on('change:state', (_AppState, state) => { window.onAppStateChangedEvent(state); });
             window.Store.Conn.on('change:battery', (state) => { window.onBatteryStateChangedEvent(state); });
             window.Store.Call.on('add', (call) => { window.onIncomingCall(call); });

--- a/src/Client.js
+++ b/src/Client.js
@@ -601,7 +601,7 @@ class Client extends EventEmitter {
             window.Store.Msg.on('change:ack', (msg, ack) => { window.onMessageAckEvent(window.WWebJS.getMessageModel(msg), ack); });
             window.Store.Msg.on('change:isUnsentMedia', (msg, unsent) => { if (msg.id.fromMe && !unsent) window.onMessageMediaUploadedEvent(window.WWebJS.getMessageModel(msg)); });
             window.Store.Msg.on('remove', (msg) => { if (msg.isNewMsg) window.onRemoveMessageEvent(window.WWebJS.getMessageModel(msg)); });
-            window.Store.Msg.on('change:body', (msg, newBody, prevBody) => { window.onEditMessageEvent(window.WWebJS.getMessageModel(msg), newBody, prevBody)});
+            window.Store.Msg.on('change:body', (msg, newBody, prevBody) => { window.onEditMessageEvent(window.WWebJS.getMessageModel(msg), newBody, prevBody); });
             window.Store.AppState.on('change:state', (_AppState, state) => { window.onAppStateChangedEvent(state); });
             window.Store.Conn.on('change:battery', (state) => { window.onBatteryStateChangedEvent(state); });
             window.Store.Call.on('add', (call) => { window.onIncomingCall(call); });

--- a/src/Client.js
+++ b/src/Client.js
@@ -738,7 +738,7 @@ class Client extends EventEmitter {
      * @param {string|MessageMedia|Location|Contact|Array<Contact>|Buttons|List} content
      * @param {MessageSendOptions} [options] - Options used when sending the message
      *
-     * @returns {Promise<string,[]>} Content and internalOptions
+     * @returns {Promise<{string,[]}>} Content and internalOptions
      */
     async handlerContent(content, options = {}) {
         if (options.mentions && options.mentions.some(possiblyContact => possiblyContact instanceof Contact)) {
@@ -793,7 +793,7 @@ class Client extends EventEmitter {
             );
         }
 
-        return [content, internalOptions];
+        return {content:content, internalOptions: internalOptions};
     }
 
     /**

--- a/src/Client.js
+++ b/src/Client.js
@@ -793,7 +793,7 @@ class Client extends EventEmitter {
             );
         }
 
-        return {content:content, internalOptions: internalOptions};
+        return {message: content, internalOptions: internalOptions};
     }
 
     /**
@@ -806,7 +806,7 @@ class Client extends EventEmitter {
      */
     async sendMessage(chatId, content, options = {}) {
         
-        const {content,internalOptions}  = await this.handlerContent(content,options);
+        const {message,internalOptions}  = await this.handlerContent(content,options);
         
         const sendSeen = typeof options.sendSeen === 'undefined' ? true : options.sendSeen;
         
@@ -820,7 +820,7 @@ class Client extends EventEmitter {
 
             const msg = await window.WWebJS.sendMessage(chat, message, options, sendSeen);
             return msg.serialize();
-        }, chatId, content, internalOptions, sendSeen);
+        }, chatId, message, internalOptions, sendSeen);
 
         return new Message(this, newMessage);
     }

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -7,7 +7,7 @@ const Order = require('./Order');
 const Payment = require('./Payment');
 const Reaction = require('./Reaction');
 const {MessageTypes} = require('../util/Constants');
-const {Contact} = require("./index");
+const {Contact} = require('./Contact');
 
 /**
  * Represents a Message on WhatsApp

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -584,7 +584,7 @@ class Message extends Base {
      * @returns {Promise}
      */
     async edit(content, options = []) {
-        const {content, internalOptions} = await this.client.handlerContent(content, options);
+        const {message, internalOptions} = await this.client.handlerContent(content, options);
 
         if (!this.fromMe) {
             throw 'Editing messages is only available for own messages';
@@ -603,7 +603,7 @@ class Message extends Base {
                 }
             }
             throw 'Editing message not available';
-        }, this.id._serialized, content, internalOptions);
+        }, this.id._serialized, message, internalOptions);
     }
 }
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -595,7 +595,8 @@ class Message extends Base {
 
             let catEdit = (msg.type === 'chat' && window.Store.MsgActionChecks.canEditText(msg));
             if (catEdit) {
-                return await window.WWebJS.editMessage(msg, message, options);
+                const msgEdit = await window.WWebJS.editMessage(msg, message, options);
+                return msgEdit.serialize();
             }
             return null;
         }, this.id._serialized, message, internalOptions);

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -224,6 +224,16 @@ class Message extends Base {
             this.productId = data.productId;
         }
 
+        /** Last edit time */
+        if (data.latestEditSenderTimestampMs) {
+            this.latestEditSenderTimestampMs = data.latestEditSenderTimestampMs;
+        }
+
+        /** Last edit message author */
+        if (data.latestEditMsgKey) {
+            this.latestEditMsgKey = data.latestEditMsgKey;
+        }
+        
         /**
          * Links included in the message.
          * @type {Array<{link: string, isSuspicious: boolean}>}

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -591,16 +591,10 @@ class Message extends Base {
         }
         await this.client.pupPage.evaluate(async (msgId, message, options) => {
             let msg = window.Store.Msg.get(msgId);
-
             let catEdit = (msg.type === 'chat' && window.Store.MsgActionChecks.canEditText(msg));
 
             if (catEdit) {
-                let chat = await window.Store.Chat.find(msg.id.remote);
-                try {
-                    await window.WWebJS.editMessage(chat, msg, message, options);
-                } catch (e) {
-                    throw e;
-                }
+                await window.WWebJS.editMessage(msg, message, options);
             }
             throw 'Editing message not available';
         }, this.id._serialized, message, internalOptions);

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -48,6 +48,7 @@ exports.Events = {
     MESSAGE_REVOKED_EVERYONE: 'message_revoke_everyone',
     MESSAGE_REVOKED_ME: 'message_revoke_me',
     MESSAGE_ACK: 'message_ack',
+    MESSAGE_EDIT: 'message_edit',
     UNREAD_COUNT: 'unread_count',
     MESSAGE_REACTION: 'message_reaction',
     MEDIA_UPLOADED: 'media_uploaded',

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -312,7 +312,6 @@ exports.LoadUtils = () => {
             options,
             locationOptions,
             attOptions,
-            quotedMsgOptions,
             vcardOptions,
             buttonOptions,
             listOptions
@@ -323,7 +322,6 @@ exports.LoadUtils = () => {
             ...locationOptions,
             ...attOptions,
             ...(attOptions.toJSON ? attOptions.toJSON() : {}),
-            ...quotedMsgOptions,
             ...vcardOptions,
             ...buttonOptions,
             ...listOptions,

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -313,7 +313,7 @@ exports.LoadUtils = () => {
         return window.Store.Msg.get(newMsgId._serialized);
     };
 
-    window.WWebJS.editMessage = async (chat, msg, content, internalOptions = {}) => {
+    window.WWebJS.editMessage = async (msg, content, internalOptions = {}) => {
 
         const extraOptions = internalOptions.extraOptions || {};
         delete internalOptions.extraOptions;

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -247,6 +247,7 @@ exports.LoadUtils = () => {
         }
         
         return {
+            message: content,
             options:options,
             locationOptions:locationOptions,
             attOptions: attOptions,
@@ -259,6 +260,7 @@ exports.LoadUtils = () => {
     
     window.WWebJS.sendMessage = async (chat, content, internalOptions = {}) => {
         let {
+            message,
             options,
             locationOptions,
             attOptions,
@@ -266,7 +268,7 @@ exports.LoadUtils = () => {
             vcardOptions,
             buttonOptions,
             listOptions
-        } = await window.Store.handlerOptions(chat, content, internalOptions);
+        } = await window.WWebJS.handlerOptions(chat, content, internalOptions);
         const meUser = window.Store.User.getMaybeMeUser();
         const isMD = window.Store.MDBackend;
         const newId = await window.Store.MsgKey.newId();
@@ -284,11 +286,11 @@ exports.LoadUtils = () => {
 
         const ephemeralFields = window.Store.EphemeralFields.getEphemeralFields(chat);
 
-        const message = {
+        const messageObject = {
             ...options,
             id: newMsgId,
             ack: 0,
-            body: content,
+            body: message,
             from: meUser,
             to: chat.id,
             local: true,
@@ -307,7 +309,7 @@ exports.LoadUtils = () => {
             ...extraOptions
         };
 
-        await window.Store.SendMessage.addAndSendMsgToChat(chat, message);
+        await window.Store.SendMessage.addAndSendMsgToChat(chat, messageObject);
         return window.Store.Msg.get(newMsgId._serialized);
     };
 
@@ -323,7 +325,7 @@ exports.LoadUtils = () => {
             vcardOptions,
             buttonOptions,
             listOptions
-        } = await window.Store.handlerOptions(chat, content, internalOptions);
+        } = await window.WWebJS.handlerOptions(chat, content, internalOptions);
         
         const message = {
             ...options,

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -256,7 +256,7 @@ exports.LoadUtils = () => {
             buttonOptions: buttonOptions,
             listOptions: listOptions
         };
-    } 
+    }; 
     
     window.WWebJS.sendMessage = async (chat, content, internalOptions = {}) => {
         let {

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -325,7 +325,7 @@ exports.LoadUtils = () => {
             vcardOptions,
             buttonOptions,
             listOptions
-        } = await window.WWebJS.handlerOptions(chat, content, internalOptions);
+        } = await window.WWebJS.handlerOptions(null, content, internalOptions);
         
         const message = {
             ...options,

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -109,6 +109,7 @@ exports.LoadUtils = () => {
         return false;
 
     };
+
     window.WWebJS.sendMessage = async (chat, content, options = {}) => {
         let attOptions = {};
         if (options.attachment) {
@@ -119,9 +120,9 @@ exports.LoadUtils = () => {
                     forceDocument: options.sendMediaAsDocument,
                     forceGif: options.sendVideoAsGif
                 });
-
+            
             if (options.caption){
-                attOptions.caption = options.caption;
+                attOptions.caption = options.caption; 
             }
             content = options.sendMediaAsSticker ? undefined : attOptions.preview;
 
@@ -133,8 +134,8 @@ exports.LoadUtils = () => {
             let quotedMessage = window.Store.Msg.get(options.quotedMessageId);
 
             // TODO remove .canReply() once all clients are updated to >= v2.2241.6
-            const canReply = window.Store.ReplyUtils ?
-                window.Store.ReplyUtils.canReplyMsg(quotedMessage.unsafe()) :
+            const canReply = window.Store.ReplyUtils ? 
+                window.Store.ReplyUtils.canReplyMsg(quotedMessage.unsafe()) : 
                 quotedMessage.canReply();
 
             if (canReply) {
@@ -205,7 +206,7 @@ exports.LoadUtils = () => {
                 }
             }
         }
-
+        
         let buttonOptions = {};
         if(options.buttons){
             let caption;
@@ -249,7 +250,7 @@ exports.LoadUtils = () => {
         const meUser = window.Store.User.getMaybeMeUser();
         const isMD = window.Store.MDBackend;
         const newId = await window.Store.MsgKey.newId();
-
+        
         const newMsgId = new window.Store.MsgKey({
             from: meUser,
             to: chat.id,
@@ -289,8 +290,8 @@ exports.LoadUtils = () => {
         await window.Store.SendMessage.addAndSendMsgToChat(chat, message);
         return window.Store.Msg.get(newMsgId._serialized);
     };
-
-    window.WWebJS.editMessage = async (msg, content, options = {}) => {
+	
+	window.WWebJS.editMessage = async (msg, content, options = {}) => {
 
         const extraOptions = options.extraOptions || {};
         delete options.extraOptions;

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -291,7 +291,7 @@ exports.LoadUtils = () => {
         return window.Store.Msg.get(newMsgId._serialized);
     };
 	
-	window.WWebJS.editMessage = async (msg, content, options = {}) => {
+    window.WWebJS.editMessage = async (msg, content, options = {}) => {
 
         const extraOptions = options.extraOptions || {};
         delete options.extraOptions;

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -246,7 +246,15 @@ exports.LoadUtils = () => {
             delete listOptions.list.footer;
         }
         
-        return [options, locationOptions, attOptions, quotedMsgOptions, vcardOptions, buttonOptions,listOptions];
+        return {
+            options:options,
+            locationOptions:locationOptions,
+            attOptions: attOptions,
+            quotedMsgOptions: quotedMsgOptions,
+            vcardOptions: vcardOptions,
+            buttonOptions: buttonOptions,
+            listOptions: listOptions
+        };
     } 
     
     window.WWebJS.sendMessage = async (chat, content, internalOptions = {}) => {

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -339,7 +339,7 @@ exports.LoadUtils = () => {
         };
 
         await window.Store.EditMessage.sendMessageEdit(msg, content, message);
-        return window.Store.Msg.get(msg._serialized);
+        return window.Store.Msg.get(msg.id._serialized);
     };
 
     window.WWebJS.toStickerData = async (mediaInfo) => {


### PR DESCRIPTION
# PR Details

Added message editing from version "2.2323.4"

## Description

Currently, message editing is only possible for text type messages. But there are other types in Whatsapp code that will be available later.

Settings are put in a separate type, we will update it as the functionality fills up.

Instructions Install the branch:
```
NPM: npm i github:tofers/whatsapp-web.js#editMsg
Yarn: yarn add github:tofers/whatsapp-web.js#editMsg
```
Message change event
```
client.on('message_edit', async (msg, newBody, prevBody) => {
    console.log('message', msg );
    console.log('message text', prevBody, newBody);
});
```

Example usage
```
client.on('message', async msg => {
    console.log('MESSAGE RECEIVED', msg);
    if (msg.body === '!edit') {
        if (msg.hasQuotedMsg) {
            const quotedMsg = await msg.getQuotedMessage();
            if (quotedMsg.fromMe) {
                quotedMsg.edit(msg.body.replace('!edit', ''))
            } else {
                msg.reply('I can only delete my own messages');
            }
        }
    }
});
```

## Related question

Haven't seen anyone ask that yet. But I need this functionality.

## Motivation and Context

To be able to update a message 

## How has this been tested

I tested it on linux systems

## Types of changes

- [ ] Change dependencies
- [ ] Bug fix (non-breaking change that fixes the problem)
- [x] New feature (non-breaching change that adds functionality)
- [x] Violating change (a fix or feature that will change existing functionality)

## Checklist

- [x] My code matches the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).


