### PR TITLE
Updated Puppeteer version to avoid warn from npm while installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "umais-whatsapp-web.js",
+    "name": "whatsapp-web.js",
     "version": "1.21.0",
     "description": "Library for interacting with the WhatsApp Web API ",
     "main": "./index.js",

--- a/package.json
+++ b/package.json
@@ -1,60 +1,60 @@
 {
-  "name": "whatsapp-web.js",
-  "version": "1.21.0",
-  "description": "Library for interacting with the WhatsApp Web API ",
-  "main": "./index.js",
-  "typings": "./index.d.ts",
-  "scripts": {
-    "test": "mocha tests --recursive --timeout 5000",
-    "test-single": "mocha",
-    "shell": "node --experimental-repl-await ./shell.js",
-    "generate-docs": "node_modules/.bin/jsdoc --configure .jsdoc.json --verbose"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/pedroslopez/whatsapp-web.js.git"
-  },
-  "keywords": [
-    "whatsapp",
-    "whatsapp-web",
-    "api",
-    "bot",
-    "client",
-    "node"
-  ],
-  "author": "Pedro Lopez",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/pedroslopez/whatsapp-web.js/issues"
-  },
-  "homepage": "https://wwebjs.dev/",
-  "dependencies": {
-    "@pedroslopez/moduleraid": "^5.0.2",
-    "fluent-ffmpeg": "^2.1.2",
-    "jsqr": "^1.3.1",
-    "mime": "^3.0.0",
-    "node-fetch": "^2.6.5",
-    "node-webpmux": "^3.1.0",
-    "puppeteer": "^13.0.0"
-  },
-  "devDependencies": {
-    "@types/node-fetch": "^2.5.12",
-    "chai": "^4.3.4",
-    "chai-as-promised": "^7.1.1",
-    "dotenv": "^16.0.0",
-    "eslint": "^8.4.1",
-    "eslint-plugin-mocha": "^10.0.3",
-    "jsdoc": "^3.6.4",
-    "jsdoc-baseline": "^0.1.5",
-    "mocha": "^9.0.2",
-    "sinon": "^13.0.1"
-  },
-  "engines": {
-    "node": ">=12.0.0"
-  },
-  "optionalDependencies": {
-    "archiver": "^5.3.1",
-    "fs-extra": "^10.1.0",
-    "unzipper": "^0.10.11"
-  }
+    "name": "umais-whatsapp-web.js",
+    "version": "1.21.0",
+    "description": "Library for interacting with the WhatsApp Web API ",
+    "main": "./index.js",
+    "typings": "./index.d.ts",
+    "scripts": {
+        "test": "mocha tests --recursive --timeout 5000",
+        "test-single": "mocha",
+        "shell": "node --experimental-repl-await ./shell.js",
+        "generate-docs": "node_modules/.bin/jsdoc --configure .jsdoc.json --verbose"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pedroslopez/whatsapp-web.js.git"
+    },
+    "keywords": [
+        "whatsapp",
+        "whatsapp-web",
+        "api",
+        "bot",
+        "client",
+        "node"
+    ],
+    "author": "Pedro Lopez",
+    "license": "Apache-2.0",
+    "bugs": {
+        "url": "https://github.com/pedroslopez/whatsapp-web.js/issues"
+    },
+    "homepage": "https://wwebjs.dev/",
+    "dependencies": {
+        "@pedroslopez/moduleraid": "^5.0.2",
+        "fluent-ffmpeg": "^2.1.2",
+        "jsqr": "^1.3.1",
+        "mime": "^3.0.0",
+        "node-fetch": "^2.6.5",
+        "node-webpmux": "^3.1.0",
+        "puppeteer": "^20.5.0"
+    },
+    "devDependencies": {
+        "@types/node-fetch": "^2.5.12",
+        "chai": "^4.3.4",
+        "chai-as-promised": "^7.1.1",
+        "dotenv": "^16.0.0",
+        "eslint": "^8.4.1",
+        "eslint-plugin-mocha": "^10.0.3",
+        "jsdoc": "^3.6.4",
+        "jsdoc-baseline": "^0.1.5",
+        "mocha": "^9.0.2",
+        "sinon": "^13.0.1"
+    },
+    "engines": {
+        "node": ">=12.0.0"
+    },
+    "optionalDependencies": {
+        "archiver": "^5.3.1",
+        "fs-extra": "^10.1.0",
+        "unzipper": "^0.10.11"
+    }
 }


### PR DESCRIPTION
# PR Details

Having a warning from npm while installing the library and after that issue, the installations just kept stuck.

## Description

### Problem: 
So, when I was trying to download the library I was having a warning from npm, and after having the warning the installation hang up and nothing was happening at all further. 
Here is the warning message that I am having,
<strong>"npm info run puppeteer@13.7.0 install node_modules/whatsapp-web.js/node_modules/puppeteer node install.js"</strong>

### Solution: 
After some debugging, I just found that inside devDependencies we have an old version of puppeteer so I just updated it from 13.6.0 to 20.5.0 and it worked fine after the updation.

## How Has This Been Tested

So, I have tested is by creating an instance of whatsapp web and its all running perfectly fine.

## Types of changes

- [ ] Dependency change
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
