### PR TITLE
getMessageById method implemented from previous PR

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -62,6 +62,9 @@ declare namespace WAWebJS {
 
         /** Get all current contact instances */
         getContacts(): Promise<Contact[]>
+
+        /** Get the message with given serializedId **/
+        getMessageById: () => Promise<Message>  
         
         /** Get the country code of a WhatsApp ID. (154185968@c.us) => (1) */
         getCountryCode(number: string): Promise<string>

--- a/src/Client.js
+++ b/src/Client.js
@@ -856,6 +856,28 @@ class Client extends EventEmitter {
     }
 
     /**
+     * Get message by serialized ID
+     * @param {string} messageId 
+     * @returns {Promise<Message>}
+     */
+    async getMessageById(messageId) {
+        const msg = await this.pupPage.evaluate(async messageId => {
+            let msg = window.Store.Msg.get(messageId);
+            if(msg) return window.WWebJS.getMessageModel(msg);
+
+            const params = messageId.split('_');
+            if(params.length !== 3) throw new Error('Invalid serialized message id specified');
+
+            let messagesObject = await window.Store.Msg.getMessagesById([messageId]);
+            if (messagesObject && messagesObject.messages.length) msg = messagesObject.messages[0];
+
+            if(msg) return window.WWebJS.getMessageModel(msg);
+        }, messageId);
+
+        if(msg) return new Message(this, msg);
+        return null;
+    }
+    /**
      * Get all current contact instances
      * @returns {Promise<Array<Contact>>}
      */


### PR DESCRIPTION
# PR Details

A new method has been added to get a message instance 

## Description

A new method has been added to get a message instance. With this method, we could grab a message to use message_edit functionality in further updates.

## Motivation and Context

We couldn't get the Message to send an action.  So, in previous PRs I found this update but it wasn't implemented in index.d.ts so I also add it.


<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Tested in Windows 11 - PyCharm console.

<!--- Include details of your testing environment, and the tests you ran to -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x ] My code follows the code style of this project.
- [x ] I have updated the documentation accordingly (index.d.ts).



