### PR TITLE
fix: Client.resetState

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1130,7 +1130,7 @@ class Client extends EventEmitter {
     */
     async resetState() {
         await this.pupPage.evaluate(() => {
-            window.Store.AppState.phoneWatchdog.shiftTimer.forceRunNow();
+            window.Store.Cmd.reconnectSocket();
         });
     }
 


### PR DESCRIPTION
# PR Details

## Description
PR fixes the `Client.resetState` method that resulted in:

```js
Error: Evaluation failed: TypeError: Cannot read properties of undefined (reading 'shiftTimer')
    at __puppeteer_evaluation_script__:3:49
    at ExecutionContext._evaluateInternal (...\node_modules\puppeteer\lib\cjs\puppeteer\common\ExecutionContext.js:221:19)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async ExecutionContext.evaluate (...\node_modules\puppeteer\lib\cjs\puppeteer\common\ExecutionContext.js:110:16)
    at async Client.resetState (...\node_modules\whatsapp-web.js\src\Client.js:1136:9)
```

Since the `window.Store.AppState.phoneWatchdog` is moved/deleted i found an alternative function to force the client state to be changed with.

When executed, the `window.Store.Cmd.reconnectSocket` forces the client state to be changed to `PAIRING` → `CONNECTED` immediately after internet reconnection.

## Related Issues
PR solves:
- #1341
- #1577

## Usage Example (also added to [example.js](https://github.com/alechkos/whatsapp-web.js/blob/a9f9f6a3c235f1401226a1260e4fdd276818c2a5/example.js#L260))
```js
const { WAState } = require('./index');

let state;
const delay = (msec) => new Promise(resolve => setTimeout(resolve, msec));

client.on('change_state', async (_state) => {
    state = _state;
    /** 
     * Once the internet connection is lost the client state will be set to WAState.OPENING.
     * The resetState function immediately changes the client state to WAState.CONNECTED
     * after internet reconnection.
     */
    while (state === WAState.OPENING) {
        await client.resetState();
        /** 
         * It is recommended to add a delay after each iteration at least 1000 msec
         * to prevent useless frequent function calls and unexpected behavior.
         */
        await delay(3000);
    }
});
```

## How Has This Been Tested

The code provided in the usage example was tested with internet disconnection for ≈1 hour and and the subsequent reconnection to observe if the client state resets to `CONNECTED` immediately after internet reconnection.

### Tested On:
- **Types of account:**
    - [X] Personal
    - [X] Buisness

- **OS:**
    - [ ] macOS
    - [ ] Linux systems
    - [X] Windows 10 (WWeb v2.2325.3)

## Types of Changes
- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly ([index.d.ts](https://github.com/pedroslopez/whatsapp-web.js/blob/a91bf1c762536055ca09a862e963ddb5e29ffe3a/index.d.ts)).