### PR TITLE
feat: send photo/video as a view once message

### DIFF
--- a/example.js
+++ b/example.js
@@ -140,6 +140,12 @@ client.on('message', async msg => {
             const attachmentData = await quotedMsg.downloadMedia();
             client.sendMessage(msg.from, attachmentData, { caption: 'Here\'s your requested media.' });
         }
+    } else if (msg.body === '!isviewonce' && msg.hasQuotedMsg) {
+        const quotedMsg = await msg.getQuotedMessage();
+        if (quotedMsg.hasMedia) {
+            const media = await quotedMsg.downloadMedia();
+            await client.sendMessage(msg.from, media, { isViewOnce: true });
+        }
     } else if (msg.body === '!location') {
         msg.reply(new Location(37.422, -122.084, 'Googleplex\nGoogle Headquarters'));
     } else if (msg.location) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -909,6 +909,8 @@ declare namespace WAWebJS {
         sendMediaAsSticker?: boolean
         /** Send media as document */
         sendMediaAsDocument?: boolean
+        /** Send photo/video as a view once message */
+        isViewOnce?: boolean
         /** Automatically parse vCards and send them as contacts */
         parseVCards?: boolean
         /** Image or videos caption */

--- a/src/Client.js
+++ b/src/Client.js
@@ -738,6 +738,7 @@ class Client extends EventEmitter {
      * @property {boolean} [sendVideoAsGif=false] - Send video as gif
      * @property {boolean} [sendMediaAsSticker=false] - Send media as a sticker
      * @property {boolean} [sendMediaAsDocument=false] - Send media as a document
+     * @property {boolean} [isViewOnce=false] - Send photo/video as a view once message
      * @property {boolean} [parseVCards=true] - Automatically parse vCards and send them as contacts
      * @property {string} [caption] - Image or video caption
      * @property {string} [quotedMessageId] - Id of the message that is being quoted (or replied to)
@@ -779,10 +780,12 @@ class Client extends EventEmitter {
 
         if (content instanceof MessageMedia) {
             internalOptions.attachment = content;
+            internalOptions.isViewOnce = options.isViewOnce,
             content = '';
         } else if (options.media instanceof MessageMedia) {
             internalOptions.attachment = options.media;
             internalOptions.caption = content;
+            internalOptions.isViewOnce = options.isViewOnce,
             content = '';
         } else if (content instanceof Location) {
             internalOptions.location = content;

--- a/src/Client.js
+++ b/src/Client.js
@@ -238,9 +238,9 @@ class Client extends EventEmitter {
                         // Listens to qr token change
                         if (mut.type === 'attributes' && mut.attributeName === 'data-ref') {
                             window.qrChanged(mut.target.dataset.ref);
-                        } else
+                        }
                         // Listens to retry button, when found, click it
-                        if (mut.type === 'childList') {
+                        else if (mut.type === 'childList') {
                             const retry_button = document.querySelector(selectors.QR_RETRY_BUTTON);
                             if (retry_button) retry_button.click();
                         }

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -125,6 +125,7 @@ exports.LoadUtils = () => {
                 attOptions.caption = options.caption; 
             }
             content = options.sendMediaAsSticker ? undefined : attOptions.preview;
+            attOptions.isViewOnce = options.isViewOnce;
 
             delete options.attachment;
             delete options.sendMediaAsSticker;

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -233,8 +233,8 @@ exports.LoadUtils = () => {
         }
 
         let listOptions = {};
-        if(options.list){
-            if(window.Store.Conn.platform === 'smba' || window.Store.Conn.platform === 'smbi'){
+        if (options.list) {
+            if (window.Store.Conn.platform === 'smba' || window.Store.Conn.platform === 'smbi') {
                 throw '[LT01] Whatsapp business can\'t send this yet';
             }
             listOptions = {


### PR DESCRIPTION
# PR Details

### - [Description](#description)

### - [Usage Example](#usage-example)

### - [How Has the PR Been Tested](#tests)
- [**The environment the PR was tested on**](#env)
- [**I want to test this PR**](#pr-testing)
- [**I have an issue while testing this PR**](#pr-testing-issue)

### - [Types of Changes](#types-of-changes)

---

## Description <a href="#description" id="description"/>
PR adds the ability to send a photo or a video as a view once message.

![](https://github.com/pedroslopez/whatsapp-web.js/assets/93551621/e493f25d-5aff-4849-910e-252ff28b11fe)

## Usage Example (also added to [example.js](https://github.com/alechkos/whatsapp-web.js/blob/e81c937c0eacdbdb8eeea6b3f76b35a2adc227b3/example.js#L143)) <a href="#usage-example" id="usage-example"/>

```js
client.on('message', async (msg) => {
    if (msg.body === '!isviewonce' && msg.hasQuotedMsg) {
        const quotedMsg = await msg.getQuotedMessage();
        if (quotedMsg.hasMedia) {
            const media = await quotedMsg.downloadMedia();
            await client.sendMessage(msg.from, media, { isViewOnce: true });
        }
    }
});
```

## How Has This Been Tested <a href="#tests" id="tests"/>
The functionality has been tested by resending photo/video files and also attachments and regular text messages in order to check if there is an error thrown.
The code used in tests:

```js
client.on('message', async (message) => {
    if (message.author === 'XXXXXXXXX@c.us') {
        const media = await message.downloadMedia();
        if (media) {
            await client.sendMessage(message.from, media, { isViewOnce: true });
            // works also with a caption
            await client.sendMessage(message.from, media, { caption: message.body, isViewOnce: true });
            
            // when isViewOnce is falsy and media is sent regulary, as expected
            await client.sendMessage(message.from, media);
            await client.sendMessage(message.from, media, { isViewOnce: false});
            
            // when isViewOnce is true but it is a non-photo/video media type and media is sent regulary, as expected
            await client.sendMessage(message.from, media, { isViewOnce: true, sendMediaAsSticker: true });
            await client.sendMessage(message.from, media, { isViewOnce: true, sendMediaAsDocument: true });
        }
        else {
            // isViewOnce has no effect on non-media messages even if provided, as expected
            await client.sendMessage(message.from, message.body);
            await client.sendMessage(message.from, message.body, { isViewOnce: true });
        }
    }
});
```

<details><summary>

### Tested On <a href="#env" id="env"/>
</summary>

#### Types of accounts:
- Personal
- Buisness

#### Environment:
- Android 10
- Windows 10:
    - WWebJS v1.21.0
    - WWeb v2.2322.15
    - Node v16.17.1
    - Chrome 114.0.5735.199
</details>

### To test this PR by yourself you can run one of the following commands: <a href="#pr-testing" id="pr-testing"/>
```powershell
# NPM
npm install github:alechkos/whatsapp-web.js#is-view-once
# YARN
yarn add github:alechkos/whatsapp-web.js#is-view-once
```

### If you encounter any issues while testing this PR, please provide in a comment: <a href="#pr-testing-issue" id="pr-testing-issue"/>
1. The code you've used without any sensitive information (use [syntax highlighting](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting) for more readability)
2. The library version
3. The WWeb version: `console.log(await client.getWwebVersion());`
4. The browser (Chrome/Chromium)
5. The error you got

## Types of Changes <a href="#types-of-changes" id="types-of-changes"/>
- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly (index.d.ts).