### PR TITLE
Type Error when starts new chat

### DIFF
--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -475,7 +475,7 @@ exports.LoadUtils = () => {
         
         res.lastMessage = null;
         if (res.msgs && res.msgs.length) {
-            const lastMessage = window.Store.Msg.get(chat.lastReceivedKey._serialized);
+            const lastMessage = window.Store.Msg.get(chat?.lastReceivedKey?._serialized);
             if (lastMessage) {
                 res.lastMessage = window.WWebJS.getMessageModel(lastMessage);
             }


### PR DESCRIPTION
# PR Details
## Description


When you try to start a new chat message (without previous message), sometimes you'll get this error:


```
Type Error: cannot read properties of undefined (reading '_serialized')
```
To fix that problem, i only added optional chaning 

## Related Issue

I saw this error only in Discord
<!--- Optional --->
<!--- If there is an issue link it here: -->

## Motivation and Context

<!--- Optional --->
<!--- Why is this change required? What problem does it solve? -->

Screenshot
![WhatsApp Image 2023-08-03 at 11 44 00](https://github.com/pedroslopez/whatsapp-web.js/assets/67132916/d7aa77d3-4262-4466-aa86-bbefadbe3808)

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



