### PR TITLE
fix: set description group

### DIFF
--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -153,8 +153,9 @@ class GroupChat extends Chat {
         const success = await this.client.pupPage.evaluate(async (chatId, description) => {
             const chatWid = window.Store.WidFactory.createWid(chatId);
             let descId = window.Store.GroupMetadata.get(chatWid).descId;
+            let newId = await window.Store.MsgKey.newId();
             try {
-                await window.Store.GroupUtils.setGroupDescription(chatWid, description, window.Store.MsgKey.newId(), descId);
+                await window.Store.GroupUtils.setGroupDescription(chatWid, description, newId, descId);
                 return true;
             } catch (err) {
                 if(err.name === 'ServerStatusCodeError') return false;


### PR DESCRIPTION
# PR Details
To fix the feature, change or update the group description `chat.setDescription()` so that it runs again
<!--- Provide a general summary of your changes in the Title above -->

## Description
Some of the functions in whatsapp web will always be updated, and now the function to get the message key id `window.Store.MsgKey.newId()` must use async await or promise, so I just changed the code a little.
<!--- Describe your changes in detail -->

## Motivation and Context
So that this group feature runs perfectly again
<!--- Optional --->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
I have tried and tested it on my own Bot using the `whatsapp-web.js` module
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



