### PR TITLE
Prevent Potential Breach in RemoteAuth Session Handling

### DIFF
--- a/src/authStrategies/RemoteAuth.js
+++ b/src/authStrategies/RemoteAuth.js
@@ -41,7 +41,7 @@ class RemoteAuth extends BaseAuthStrategy {
         this.clientId = clientId;
         this.backupSyncIntervalMs = backupSyncIntervalMs;
         this.dataPath = path.resolve(dataPath || './.wwebjs_auth/');
-        this.tempDir = `${this.dataPath}/wwebjs_temp_session`;
+        this.tempDir = `${this.dataPath}/wwebjs_temp_session_${this.clientId}`;
         this.requiredDirs = ['Default', 'IndexedDB', 'Local Storage']; /* => Required Files & Dirs in WWebJS to restore session */
     }
 


### PR DESCRIPTION
# PR Details

This PR addresses a potential security concern within the RemoteAuth Strategy.

## Motivation and Context

I have a project running with around 30 devices, after I migrated my AuthStrategy to RemoteAuth I noticed a weird behavior where some of my devices was connecting in sessions from another devices. After looking into the ```RemoteAuth.js``` file I noticed that while zipping/extracting the session files it creates a temporary directory named ```wwebjs_temp_session```. If by coincidence multiple devices try to backup/restore sessions at the exact same time they might end up mixing the sessions, leading to a possible security breach since one Client would be connecting to the session of another Client, depending on your implementation this could lead to serious problems.

## Description

To resolve this issue, I've made a simple modification by updating the ```tempDir``` variable to include the ```clientId```. This change ensures that the problem I've described is prevented from occurring.

## How Has This Been Tested

I conducted testing in both a local environment, involving 2 devices, and a production setting with 34 devices. It's important to note that replicating the issue is complicated due to its dependency on multiple instances attempting backup/restore operations simultaneously. The speed of the process contributes to this difficulty, as it needs precise synchronization for the issue to manifest.

## Types of changes

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts). (No need)
