### PR TITLE
add to MessageMedia class fromVars property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -975,6 +975,9 @@ declare namespace WAWebJS {
         /** Creates a MessageMedia instance from a local file path */
         static fromFilePath: (filePath: string) => MessageMedia
 
+        /** Creates a MessageMedia instance from variables */
+        static fromVars: (mimetype: string, b64data: string, filename: string) => MessageMedia
+
         /** Creates a MessageMedia instance from a URL */
         static fromUrl: (url: string, options?: MediaFromURLOptions) => Promise<MessageMedia>
     }

--- a/src/structures/MessageMedia.js
+++ b/src/structures/MessageMedia.js
@@ -54,6 +54,17 @@ class MessageMedia {
     }
 
     /**
+     * Creates a MessageMedia instance directly from other variables
+     * @param {string} b64data
+     * @param {string} mimetype
+     * @param {string} filename
+     * @returns {MessageMedia}
+     */
+    static fromVars(mimetype,b64data,filename) {
+        return new MessageMedia(mimetype, b64data, filename);
+    }
+
+    /**
      * Creates a MessageMedia instance from a URL
      * @param {string} url
      * @param {Object} [options]


### PR DESCRIPTION
# PR Details
MessageMedia class support only fromFile and fromUrl properties
i needed a way to pass the data as variables to MessageMedia from other application that run alongside
so i added fromVars property, it will accept mimetype, b64data, filename vars

example (not real):

```
// send/ptt
app.post('/send/ptt', async (req, res) => {
  const { phone, message } = req.body;
  media = await message.MessageMedia

  const ptt = MessageMedia.fromVars(media.mimetype,media.data,media.filename)
  const response = await client.sendMessage(phone, ptt, { sendAudioAsVoice: true });
```

<!--- Provide a general summary of your changes in the Title above -->
updated:
index.d.ts
src/structures/MessageMedia.js


## How Has This Been Tested
I tetsted providing opus file as base 64 with file name as null
and with const response = await client.sendMessage(phone, ptt, { sendAudioAsVoice: true });
so it set the audio as PTT



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly (index.d.ts).



