### PR TITLE
fix: selector on ready and event disconnected

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -172,7 +172,7 @@ class Client extends EventEmitter {
             }
         );
 
-        const INTRO_IMG_SELECTOR = '[data-icon=\'chat\']';
+        const INTRO_IMG_SELECTOR = '[data-icon=\'menu\']';
         const INTRO_QRCODE_SELECTOR = 'div[data-ref] canvas';
 
         // Checks which selector appears first
@@ -737,6 +737,7 @@ class Client extends EventEmitter {
     async destroy() {
         await this.pupBrowser.close();
         await this.authStrategy.destroy();
+        this.emit(Events.DISCONNECTED, 'DISCONNECTED');
     }
 
     /**
@@ -755,6 +756,7 @@ class Client extends EventEmitter {
         }
         
         await this.authStrategy.logout();
+        this.emit(Events.DISCONNECTED, 'DISCONNECTED');
     }
 
     /**

--- a/src/Client.js
+++ b/src/Client.js
@@ -171,14 +171,14 @@ class Client extends EventEmitter {
                 PROGRESS_MESSAGE: '//*[@id=\'app\']/div/div/div[3]',
             }
         );
-
-        const INTRO_IMG_SELECTOR = '[data-icon=\'menu\']';
+        const INTRO_IMG_SELECTOR = ['[data-icon*=community]', '[data-icon*=status]', '[data-icon*=community]', '[data-icon*=chat]', '[data-icon*=back]', '[data-icon*=search]', '[data-icon*=filter]', '[data-icon*=lock-small]', '[data-icon*=chat]'];
         const INTRO_QRCODE_SELECTOR = 'div[data-ref] canvas';
 
         // Checks which selector appears first
         const needAuthentication = await Promise.race([
             new Promise(resolve => {
-                page.waitForSelector(INTRO_IMG_SELECTOR, { timeout: this.options.authTimeoutMs })
+                page.waitForFunction((INTRO_IMG_SELECTOR) => 
+                    !!document.querySelectorAll(INTRO_IMG_SELECTOR).length, { timeout: this.options.authTimeoutMs }, INTRO_IMG_SELECTOR)
                     .then(() => resolve(false))
                     .catch((err) => resolve(err));
             }),


### PR DESCRIPTION
# PR Details

Fix bug selector on ready and disconnected event doesn't trigger when logout and destroy

## Description

- Event on ready doesn't trigger because selector [data-icon=\'chat\'] is not found, so code always awaiting, so I change the selector to [data-icon=\'menu\']
- Event on disconnected doesn't trigger, so I added event at the end of the destroy and logout function

## Related Issue

#2463 

## Motivation and Context

## How Has This Been Tested

I tested using run command `npm run shell`

## Types of changes

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



