### PR TITLE
Fix: INTRO_IMG_SELECTOR not working

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -172,7 +172,7 @@ class Client extends EventEmitter {
             }
         );
 
-        const INTRO_IMG_SELECTOR = '[data-icon=\'chat\']';
+        const INTRO_IMG_SELECTOR = '[data-icon="chat"],[data-icon="intro-md-beta-logo-dark"],[data-icon="intro-md-beta-logo-light"],[aria-label="profile photo"]';
         const INTRO_QRCODE_SELECTOR = 'div[data-ref] canvas';
 
         // Checks which selector appears first


### PR DESCRIPTION
# PR Details

INTRO_IMG_SELECTOR is a DOM selector to recognize that the message screen has loaded.

## Description

I added additional selectors to the intro image, as well as adding a selector to the profile logo

## Related Issue

## Motivation and Context

## How Has This Been Tested

- I scanned the qrcode
- I checked if the 'ready' event was fired

## Types of changes

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



