### PR TITLE
fix: chat object creation within the event

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -285,13 +285,13 @@ class Client extends EventEmitter {
              */
             window.compareWwebVersions = (lOperand, operator, rOperand) => {
                 if (!['>', '>=', '<', '<=', '='].includes(operator)) {
-                    throw class _ extends Error {
+                    throw new class _ extends Error {
                         constructor(m) { super(m); this.name = 'CompareWwebVersionsError'; }
                     }('Invalid comparison operator is provided');
 
                 }
                 if (typeof lOperand !== 'string' || typeof rOperand !== 'string') {
-                    throw class _ extends Error {
+                    throw new class _ extends Error {
                         constructor(m) { super(m); this.name = 'CompareWwebVersionsError'; }
                     }('A non-string WWeb version type is provided');
                 }

--- a/src/Client.js
+++ b/src/Client.js
@@ -11,7 +11,7 @@ const { ExposeStore, LoadUtils } = require('./util/Injected');
 const ChatFactory = require('./factories/ChatFactory');
 const ContactFactory = require('./factories/ContactFactory');
 const WebCacheFactory = require('./webCache/WebCacheFactory');
-const { ClientInfo, Message, MessageMedia, Contact, Location, GroupNotification, Label, Call, Buttons, List, Reaction, Chat } = require('./structures');
+const { ClientInfo, Message, MessageMedia, Contact, Location, GroupNotification, Label, Call, Buttons, List, Reaction } = require('./structures');
 const LegacySessionAuth = require('./authStrategies/LegacySessionAuth');
 const NoAuth = require('./authStrategies/NoAuth');
 
@@ -608,16 +608,20 @@ class Client extends EventEmitter {
             }
         });
 
-        await page.exposeFunction('onRemoveChatEvent', (chat) => {
+        await page.exposeFunction('onRemoveChatEvent', async (chat) => {
+            const _chat = await this.getChatById(chat.id);
+
             /**
              * Emitted when a chat is removed
              * @event Client#chat_removed
              * @param {Chat} chat
              */
-            this.emit(Events.CHAT_REMOVED, new Chat(this, chat));
+            this.emit(Events.CHAT_REMOVED, _chat);
         });
         
-        await page.exposeFunction('onArchiveChatEvent', (chat, currState, prevState) => {
+        await page.exposeFunction('onArchiveChatEvent', async (chat, currState, prevState) => {
+            const _chat = await this.getChatById(chat.id);
+            
             /**
              * Emitted when a chat is archived/unarchived
              * @event Client#chat_archived
@@ -625,7 +629,7 @@ class Client extends EventEmitter {
              * @param {boolean} currState
              * @param {boolean} prevState
              */
-            this.emit(Events.CHAT_ARCHIVED, new Chat(this, chat), currState, prevState);
+            this.emit(Events.CHAT_ARCHIVED, _chat, currState, prevState);
         });
 
         await page.exposeFunction('onEditMessageEvent', (msg, newBody, prevBody) => {

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -80,11 +80,8 @@ exports.ExposeStore = (moduleRaidStr) => {
         };
     }
 
-    if (window.mR.findModule('ChatCollection')[0] && window.mR.findModule('ChatCollection')[0].ChatCollection) {
-        if (typeof window.mR.findModule('ChatCollection')[0].ChatCollection.findImpl === 'undefined' && typeof window.mR.findModule('ChatCollection')[0].ChatCollection._find != 'undefined') {
-            window.mR.findModule('ChatCollection')[0].ChatCollection.findImpl = window.mR.findModule('ChatCollection')[0].ChatCollection._find;
-        }
-    }
+    // eslint-disable-next-line no-undef
+    if ((m = window.mR.findModule('ChatCollection')[0]) && m.ChatCollection && typeof m.ChatCollection.findImpl === 'undefined' && typeof m.ChatCollection._find !== 'undefined') m.ChatCollection.findImpl = m.ChatCollection._find;
 
     // TODO remove these once everybody has been updated to WWebJS with legacy sessions removed
     const _linkPreview = window.mR.findModule('queryLinkPreview');


### PR DESCRIPTION
# Table of Contents <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2506#toc" id="toc"/>

### - [Description](https://github.com/pedroslopez/whatsapp-web.js/pull/2506#description)

### - [Related Issue](https://github.com/pedroslopez/whatsapp-web.js/pull/2506#related-issues)

### - [I Want to Test this PR](https://github.com/pedroslopez/whatsapp-web.js/pull/2506#pr-testing)

### - [How Has the PR Been Tested (latest test on 14.09.2023)](https://github.com/pedroslopez/whatsapp-web.js/pull/2506#tests)
- [**The environment the PR was tested on**](https://github.com/pedroslopez/whatsapp-web.js/pull/2506#env)
- [**I have an issue while testing this PR**](https://github.com/pedroslopez/whatsapp-web.js/pull/2506#pr-testing-issue)

### - [Types of Changes](https://github.com/pedroslopez/whatsapp-web.js/pull/2506#types-of-changes)

---

## Description [_[Back to TOC]_](https://github.com/pedroslopez/whatsapp-web.js/pull/2506#toc) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2506#description" id="description"/>
The use of `new Chat(client, chat)` within two events `onRemoveChatEvent` and `onArchiveChatEvent` creates an invalid chat object where the `chat.id` is not an object but a string, this causes issues with the methods that use that chat object, like a `getContact` method of a `Chat` class.

This PR resolves the issue by allowing the creation of a chat object where the `chat.id` property is a wid type object.

A chat object using an old implementation:
```js
{
    id: '0@c.us',
    name: 'WhatsApp',
    isGroup: false,
    isReadOnly: false,
    unreadCount: 2,
    timestamp: 1694334251,
    archived: true,
    pinned: false,
    isMuted: false,
    muteExpiration: 0,
    lastMessage: {}
}
```

A chat object using a PR implementation:
```js
{
    id: {
        server: 'c.us',
        user: '0',
        _serialized: '0@c.us'
    },
    name: 'WhatsApp',
    isGroup: false,
    isReadOnly: false,
    unreadCount: 2,
    timestamp: 1694334251,
    archived: true,
    pinned: false,
    isMuted: false,
    muteExpiration: 0,
    lastMessage: {}
}
```

## Related Issue <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2506#related-issues" id="related-issues"/>
PR fixes #2504

## To test this PR by yourself you can run one of the following commands: <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2506#pr-testing" id="pr-testing"/>

- **NPM**
```powershell
npm install github:alechkos/whatsapp-web.js#patch-2505
```
- **YARN**
```powershell
yarn add github:alechkos/whatsapp-web.js#patch-2505
```

## How Has This Been Tested (latest test on 14.09.2023) [_[Back to TOC]_](https://github.com/pedroslopez/whatsapp-web.js/pull/2506#toc) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2506#tests" id="tests"/>
The PR was tested by firing two events `onRemoveChatEvent` and `onArchiveChatEvent` and checking arguments of callback functions.
The code used in tests:

```js
client.on('chat_archived', async (chat) => {
    const contact = await chat.getContact(); // no error is thrown after applying the fix
    console.log(contact);
});
```

### Tested On: <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2506#env" id="env"/>

#### Types of accounts:
- Personal
- Buisness

#### Environment:
- Android 10
- Windows 10:
    - WWebJS **v1.22.2-alpha.0**
    - WWeb **v2.2333.11**
    - Puppeteer **v18.2.1**
    - Node **v18.17.1**
    - Chrome **v116.0.5845.111**

<details><summary>

### If you encounter any issues while testing this PR, please provide in a comment (click to expand): <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2506#pr-testing-issue" id="pr-testing-issue"/>
</summary>

1. The code you've used without any sensitive information (use [syntax highlighting](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting) for more readability)
6. The library version
7. The WWeb version: `console.log(await client.getWWebVersion());`
8. The browser (Chrome/Chromium)
9. The error you got

> [!IMPORTANT]
> **You have to [reapply](https://github.com/pedroslopez/whatsapp-web.js/pull/2506#pr-testing) the PR each time it is changed (new commits were pushed since your last application)**
</details>

## Types of Changes [_[Back to TOC]_](https://github.com/pedroslopez/whatsapp-web.js/pull/2506#toc) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2506#types-of-changes" id="types-of-changes"/>
- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project
- [ ] I have updated the usage example accordingly (example.js)
- [ ] I have updated the documentation accordingly (index.d.ts)