### PR TITLE
feat: group membership requests

### DIFF
--- a/example.js
+++ b/example.js
@@ -232,6 +232,39 @@ client.on('message', async msg => {
     } else if (msg.body === '!removelabels') {
         const chat = await msg.getChat();
         await chat.changeLabels([]);
+    } else if (msg.body === '!approverequest') {
+        /**
+         * Presented an example for membership request approvals, the same examples are for the request rejections.
+         * To approve the membership request from a specific user:
+         */
+        await client.approveGroupMembershipRequests(msg.from, 'number@c.us');
+        /** The same for execution on group object (no need to provide the group ID): */
+        const group = await msg.getChat();
+        await group.approveGroupMembershipRequests('number@c.us');
+        /** To approve several membership requests: */
+        const approval = await client.approveGroupMembershipRequests(msg.from, ['number1@c.us', 'number2@c.us']);
+        /**
+         * The example of the {@link approval} output:
+         * [
+         *     {
+         *         requesterId: 'number1@c.us'
+         *     },
+         *     {
+         *         requesterId: 'number2@c.us',
+         *         error: {...}
+         *     }
+         * ]
+         *
+         */
+        console.log(approval);
+        /** To approve all the existing membership requests (simply don't provide any user IDs): */
+        await client.approveGroupMembershipRequests(msg.from);
+        /** To change the sleep value to 300 ms: */
+        await client.approveGroupMembershipRequests(msg.from, ['number1@c.us', 'number2@c.us'], 300);
+        /** To change the sleep value to random value between 100 and 300 ms: */
+        await client.approveGroupMembershipRequests(msg.from, ['number1@c.us', 'number2@c.us'], [100, 300]);
+        /** To explicitly disable the sleep: */
+        await client.approveGroupMembershipRequests(msg.from, ['number1@c.us', 'number2@c.us'], null);
     }
 });
 
@@ -352,4 +385,30 @@ client.on('group_admin_changed', (notification) => {
     } else if (notification.type === 'demote')
         /** Emitted when a current user is demoted to a regular user. */
         console.log(`You were demoted by ${notification.author}`);
+});
+
+client.on('group_membership_request', async (notification) => {
+    /**
+     * The example of the {@link notification} output:
+     * {
+     *     id: {
+     *         fromMe: false,
+     *         remote: 'group@g.us',
+     *         id: '123123123132132132',
+     *         participant: 'requester@c.us',
+     *         _serialized: 'false_groupId@g.us_123123123132132132_requester@c.us'
+     *     },
+     *     body: '',
+     *     type: 'created_membership_requests',
+     *     timestamp: 1694456538,
+     *     chatId: 'group@g.us',
+     *     author: 'requester@c.us',
+     *     recipientIds: []
+     * }
+     *
+     */
+    console.log(notification);
+    /** You can approve or reject the newly appeared membership request: */
+    await client.approveGroupMembershipRequestss('groupId@g.us', notification.author);
+    await client.rejectGroupMembershipRequests('groupId@g.us', notification.author);
 });

--- a/example.js
+++ b/example.js
@@ -244,12 +244,14 @@ client.on('message', async msg => {
          * Presented an example for membership request approvals, the same examples are for the request rejections.
          * To approve the membership request from a specific user:
          */
-        await client.approveGroupMembershipRequests(msg.from, 'number@c.us');
+        await client.approveGroupMembershipRequests(msg.from, { requesterIds: 'number@c.us' });
         /** The same for execution on group object (no need to provide the group ID): */
         const group = await msg.getChat();
-        await group.approveGroupMembershipRequests('number@c.us');
+        await group.approveGroupMembershipRequests({ requesterIds: 'number@c.us' });
         /** To approve several membership requests: */
-        const approval = await client.approveGroupMembershipRequests(msg.from, ['number1@c.us', 'number2@c.us']);
+        const approval = await client.approveGroupMembershipRequests(msg.from, {
+            requesterIds: ['number1@c.us', 'number2@c.us']
+        });
         /**
          * The example of the {@link approval} output:
          * [
@@ -267,11 +269,20 @@ client.on('message', async msg => {
         /** To approve all the existing membership requests (simply don't provide any user IDs): */
         await client.approveGroupMembershipRequests(msg.from);
         /** To change the sleep value to 300 ms: */
-        await client.approveGroupMembershipRequests(msg.from, ['number1@c.us', 'number2@c.us'], 300);
+        await client.approveGroupMembershipRequests(msg.from, {
+            requesterIds: ['number1@c.us', 'number2@c.us'],
+            sleep: 300
+        });
         /** To change the sleep value to random value between 100 and 300 ms: */
-        await client.approveGroupMembershipRequests(msg.from, ['number1@c.us', 'number2@c.us'], [100, 300]);
+        await client.approveGroupMembershipRequests(msg.from, {
+            requesterIds: ['number1@c.us', 'number2@c.us'],
+            sleep: [100, 300]
+        });
         /** To explicitly disable the sleep: */
-        await client.approveGroupMembershipRequests(msg.from, ['number1@c.us', 'number2@c.us'], null);
+        await client.approveGroupMembershipRequests(msg.from, {
+            requesterIds: ['number1@c.us', 'number2@c.us'],
+            sleep: null
+        });
     }
 });
 

--- a/example.js
+++ b/example.js
@@ -255,13 +255,15 @@ client.on('message', async msg => {
         /**
          * The example of the {@link approval} output:
          * [
-         *     {
-         *         requesterId: 'number1@c.us'
-         *     },
-         *     {
-         *         requesterId: 'number2@c.us',
-         *         error: {...}
-         *     }
+         *   {
+         *     requesterId: 'number1@c.us',
+         *     message: 'Rejected successfully'
+         *   },
+         *   {
+         *     requesterId: 'number2@c.us',
+         *     error: 404,
+         *     message: 'ParticipantRequestNotFoundError'
+         *   }
          * ]
          *
          */

--- a/example.js
+++ b/example.js
@@ -393,22 +393,22 @@ client.on('group_membership_request', async (notification) => {
      * {
      *     id: {
      *         fromMe: false,
-     *         remote: 'group@g.us',
+     *         remote: 'groupId@g.us',
      *         id: '123123123132132132',
-     *         participant: 'requester@c.us',
-     *         _serialized: 'false_groupId@g.us_123123123132132132_requester@c.us'
+     *         participant: 'number@c.us',
+     *         _serialized: 'false_groupId@g.us_123123123132132132_number@c.us'
      *     },
      *     body: '',
      *     type: 'created_membership_requests',
      *     timestamp: 1694456538,
-     *     chatId: 'group@g.us',
-     *     author: 'requester@c.us',
+     *     chatId: 'groupId@g.us',
+     *     author: 'number@c.us',
      *     recipientIds: []
      * }
      *
      */
     console.log(notification);
     /** You can approve or reject the newly appeared membership request: */
-    await client.approveGroupMembershipRequestss('groupId@g.us', notification.author);
-    await client.rejectGroupMembershipRequests('groupId@g.us', notification.author);
+    await client.approveGroupMembershipRequestss(notification.chatId, notification.author);
+    await client.rejectGroupMembershipRequests(notification.chatId, notification.author);
 });

--- a/index.d.ts
+++ b/index.d.ts
@@ -210,6 +210,15 @@ declare namespace WAWebJS {
             notification: GroupNotification
         ) => void): this
 
+        /**
+         * Emitted when some user requested to join the group
+         * that has the membership approval mode turned on
+         */
+        on(event: 'group_membership_request', listener: (
+            /** GroupNotification with more information about the action */
+            notification: GroupNotification
+        ) => void): this
+
         /** Emitted when group settings are updated, such as subject, description or picture */
         on(event: 'group_update', listener: (
             /** GroupNotification with more information about the action */
@@ -589,6 +598,7 @@ declare namespace WAWebJS {
         GROUP_JOIN = 'group_join',
         GROUP_LEAVE = 'group_leave',
         GROUP_ADMIN_CHANGED = 'group_admin_changed',
+        GROUP_MEMBERSHIP_REQUEST = 'group_membership_request',
         GROUP_UPDATE = 'group_update',
         QR_RECEIVED = 'qr',
         LOADING_SCREEN = 'loading_screen',

--- a/index.d.ts
+++ b/index.d.ts
@@ -1275,6 +1275,14 @@ declare namespace WAWebJS {
         t: number
     }
 
+    /** An object that handles the result of membership request action */
+    export interface MembershipRequestActionResult {
+        /** User ID whos membership request was approved/rejected */
+        requesterId: string;
+        /** An error that occurred during the operation for the participant, if any */
+        error: Object|null;
+    }
+
     export interface GroupChat extends Chat {
         /** Group owner */
         owner: ContactId;
@@ -1296,14 +1304,14 @@ declare namespace WAWebJS {
         setSubject: (subject: string) => Promise<boolean>;
         /** Updates the group description */
         setDescription: (description: string) => Promise<boolean>;
-        /** Updates the group settings to only allow admins to send messages 
-         * @param {boolean} [adminsOnly=true] Enable or disable this option 
+        /** Updates the group settings to only allow admins to send messages
+         * @param {boolean} [adminsOnly=true] Enable or disable this option
          * @returns {Promise<boolean>} Returns true if the setting was properly updated. This can return false if the user does not have the necessary permissions.
          */
         setMessagesAdminsOnly: (adminsOnly?: boolean) => Promise<boolean>;
         /**
          * Updates the group settings to only allow admins to edit group info (title, description, photo).
-         * @param {boolean} [adminsOnly=true] Enable or disable this option 
+         * @param {boolean} [adminsOnly=true] Enable or disable this option
          * @returns {Promise<boolean>} Returns true if the setting was properly updated. This can return false if the user does not have the necessary permissions.
          */
         setInfoAdminsOnly: (adminsOnly?: boolean) => Promise<boolean>;
@@ -1313,17 +1321,19 @@ declare namespace WAWebJS {
          */
         getGroupMembershipRequests: () => Promise<Array<GroupMembershipRequest>>;
         /**
-         * Approves the membership request if exists
-         * @param {string} requesterId The user ID who requested to join the group
-         * @returns {Promise<boolean>} Returns true if the operation completed successfully, false otherwise
+         * Approves membership requests if any
+         * @param {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
+         * @param {Array<number>|number} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
+         * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
          */
-        approveGroupMembershipRequest: (requesterId: string) => Promise<boolean>;
+        approveGroupMembershipRequests: (requesterIds: Array<string>|string|null, sleep: Array<number>|number) => Promise<Array<MembershipRequestActionResult>>;
         /**
-         * Rejects the membership request if exists
-         * @param {string} requesterId The user ID who requested to join the group
-         * @returns {Promise<boolean>} Returns true if the operation completed successfully, false otherwise
+         * Rejects membership requests if any
+         * @param {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
+         * @param {Array<number>|number} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
+         * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
          */
-        rejectGroupMembershipRequest: (requesterId: string) => Promise<boolean>;
+        rejectGroupMembershipRequests: (requesterIds: Array<string>|string|null, sleep: Array<number>|number) => Promise<Array<MembershipRequestActionResult>>;
         /** Gets the invite code for a specific group */
         getInviteCode: () => Promise<string>;
         /** Invalidates the current group invite code and generates a new one */

--- a/index.d.ts
+++ b/index.d.ts
@@ -1351,8 +1351,7 @@ declare namespace WAWebJS {
          * @param {MembershipRequestActionOptions} options Options for performing a membership request action
          * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were rejected and an error for each requester, if any occurred during the operation. If there are no requests, an empty array will be returned
          */
-        rejectGroupMembershipRequests: (options: MembershipRequestActionOptions
-        ) => Promise<Array<MembershipRequestActionResult>>;
+        rejectGroupMembershipRequests: (options: MembershipRequestActionOptions) => Promise<Array<MembershipRequestActionResult>>;
         /** Gets the invite code for a specific group */
         getInviteCode: () => Promise<string>;
         /** Invalidates the current group invite code and generates a new one */

--- a/index.d.ts
+++ b/index.d.ts
@@ -163,6 +163,9 @@ declare namespace WAWebJS {
         /** Gets an array of membership requests */
         getGroupMembershipRequests: (groupId: string) => Promise<Array<GroupMembershipRequest>>
 
+        /** Tries to get the membership request and approve it so that the requester can join the group */
+        approveGroupMembershipRequest: (groupId: string, requesterId: string) => Promise<boolean>;
+
         /** Generic event */
         on(event: string, listener: (...args: any) => void): this
 
@@ -1258,16 +1261,16 @@ declare namespace WAWebJS {
     /** An object that handles the information about the group membership request */
     export interface GroupMembershipRequest {
         /** The wid of a user who requests to enter the group */
-        id: Object<Wid>,
+        id: Object;
         /** The wid of a user who created that request */
-        addedBy: Object<Wid>,
+        addedBy: Object;
         /** The wid of a community parent group to which the current group is linked */
-        parentGroupId: Object<Wid> | null,
+        parentGroupId: Object | null;
         /** The method used to create the request: NonAdminAdd/InviteLink/LinkedGroupJoin */
         requestMethod: string,
         /** The timestamp the request was created at */
         t: number
-    };
+    }
 
     export interface GroupChat extends Chat {
         /** Group owner */
@@ -1306,6 +1309,12 @@ declare namespace WAWebJS {
          * @returns {Promise<Array<GroupMembershipRequest>>} An array of membership requests
          */
         getGroupMembershipRequests: () => Promise<Array<GroupMembershipRequest>>;
+        /**
+         * Tries to get the membership request and approve it so that the requester can join the group
+         * @param {string} requesterId The user ID who requested to join the group
+         * @returns {Promise<boolean>} Returns true if the operation completed successfully, false otherwise
+         */
+        approveGroupMembershipRequest: (requesterId: string) => Promise<boolean>;
         /** Gets the invite code for a specific group */
         getInviteCode: () => Promise<string>;
         /** Invalidates the current group invite code and generates a new one */

--- a/index.d.ts
+++ b/index.d.ts
@@ -163,7 +163,7 @@ declare namespace WAWebJS {
         /** Gets an array of membership requests */
         getGroupMembershipRequests: (groupId: string) => Promise<Array<GroupMembershipRequest>>
 
-        /** Tries to get the membership request and approve it so that the requester can join the group */
+        /** Approves the membership request if exists */
         approveGroupMembershipRequest: (groupId: string, requesterId: string) => Promise<boolean>;
 
         /** Generic event */
@@ -1310,7 +1310,7 @@ declare namespace WAWebJS {
          */
         getGroupMembershipRequests: () => Promise<Array<GroupMembershipRequest>>;
         /**
-         * Tries to get the membership request and approve it so that the requester can join the group
+         * Approves the membership request if exists
          * @param {string} requesterId The user ID who requested to join the group
          * @returns {Promise<boolean>} Returns true if the operation completed successfully, false otherwise
          */

--- a/index.d.ts
+++ b/index.d.ts
@@ -1289,8 +1289,10 @@ declare namespace WAWebJS {
     export interface MembershipRequestActionResult {
         /** User ID whos membership request was approved/rejected */
         requesterId: Array<string> | string | null;
-        /** An error that occurred during the operation for the participant, if any */
-        error: Object | null;
+        /** An error code that occurred during the operation for the participant */
+        error?: number;
+        /** A message with a result of membership request action */
+        message: string;
     }
 
     /** Options for performing a membership request action  */
@@ -1341,18 +1343,15 @@ declare namespace WAWebJS {
         /**
          * Approves membership requests if any
          * @param {MembershipRequestActionOptions} options Options for performing a membership request action
-         * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
+         * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation. If there are no requests, an empty array will be returned
          */
         approveGroupMembershipRequests: (options: MembershipRequestActionOptions) => Promise<Array<MembershipRequestActionResult>>;
         /**
          * Rejects membership requests if any
-         * @param {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
-         * @param {Array<number>|number} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
-         * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
+         * @param {MembershipRequestActionOptions} options Options for performing a membership request action
+         * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were rejected and an error for each requester, if any occurred during the operation. If there are no requests, an empty array will be returned
          */
-        rejectGroupMembershipRequests: (
-            requesterIds: Array<string> | string | null,
-            sleep: Array<number> | number | null
+        rejectGroupMembershipRequests: (options: MembershipRequestActionOptions
         ) => Promise<Array<MembershipRequestActionResult>>;
         /** Gets the invite code for a specific group */
         getInviteCode: () => Promise<string>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -164,10 +164,10 @@ declare namespace WAWebJS {
         getGroupMembershipRequests: (groupId: string) => Promise<Array<GroupMembershipRequest>>
 
         /** Approves membership requests if any */
-        approveGroupMembershipRequests: (groupId: string, requesterIds: Array<string>|string|null, sleep: Array<number>|number|null) => Promise<Array<MembershipRequestActionResult>>;
+        approveGroupMembershipRequests: (groupId: string, options: MembershipRequestActionOptions) => Promise<Array<MembershipRequestActionResult>>;
 
         /** Rejects membership requests if any */
-        rejectGroupMembershipRequests: (groupId: string, requesterIds: Array<string>|string|null, sleep: Array<number>|number|null) => Promise<Array<MembershipRequestActionResult>>;
+        rejectGroupMembershipRequests: (groupId: string, options: MembershipRequestActionOptions) => Promise<Array<MembershipRequestActionResult>>;
 
         /** Generic event */
         on(event: string, listener: (...args: any) => void): this
@@ -1285,12 +1285,20 @@ declare namespace WAWebJS {
         t: number
     }
 
-    /** An object that handles the result of membership request action */
+    /** An object that handles the result for membership request action */
     export interface MembershipRequestActionResult {
         /** User ID whos membership request was approved/rejected */
-        requesterId: string;
+        requesterId: Array<string> | string | null;
         /** An error that occurred during the operation for the participant, if any */
-        error: Object|null;
+        error: Object | null;
+    }
+
+    /** Options for performing a membership request action  */
+    export interface MembershipRequestActionOptions {
+        /** User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group */
+        requesterIds: Array<string> | string | null;
+        /** The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500] */
+        sleep: Array<number> | number | null;
     }
 
     export interface GroupChat extends Chat {
@@ -1332,18 +1340,20 @@ declare namespace WAWebJS {
         getGroupMembershipRequests: () => Promise<Array<GroupMembershipRequest>>;
         /**
          * Approves membership requests if any
-         * @param {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
-         * @param {Array<number>|number} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
+         * @param {MembershipRequestActionOptions} options Options for performing a membership request action
          * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
          */
-        approveGroupMembershipRequests: (requesterIds: Array<string>|string|null, sleep: Array<number>|number|null) => Promise<Array<MembershipRequestActionResult>>;
+        approveGroupMembershipRequests: (options: MembershipRequestActionOptions) => Promise<Array<MembershipRequestActionResult>>;
         /**
          * Rejects membership requests if any
          * @param {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
          * @param {Array<number>|number} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
          * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
          */
-        rejectGroupMembershipRequests: (requesterIds: Array<string>|string|null, sleep: Array<number>|number|null) => Promise<Array<MembershipRequestActionResult>>;
+        rejectGroupMembershipRequests: (
+            requesterIds: Array<string> | string | null,
+            sleep: Array<number> | number | null
+        ) => Promise<Array<MembershipRequestActionResult>>;
         /** Gets the invite code for a specific group */
         getInviteCode: () => Promise<string>;
         /** Invalidates the current group invite code and generates a new one */

--- a/index.d.ts
+++ b/index.d.ts
@@ -163,11 +163,11 @@ declare namespace WAWebJS {
         /** Gets an array of membership requests */
         getGroupMembershipRequests: (groupId: string) => Promise<Array<GroupMembershipRequest>>
 
-        /** Approves the membership request if exists */
-        approveGroupMembershipRequest: (groupId: string, requesterId: string) => Promise<boolean>;
+        /** Approves membership requests if any */
+        approveGroupMembershipRequests: (groupId: string, requesterIds: Array<string>|string|null, sleep: Array<number>|number|null) => Promise<Array<MembershipRequestActionResult>>;
 
-        /** Rejects the membership request if exists */
-        rejectGroupMembershipRequest: (groupId: string, requesterId: string) => Promise<boolean>;
+        /** Rejects membership requests if any */
+        rejectGroupMembershipRequests: (groupId: string, requesterIds: Array<string>|string|null, sleep: Array<number>|number|null) => Promise<Array<MembershipRequestActionResult>>;
 
         /** Generic event */
         on(event: string, listener: (...args: any) => void): this
@@ -1326,14 +1326,14 @@ declare namespace WAWebJS {
          * @param {Array<number>|number} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
          * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
          */
-        approveGroupMembershipRequests: (requesterIds: Array<string>|string|null, sleep: Array<number>|number) => Promise<Array<MembershipRequestActionResult>>;
+        approveGroupMembershipRequests: (requesterIds: Array<string>|string|null, sleep: Array<number>|number|null) => Promise<Array<MembershipRequestActionResult>>;
         /**
          * Rejects membership requests if any
          * @param {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
          * @param {Array<number>|number} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
          * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
          */
-        rejectGroupMembershipRequests: (requesterIds: Array<string>|string|null, sleep: Array<number>|number) => Promise<Array<MembershipRequestActionResult>>;
+        rejectGroupMembershipRequests: (requesterIds: Array<string>|string|null, sleep: Array<number>|number|null) => Promise<Array<MembershipRequestActionResult>>;
         /** Gets the invite code for a specific group */
         getInviteCode: () => Promise<string>;
         /** Invalidates the current group invite code and generates a new one */

--- a/index.d.ts
+++ b/index.d.ts
@@ -160,6 +160,9 @@ declare namespace WAWebJS {
         /** Deletes the current user's profile picture */
         deleteProfilePicture(): Promise<boolean>
 
+        /** Gets an array of membership requests */
+        getGroupMembershipRequests: (groupId: string) => Promise<Array<GroupMembershipRequest>>
+
         /** Generic event */
         on(event: string, listener: (...args: any) => void): this
 
@@ -1252,6 +1255,20 @@ declare namespace WAWebJS {
              [key: string]: number;
          }>
 
+    /** An object that handles the information about the group membership request */
+    export interface GroupMembershipRequest {
+        /** The wid of a user who requests to enter the group */
+        id: Object<Wid>,
+        /** The wid of a user who created that request */
+        addedBy: Object<Wid>,
+        /** The wid of a community parent group to which the current group is linked */
+        parentGroupId: Object<Wid> | null,
+        /** The method used to create the request: NonAdminAdd/InviteLink/LinkedGroupJoin */
+        requestMethod: string,
+        /** The timestamp the request was created at */
+        t: number
+    };
+
     export interface GroupChat extends Chat {
         /** Group owner */
         owner: ContactId;
@@ -1284,6 +1301,11 @@ declare namespace WAWebJS {
          * @returns {Promise<boolean>} Returns true if the setting was properly updated. This can return false if the user does not have the necessary permissions.
          */
         setInfoAdminsOnly: (adminsOnly?: boolean) => Promise<boolean>;
+        /**
+         * Gets an array of membership requests
+         * @returns {Promise<Array<GroupMembershipRequest>>} An array of membership requests
+         */
+        getGroupMembershipRequests: () => Promise<Array<GroupMembershipRequest>>;
         /** Gets the invite code for a specific group */
         getInviteCode: () => Promise<string>;
         /** Invalidates the current group invite code and generates a new one */

--- a/index.d.ts
+++ b/index.d.ts
@@ -166,6 +166,9 @@ declare namespace WAWebJS {
         /** Approves the membership request if exists */
         approveGroupMembershipRequest: (groupId: string, requesterId: string) => Promise<boolean>;
 
+        /** Rejects the membership request if exists */
+        rejectGroupMembershipRequest: (groupId: string, requesterId: string) => Promise<boolean>;
+
         /** Generic event */
         on(event: string, listener: (...args: any) => void): this
 
@@ -1315,6 +1318,12 @@ declare namespace WAWebJS {
          * @returns {Promise<boolean>} Returns true if the operation completed successfully, false otherwise
          */
         approveGroupMembershipRequest: (requesterId: string) => Promise<boolean>;
+        /**
+         * Rejects the membership request if exists
+         * @param {string} requesterId The user ID who requested to join the group
+         * @returns {Promise<boolean>} Returns true if the operation completed successfully, false otherwise
+         */
+        rejectGroupMembershipRequest: (requesterId: string) => Promise<boolean>;
         /** Gets the invite code for a specific group */
         getInviteCode: () => Promise<string>;
         /** Invalidates the current group invite code and generates a new one */

--- a/src/Client.js
+++ b/src/Client.js
@@ -1465,7 +1465,7 @@ class Client extends EventEmitter {
     async getGroupMembershipRequests(groupId) {
         return await this.pupPage.evaluate(async (gropId) => {
             const groupWid = window.Store.WidFactory.createWid(gropId);
-            return await window.Store.GroupUtils.getMembershipApprovalRequests(groupWid);
+            return await window.Store.MembershipRequestUtils.getMembershipApprovalRequests(groupWid);
         }, groupId);
     }
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -1480,6 +1480,18 @@ class Client extends EventEmitter {
             return await window.WWebJS.membershipRequestAction(groupId, requesterId, 'Approve');
         }, groupId, requesterId);
     }
+
+    /**
+     * Rejects the membership request if exists
+     * @param {string} groupId The group ID to get the membership request for
+     * @param {string} requesterId The user ID who requested to join the group
+     * @returns {Promise<boolean>} Returns true if the operation completed successfully, false otherwise
+     */
+    async rejectGroupMembershipRequest(groupId, requesterId) {
+        return await this.pupPage.evaluate(async (groupId, requesterId) => {
+            return await window.WWebJS.membershipRequestAction(groupId, requesterId, 'Reject');
+        }, groupId, requesterId);
+    }
 }
 
 module.exports = Client;

--- a/src/Client.js
+++ b/src/Client.js
@@ -1470,7 +1470,7 @@ class Client extends EventEmitter {
     }
 
     /**
-     * Tries to get the membership request and approve it so that the requester can join the group
+     * Approves the membership request if exists
      * @param {string} groupId The group ID to get the membership request for
      * @param {string} requesterId The user ID who requested to join the group
      * @returns {Promise<boolean>} Returns true if the operation completed successfully, false otherwise

--- a/src/Client.js
+++ b/src/Client.js
@@ -1473,7 +1473,8 @@ class Client extends EventEmitter {
      * An object that handles the result for membership request action
      * @typedef {Object} MembershipRequestActionResult
      * @property {string} requesterId User ID whos membership request was approved/rejected
-     * @property {Object|null} error An error that occurred during the operation for the participant, if any
+     * @property {number|undefined} error An error code that occurred during the operation for the participant
+     * @property {string} message A message with a result of membership request action
      */
 
     /**
@@ -1487,7 +1488,7 @@ class Client extends EventEmitter {
      * Approves membership requests if any
      * @param {string} groupId The group ID to get the membership request for
      * @param {MembershipRequestActionOptions} options Options for performing a membership request action
-     * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
+     * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation. If there are no requests, an empty array will be returned
      */
     async approveGroupMembershipRequests(groupId, options = {}) {
         return await this.pupPage.evaluate(async (groupId, options) => {
@@ -1500,7 +1501,7 @@ class Client extends EventEmitter {
      * Rejects membership requests if any
      * @param {string} groupId The group ID to get the membership request for
      * @param {MembershipRequestActionOptions} options Options for performing a membership request action
-     * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were rejected and an error for each requester, if any occurred during the operation
+     * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were rejected and an error for each requester, if any occurred during the operation. If there are no requests, an empty array will be returned
      */
     async rejectGroupMembershipRequests(groupId, options = {}) {
         return await this.pupPage.evaluate(async (groupId, options) => {

--- a/src/Client.js
+++ b/src/Client.js
@@ -1480,7 +1480,7 @@ class Client extends EventEmitter {
      * Approves membership requests if any
      * @param {string} groupId The group ID to get the membership request for
      * @param {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
-     * @param {Array<number>|number} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
+     * @param {Array<number>|number|null} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
      * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
      */
     async approveGroupMembershipRequests(groupId, requesterIds = null, sleep = [250, 500]) {
@@ -1493,7 +1493,7 @@ class Client extends EventEmitter {
      * Rejects membership requests if any
      * @param {string} groupId The group ID to get the membership request for
      * @param {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
-     * @param {Array<number>|number} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
+     * @param {Array<number>|number|null} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
      * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were rejected and an error for each requester, if any occurred during the operation
      */
     async rejectGroupMembershipRequests(groupId, requesterIds = null, sleep = [250, 500]) {

--- a/src/Client.js
+++ b/src/Client.js
@@ -286,13 +286,13 @@ class Client extends EventEmitter {
              */
             window.compareWwebVersions = (lOperand, operator, rOperand) => {
                 if (!['>', '>=', '<', '<=', '='].includes(operator)) {
-                    throw class _ extends Error {
+                    throw new class _ extends Error {
                         constructor(m) { super(m); this.name = 'CompareWwebVersionsError'; }
                     }('Invalid comparison operator is provided');
 
                 }
                 if (typeof lOperand !== 'string' || typeof rOperand !== 'string') {
-                    throw class _ extends Error {
+                    throw new class _ extends Error {
                         constructor(m) { super(m); this.name = 'CompareWwebVersionsError'; }
                     }('A non-string WWeb version type is provided');
                 }

--- a/src/Client.js
+++ b/src/Client.js
@@ -1477,21 +1477,7 @@ class Client extends EventEmitter {
      */
     async approveGroupMembershipRequest(groupId, requesterId) {
         return await this.pupPage.evaluate(async (groupId, requesterId) => {
-            const groupWid = window.Store.WidFactory.createWid(groupId);
-            const group = await window.Store.Chat.find(groupWid);
-            const membershipRequest =
-                group.groupMetadata.membershipApprovalRequests._models.find(m => m.id._serialized === requesterId);
-            if (!membershipRequest) return false;
-            try {
-                const [response] =
-                    await window.Store.MembershipRequestUtils.approveRequest(group.id, [membershipRequest.id]);
-                return response.error
-                    ? false
-                    : true;
-            } catch (err) {
-                if (err.name === 'ServerStatusCodeError') return false;
-                throw err;
-            }
+            return await window.WWebJS.membershipRequestAction(groupId, requesterId, 'Approve');
         }, groupId, requesterId);
     }
 }

--- a/src/Client.js
+++ b/src/Client.js
@@ -1446,6 +1446,28 @@ class Client extends EventEmitter {
             return await window.Store.Label.addOrRemoveLabels(actions, chats);
         }, labelIds, chatIds);
     }
+
+    /**
+     * An object that handles the information about the group membership request
+     * @typedef {Object} GroupMembershipRequest
+     * @property {Object<Wid>} id The wid of a user who requests to enter the group
+     * @property {Object<Wid>} addedBy The wid of a user who created that request
+     * @property {Object<Wid>|null} parentGroupId The wid of a community parent group to which the current group is linked
+     * @property {string} requestMethod The method used to create the request: NonAdminAdd/InviteLink/LinkedGroupJoin
+     * @property {number} t The timestamp the request was created at
+     */
+
+    /**
+     * Gets an array of membership requests
+     * @param {string} groupId The ID of a group to get membership requests for
+     * @returns {Promise<Array<GroupMembershipRequest>>} An array of membership requests
+     */
+    async getGroupMembershipRequests(groupId) {
+        return await this.pupPage.evaluate(async (gropId) => {
+            const groupWid = window.Store.WidFactory.createWid(gropId);
+            return await window.Store.GroupUtils.getMembershipApprovalRequests(groupWid);
+        }, groupId);
+    }
 }
 
 module.exports = Client;

--- a/src/Client.js
+++ b/src/Client.js
@@ -51,6 +51,7 @@ const NoAuth = require('./authStrategies/NoAuth');
  * @fires Client#change_state
  * @fires Client#contact_changed
  * @fires Client#group_admin_changed
+ * @fires Client#group_membership_request
  */
 class Client extends EventEmitter {
     constructor(options = {}) {
@@ -379,6 +380,17 @@ class Client extends EventEmitter {
                      * @param {GroupNotification} notification GroupNotification with more information about the action
                      */
                     this.emit(Events.GROUP_ADMIN_CHANGED, notification);
+                } else if (msg.subtype === 'created_membership_requests') {
+                    /**
+                     * Emitted when some user requested to join the group
+                     * that has the membership approval mode turned on
+                     * @event Client#group_membership_request
+                     * @param {GroupNotification} notification GroupNotification with more information about the action
+                     * @param {string} notification.chatId The group ID the request was made for
+                     * @param {string} notification.author The user ID that made a request
+                     * @param {number} notification.timestamp The timestamp the request was made at
+                     */
+                    this.emit(Events.GROUP_MEMBERSHIP_REQUEST, notification);
                 } else {
                     /**
                      * Emitted when group settings are updated, such as subject, description or picture.

--- a/src/Client.js
+++ b/src/Client.js
@@ -1470,27 +1470,36 @@ class Client extends EventEmitter {
     }
 
     /**
-     * Approves the membership request if exists
-     * @param {string} groupId The group ID to get the membership request for
-     * @param {string} requesterId The user ID who requested to join the group
-     * @returns {Promise<boolean>} Returns true if the operation completed successfully, false otherwise
+     * An object that handles the result of membership request action
+     * @typedef {Object} MembershipRequestActionResult
+     * @property {string} requesterId User ID whos membership request was approved/rejected
+     * @property {Object|null} error An error that occurred during the operation for the participant, if any
      */
-    async approveGroupMembershipRequest(groupId, requesterId) {
-        return await this.pupPage.evaluate(async (groupId, requesterId) => {
-            return await window.WWebJS.membershipRequestAction(groupId, requesterId, 'Approve');
-        }, groupId, requesterId);
+
+    /**
+     * Approves membership requests if any
+     * @param {string} groupId The group ID to get the membership request for
+     * @param {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
+     * @param {Array<number>|number} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
+     * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
+     */
+    async approveGroupMembershipRequests(groupId, requesterIds = null, sleep = [250, 500]) {
+        return await this.pupPage.evaluate(async (groupId, requesterIds, sleep) => {
+            return await window.WWebJS.membershipRequestAction(groupId, 'Approve', requesterIds, sleep);
+        }, groupId, requesterIds, sleep);
     }
 
     /**
-     * Rejects the membership request if exists
+     * Rejects membership requests if any
      * @param {string} groupId The group ID to get the membership request for
-     * @param {string} requesterId The user ID who requested to join the group
-     * @returns {Promise<boolean>} Returns true if the operation completed successfully, false otherwise
+     * @param {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
+     * @param {Array<number>|number} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
+     * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were rejected and an error for each requester, if any occurred during the operation
      */
-    async rejectGroupMembershipRequest(groupId, requesterId) {
-        return await this.pupPage.evaluate(async (groupId, requesterId) => {
-            return await window.WWebJS.membershipRequestAction(groupId, requesterId, 'Reject');
-        }, groupId, requesterId);
+    async rejectGroupMembershipRequests(groupId, requesterIds = null, sleep = [250, 500]) {
+        return await this.pupPage.evaluate(async (groupId, requesterIds, sleep) => {
+            return await window.WWebJS.membershipRequestAction(groupId, 'Reject', requesterIds, sleep);
+        }, groupId, requesterIds, sleep);
     }
 }
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -1470,36 +1470,43 @@ class Client extends EventEmitter {
     }
 
     /**
-     * An object that handles the result of membership request action
+     * An object that handles the result for membership request action
      * @typedef {Object} MembershipRequestActionResult
      * @property {string} requesterId User ID whos membership request was approved/rejected
      * @property {Object|null} error An error that occurred during the operation for the participant, if any
      */
 
     /**
+     * An object that handles options for {@link approveGroupMembershipRequests} and {@link rejectGroupMembershipRequests} methods
+     * @typedef {Object} MembershipRequestActionOptions
+     * @property {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
+     * @property {Array<number>|number|null} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
+     */
+
+    /**
      * Approves membership requests if any
      * @param {string} groupId The group ID to get the membership request for
-     * @param {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
-     * @param {Array<number>|number|null} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
+     * @param {MembershipRequestActionOptions} options Options for performing a membership request action
      * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
      */
-    async approveGroupMembershipRequests(groupId, requesterIds = null, sleep = [250, 500]) {
-        return await this.pupPage.evaluate(async (groupId, requesterIds, sleep) => {
+    async approveGroupMembershipRequests(groupId, options = {}) {
+        return await this.pupPage.evaluate(async (groupId, options) => {
+            const { requesterIds = null, sleep = [250, 500] } = options;
             return await window.WWebJS.membershipRequestAction(groupId, 'Approve', requesterIds, sleep);
-        }, groupId, requesterIds, sleep);
+        }, groupId, options);
     }
 
     /**
      * Rejects membership requests if any
      * @param {string} groupId The group ID to get the membership request for
-     * @param {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
-     * @param {Array<number>|number|null} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
+     * @param {MembershipRequestActionOptions} options Options for performing a membership request action
      * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were rejected and an error for each requester, if any occurred during the operation
      */
-    async rejectGroupMembershipRequests(groupId, requesterIds = null, sleep = [250, 500]) {
-        return await this.pupPage.evaluate(async (groupId, requesterIds, sleep) => {
+    async rejectGroupMembershipRequests(groupId, options = {}) {
+        return await this.pupPage.evaluate(async (groupId, options) => {
+            const { requesterIds = null, sleep = [250, 500] } = options;
             return await window.WWebJS.membershipRequestAction(groupId, 'Reject', requesterIds, sleep);
-        }, groupId, requesterIds, sleep);
+        }, groupId, options);
     }
 }
 

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -293,7 +293,7 @@ class GroupChat extends Chat {
     /**
      * Approves membership requests if any
      * @param {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
-     * @param {Array<number>|number} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
+     * @param {Array<number>|number|null} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
      * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
      */
     async approveGroupMembershipRequests(requesterIds = null, sleep = [250, 500]) {
@@ -303,7 +303,7 @@ class GroupChat extends Chat {
     /**
      * Rejects membership requests if any
      * @param {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
-     * @param {Array<number>|number} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
+     * @param {Array<number>|number|null} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
      * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
      */
     async rejectGroupMembershipRequests(requesterIds = null, sleep = [250, 500]) {

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -293,6 +293,15 @@ class GroupChat extends Chat {
     }
 
     /**
+     * Rejects the membership request if exists
+     * @param {string} requesterId The user ID who requested to join the group
+     * @returns {Promise<boolean>} Returns true if the operation completed successfully, false otherwise
+     */
+    async rejectGroupMembershipRequest(requesterId) {
+        return await this.client.rejectGroupMembershipRequest(this.id._serialized, requesterId);
+    }
+
+    /**
      * Makes the bot leave the group
      * @returns {Promise}
      */

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -287,7 +287,8 @@ class GroupChat extends Chat {
      * An object that handles the result for membership request action
      * @typedef {Object} MembershipRequestActionResult
      * @property {string} requesterId User ID whos membership request was approved/rejected
-     * @property {Object|null} error An error that occurred during the operation for the participant, if any
+     * @property {number} error An error code that occurred during the operation for the participant
+     * @property {string} message A message with a result of membership request action
      */
 
     /**
@@ -300,7 +301,7 @@ class GroupChat extends Chat {
     /**
      * Approves membership requests if any
      * @param {MembershipRequestActionOptions} options Options for performing a membership request action
-     * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
+     * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation. If there are no requests, an empty array will be returned
      */
     async approveGroupMembershipRequests(options = {}) {
         return await this.client.approveGroupMembershipRequests(this.id._serialized, options);
@@ -309,7 +310,7 @@ class GroupChat extends Chat {
     /**
      * Rejects membership requests if any
      * @param {MembershipRequestActionOptions} options Options for performing a membership request action
-     * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
+     * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were rejected and an error for each requester, if any occurred during the operation. If there are no requests, an empty array will be returned
      */
     async rejectGroupMembershipRequests(options = {}) {
         return await this.client.rejectGroupMembershipRequests(this.id._serialized, options);

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -284,7 +284,7 @@ class GroupChat extends Chat {
     }
 
     /**
-     * Tries to get the membership request and approve it so that the requester can join the group
+     * Approves the membership request if exists
      * @param {string} requesterId The user ID who requested to join the group
      * @returns {Promise<boolean>} Returns true if the operation completed successfully, false otherwise
      */

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -284,21 +284,30 @@ class GroupChat extends Chat {
     }
 
     /**
-     * Approves the membership request if exists
-     * @param {string} requesterId The user ID who requested to join the group
-     * @returns {Promise<boolean>} Returns true if the operation completed successfully, false otherwise
+     * An object that handles the result of membership request action
+     * @typedef {Object} MembershipRequestActionResult
+     * @property {string} requesterId User ID whos membership request was approved/rejected
+     * @property {Object|null} error An error that occurred during the operation for the participant, if any
      */
-    async approveGroupMembershipRequest(requesterId) {
-        return await this.client.approveGroupMembershipRequest(this.id._serialized, requesterId);
+
+    /**
+     * Approves membership requests if any
+     * @param {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
+     * @param {Array<number>|number} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
+     * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
+     */
+    async approveGroupMembershipRequests(requesterIds = null, sleep = [250, 500]) {
+        return await this.client.approveGroupMembershipRequests(this.id._serialized, requesterIds, sleep);
     }
 
     /**
-     * Rejects the membership request if exists
-     * @param {string} requesterId The user ID who requested to join the group
-     * @returns {Promise<boolean>} Returns true if the operation completed successfully, false otherwise
+     * Rejects membership requests if any
+     * @param {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
+     * @param {Array<number>|number} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
+     * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
      */
-    async rejectGroupMembershipRequest(requesterId) {
-        return await this.client.rejectGroupMembershipRequest(this.id._serialized, requesterId);
+    async rejectGroupMembershipRequests(requesterIds = null, sleep = [250, 500]) {
+        return await this.client.rejectGroupMembershipRequests(this.id._serialized, requesterIds, sleep);
     }
 
     /**

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -268,9 +268,9 @@ class GroupChat extends Chat {
     /**
      * An object that handles the information about the group membership request
      * @typedef {Object} GroupMembershipRequest
-     * @property {Object<Wid>} id The wid of a user who requests to enter the group
-     * @property {Object<Wid>} addedBy The wid of a user who created that request
-     * @property {Object<Wid>|null} parentGroupId The wid of a community parent group to which the current group is linked
+     * @property {Object} id The wid of a user who requests to enter the group
+     * @property {Object} addedBy The wid of a user who created that request
+     * @property {Object|null} parentGroupId The wid of a community parent group to which the current group is linked
      * @property {string} requestMethod The method used to create the request: NonAdminAdd/InviteLink/LinkedGroupJoin
      * @property {number} t The timestamp the request was created at
      */
@@ -281,6 +281,15 @@ class GroupChat extends Chat {
      */
     async getGroupMembershipRequests() {
         return await this.client.getGroupMembershipRequests(this.id._serialized);
+    }
+
+    /**
+     * Tries to get the membership request and approve it so that the requester can join the group
+     * @param {string} requesterId The user ID who requested to join the group
+     * @returns {Promise<boolean>} Returns true if the operation completed successfully, false otherwise
+     */
+    async approveGroupMembershipRequest(requesterId) {
+        return await this.client.approveGroupMembershipRequest(this.id._serialized, requesterId);
     }
 
     /**

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -264,6 +264,24 @@ class GroupChat extends Chat {
 
         return codeRes.code;
     }
+    
+    /**
+     * An object that handles the information about the group membership request
+     * @typedef {Object} GroupMembershipRequest
+     * @property {Object<Wid>} id The wid of a user who requests to enter the group
+     * @property {Object<Wid>} addedBy The wid of a user who created that request
+     * @property {Object<Wid>|null} parentGroupId The wid of a community parent group to which the current group is linked
+     * @property {string} requestMethod The method used to create the request: NonAdminAdd/InviteLink/LinkedGroupJoin
+     * @property {number} t The timestamp the request was created at
+     */
+    
+    /**
+     * Gets an array of membership requests
+     * @returns {Promise<Array<GroupMembershipRequest>>} An array of membership requests
+     */
+    async getGroupMembershipRequests() {
+        return await this.client.getGroupMembershipRequests(this.id._serialized);
+    }
 
     /**
      * Makes the bot leave the group

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -284,30 +284,35 @@ class GroupChat extends Chat {
     }
 
     /**
-     * An object that handles the result of membership request action
+     * An object that handles the result for membership request action
      * @typedef {Object} MembershipRequestActionResult
      * @property {string} requesterId User ID whos membership request was approved/rejected
      * @property {Object|null} error An error that occurred during the operation for the participant, if any
      */
 
     /**
+     * An object that handles options for {@link approveGroupMembershipRequests} and {@link rejectGroupMembershipRequests} methods
+     * @typedef {Object} MembershipRequestActionOptions
+     * @property {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
+     * @property {Array<number>|number|null} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
+     */
+
+    /**
      * Approves membership requests if any
-     * @param {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
-     * @param {Array<number>|number|null} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
+     * @param {MembershipRequestActionOptions} options Options for performing a membership request action
      * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
      */
-    async approveGroupMembershipRequests(requesterIds = null, sleep = [250, 500]) {
-        return await this.client.approveGroupMembershipRequests(this.id._serialized, requesterIds, sleep);
+    async approveGroupMembershipRequests(options = {}) {
+        return await this.client.approveGroupMembershipRequests(this.id._serialized, options);
     }
 
     /**
      * Rejects membership requests if any
-     * @param {Array<string>|string|null} requesterIds User ID/s who requested to join the group, if no value is provided, the method will search for all membership requests for that group
-     * @param {Array<number>|number|null} sleep The number of milliseconds to wait before performing an operation for the next requester. If it is an array, a random sleep time between the sleep[0] and sleep[1] values will be added (the difference must be >=100 ms, otherwise, a random sleep time between sleep[1] and sleep[1] + 100 will be added). If sleep is a number, a sleep time equal to its value will be added. By default, sleep is an array with a value of [250, 500]
+     * @param {MembershipRequestActionOptions} options Options for performing a membership request action
      * @returns {Promise<Array<MembershipRequestActionResult>>} Returns an array of requester IDs whose membership requests were approved and an error for each requester, if any occurred during the operation
      */
-    async rejectGroupMembershipRequests(requesterIds = null, sleep = [250, 500]) {
-        return await this.client.rejectGroupMembershipRequests(this.id._serialized, requesterIds, sleep);
+    async rejectGroupMembershipRequests(options = {}) {
+        return await this.client.rejectGroupMembershipRequests(this.id._serialized, options);
     }
 
     /**

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -56,6 +56,7 @@ exports.Events = {
     GROUP_JOIN: 'group_join',
     GROUP_LEAVE: 'group_leave',
     GROUP_ADMIN_CHANGED: 'group_admin_changed',
+    GROUP_MEMBERSHIP_REQUEST: 'group_membership_request',
     GROUP_UPDATE: 'group_update',
     QR_RECEIVED: 'qr',
     LOADING_SCREEN: 'loading_screen',

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -74,7 +74,7 @@ exports.ExposeStore = (moduleRaidStr) => {
     window.Store.MembershipRequestUtils = {
         ...window.mR.findModule('getMembershipApprovalRequests')[0],
         ...window.mR.findModule('sendMembershipRequestsActionRPC')[0],
-        ...window.mR.findModule('queryAndUpdateGroupMembershipApprovalRequests')[0]
+        ...window.mR.findModule('queryAndUpdateGroupMetadataById')[0]
     };
 
     if (!window.Store.Chat._find) {
@@ -844,8 +844,7 @@ exports.LoadUtils = () => {
         let response;
         let result = [];
 
-        await window.Store.MembershipRequestUtils.queryAndUpdateGroupMembershipApprovalRequests(groupWid);
-        await new Promise((resolve) => setTimeout(resolve, 100));
+        await window.Store.MembershipRequestUtils.queryAndUpdateGroupMetadataById(groupWid);
 
         if (!requesterIds?.length) {
             membershipRequests = group.groupMetadata.membershipApprovalRequests._models.map(({ id }) => id);

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -63,16 +63,15 @@ exports.ExposeStore = (moduleRaidStr) => {
         ...window.mR.findModule('toWebpSticker')[0],
         ...window.mR.findModule('addWebpMetadata')[0]
     };
-  
     window.Store.GroupUtils = {
         ...window.mR.findModule('createGroup')[0],
         ...window.mR.findModule('setGroupDescription')[0],
         ...window.mR.findModule('sendExitGroup')[0],
         ...window.mR.findModule('sendSetPicture')[0]
     };
-
     window.Store.MembershipRequestUtils = {
-        ...window.mR.findModule('getMembershipApprovalRequests')[0]
+        ...window.mR.findModule('getMembershipApprovalRequests')[0],
+        approveRequest: window.mR.findModule('membershipApprovalRequestAction')[0].membershipApprovalRequestAction,
     };
 
     if (!window.Store.Chat._find) {

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -832,4 +832,24 @@ exports.LoadUtils = () => {
             throw err;
         }
     };
+
+    window.WWebJS.membershipRequestAction = async (groupId, requesterId, action) => {
+        const groupWid = window.Store.WidFactory.createWid(groupId);
+        const group = await window.Store.Chat.find(groupWid);
+        const membershipRequest = group.groupMetadata.membershipApprovalRequests._models.find(
+            (m) => m.id._serialized === requesterId
+        );
+        if (!membershipRequest) return false;
+        try {
+            const [response] = await window.Store.MembershipRequestUtils.approveRequest(
+                group.id,
+                [membershipRequest.id],
+                action
+            );
+            return response.error ? false : true;
+        } catch (err) {
+            if (err.name === 'ServerStatusCodeError') return false;
+            throw err;
+        }
+    };
 };

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -71,7 +71,7 @@ exports.ExposeStore = (moduleRaidStr) => {
     };
     window.Store.MembershipRequestUtils = {
         ...window.mR.findModule('getMembershipApprovalRequests')[0],
-        approveRequest: window.mR.findModule('membershipApprovalRequestAction')[0].membershipApprovalRequestAction,
+        ...window.mR.findModule('membershipApprovalRequestAction')[0],
     };
 
     if (!window.Store.Chat._find) {
@@ -841,7 +841,7 @@ exports.LoadUtils = () => {
         );
         if (!membershipRequest) return false;
         try {
-            const [response] = await window.Store.MembershipRequestUtils.approveRequest(
+            const [response] = await window.Store.MembershipRequestUtils.membershipApprovalRequestAction(
                 group.id,
                 [membershipRequest.id],
                 action

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -80,11 +80,8 @@ exports.ExposeStore = (moduleRaidStr) => {
         };
     }
 
-    if (window.mR.findModule('ChatCollection')[0] && window.mR.findModule('ChatCollection')[0].ChatCollection) {
-        if (typeof window.mR.findModule('ChatCollection')[0].ChatCollection.findImpl === 'undefined' && typeof window.mR.findModule('ChatCollection')[0].ChatCollection._find != 'undefined') {
-            window.mR.findModule('ChatCollection')[0].ChatCollection.findImpl = window.mR.findModule('ChatCollection')[0].ChatCollection._find;
-        }
-    }
+    // eslint-disable-next-line no-undef
+    if ((m = window.mR.findModule('ChatCollection')[0]) && m.ChatCollection && typeof m.ChatCollection.findImpl === 'undefined' && typeof m.ChatCollection._find !== 'undefined') m.ChatCollection.findImpl = m.ChatCollection._find;
 
     // TODO remove these once everybody has been updated to WWebJS with legacy sessions removed
     const _linkPreview = window.mR.findModule('queryLinkPreview');

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -71,6 +71,10 @@ exports.ExposeStore = (moduleRaidStr) => {
         ...window.mR.findModule('sendSetPicture')[0]
     };
 
+    window.Store.MembershipRequestUtils = {
+        ...window.mR.findModule('getMembershipApprovalRequests')[0]
+    };
+
     if (!window.Store.Chat._find) {
         window.Store.Chat._find = e => {
             const target = window.Store.Chat.get(e);

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -14,6 +14,7 @@ exports.ExposeStore = (moduleRaidStr) => {
     window.Store.CryptoLib = window.mR.findModule('decryptE2EMedia')[0];
     window.Store.DownloadManager = window.mR.findModule('downloadManager')[0].downloadManager;
     window.Store.GroupMetadata = window.mR.findModule('GroupMetadata')[0].default.GroupMetadata;
+    window.Store.GroupMetadata.queryAndUpdate = window.mR.findModule('queryAndUpdateGroupMetadataById')[0].queryAndUpdateGroupMetadataById;
     window.Store.Invite = window.mR.findModule('resetGroupInviteCode')[0];
     window.Store.InviteInfo = window.mR.findModule('queryGroupInvite')[0];
     window.Store.Label = window.mR.findModule('LabelCollection')[0].LabelCollection;
@@ -73,8 +74,7 @@ exports.ExposeStore = (moduleRaidStr) => {
     };
     window.Store.MembershipRequestUtils = {
         ...window.mR.findModule('getMembershipApprovalRequests')[0],
-        ...window.mR.findModule('sendMembershipRequestsActionRPC')[0],
-        ...window.mR.findModule('queryAndUpdateGroupMetadataById')[0]
+        ...window.mR.findModule('sendMembershipRequestsActionRPC')[0]
     };
 
     if (!window.Store.Chat._find) {
@@ -874,7 +874,7 @@ exports.LoadUtils = () => {
         let response;
         let result = [];
 
-        await window.Store.MembershipRequestUtils.queryAndUpdateGroupMetadataById(groupWid);
+        await window.Store.GroupMetadata.queryAndUpdate(groupWid);
 
         if (!requesterIds?.length) {
             membershipRequests = group.groupMetadata.membershipApprovalRequests._models.map(({ id }) => id);

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -59,6 +59,8 @@ exports.ExposeStore = (moduleRaidStr) => {
     window.Store.SocketWap = window.mR.findModule('wap')[0];
     window.Store.SearchContext = window.mR.findModule('getSearchContext')[0].getSearchContext;
     window.Store.DrawerManager = window.mR.findModule('DrawerManager')[0].DrawerManager;
+    window.Store.WidToJid = window.mR.findModule('widToUserJid')[0];
+    window.Store.JidToWid = window.mR.findModule('userJidToUserWid')[0];
     window.Store.StickerTools = {
         ...window.mR.findModule('toWebpSticker')[0],
         ...window.mR.findModule('addWebpMetadata')[0]

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -902,7 +902,9 @@ exports.LoadUtils = () => {
                     }
                 }
 
-                sleep && participantArgs.length > 1 &&
+                sleep &&
+                    participantArgs.length > 1 &&
+                    participantArgs.indexOf(args) !== participantArgs.length - 1 &&
                     (await new Promise((resolve) => setTimeout(resolve, _getSleepTime(sleep))));
             }
             return result;

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -937,7 +937,7 @@ exports.LoadUtils = () => {
                             return {
                                 requesterId: window.Store.WidFactory.createWid(p.jid)._serialized,
                                 ...(error
-                                    ? { error: +error, message: membReqResCodes[error] }
+                                    ? { error: +error, message: membReqResCodes[error] || membReqResCodes.default }
                                     : { message: `${toApprove ? 'Approved' : 'Rejected'} successfully` })
                             };
                         });

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -866,7 +866,7 @@ exports.LoadUtils = () => {
         }
     };
 
-    window.WWebJS.membershipRequestAction = async (groupId, action, requesterIds = null, sleep = [250, 500]) => {
+    window.WWebJS.membershipRequestAction = async (groupId, action, requesterIds, sleep) => {
         const groupWid = window.Store.WidFactory.createWid(groupId);
         const group = await window.Store.Chat.find(groupWid);
         const toApprove = action === 'Approve';

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -943,6 +943,11 @@ exports.LoadUtils = () => {
                         });
                         _ && result.push(_);
                     }
+                } else {
+                    result.push({
+                        requesterId: window.Store.JidToWid.userJidToUserWid(participant.participantArgs[0].participantJid)._serialized,
+                        message: 'ServerStatusCodeError'
+                    });
                 }
 
                 sleep &&

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -71,7 +71,8 @@ exports.ExposeStore = (moduleRaidStr) => {
     };
     window.Store.MembershipRequestUtils = {
         ...window.mR.findModule('getMembershipApprovalRequests')[0],
-        ...window.mR.findModule('sendMembershipRequestsActionRPC')[0]
+        ...window.mR.findModule('sendMembershipRequestsActionRPC')[0],
+        ...window.mR.findModule('queryAndUpdateGroupMembershipApprovalRequests')[0]
     };
 
     if (!window.Store.Chat._find) {
@@ -840,6 +841,9 @@ exports.LoadUtils = () => {
         let membershipRequests;
         let response;
         let result = [];
+
+        await window.Store.MembershipRequestUtils.queryAndUpdateGroupMembershipApprovalRequests(groupWid);
+        await new Promise((resolve) => setTimeout(resolve, 100));
 
         if (!requesterIds?.length) {
             membershipRequests = group.groupMetadata.membershipApprovalRequests._models.map(({ id }) => id);


### PR DESCRIPTION
# Table of Contents <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2516#toc" id="toc"/>

### - [Description](https://github.com/pedroslopez/whatsapp-web.js/pull/2516#description)

### - [Related Issues](https://github.com/pedroslopez/whatsapp-web.js/pull/2516#related-issues)

### - [Usage Example](https://github.com/pedroslopez/whatsapp-web.js/pull/2516#usage-example)

### - [I Want to Test this PR](https://github.com/pedroslopez/whatsapp-web.js/pull/2516#pr-testing)

### - [How Has the PR Been Tested (latest test on 25.09.2023)](https://github.com/pedroslopez/whatsapp-web.js/pull/2516#tests)
- [**The environment the PR was tested on**](https://github.com/pedroslopez/whatsapp-web.js/pull/2516#env)
- [**I have an issue while testing this PR**](https://github.com/pedroslopez/whatsapp-web.js/pull/2516#pr-testing-issue)

### - [Types of Changes](https://github.com/pedroslopez/whatsapp-web.js/pull/2516#types-of-changes)

---

## Description [_[Back to TOC]_](https://github.com/pedroslopez/whatsapp-web.js/pull/2516#toc) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2516#description" id="description"/>
The PR adds functionality to get, approve, reject and listen to group membership requests.
Things that were added:
1. An event to listen to new group membership requests
2. Three new methods both for `Client` and `GroupChat` classes (to execute on `GroupChat` object and without it):
    - `getGroupMembershipRequests` method that returns membership requests for specific group
    - `approveGroupMembershipRequests` method to approve requests from specific user, several users or all the existing membership requests
    - `rejectGroupMembershipRequests` the same as previous but to reject requests

More about `approveGroupMembershipRequests` and `rejectGroupMembershipRequests`:
- Both methods take:
    - group ID (if you are calling the method from `client` instance)
    - optional parameter `options`
- Options can take:
    - `requesterIds`: a single user ID as a string or an array of user IDs to approve/reject requests from
    - `sleep`: a sleep value
- The sleep value is necessary to avoid the risk of your accounts being banned. According to the logic of how these methods work in the WA, the operation is performed on only one user at a time, and we iterate over each user ID to perform the operation. If you pass more than one user ID, the method will, by default, choose a random sleep value between 250 to 500 milliseconds to wait before operation with next user. However, you have the flexibility to change this sleep value as needed
- If you want to approve or reject all existing membership requests for a specific group without specifying user IDs individually, you can simply call these methods without passing any user IDs
- An empty array will be returned in these cases:
    1. You wanted to approve/reject all the membership requests but there are no any
    2. A `SmaxParsingFailure` error was occupied

## Related Issues <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2516#related-issues" id="related-issues"/>
PR closes #2379 closes #2241

## Usage Example [_[Back to TOC]_](https://github.com/pedroslopez/whatsapp-web.js/pull/2516#toc) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2516#usage-example" id="usage-example"/>

### Methods:
```js
client.on('message', async (msg) => {
    if (msg.body === '!approverequest') {
        /**
         * Presented an example for membership request approvals, the same examples are for the requesrejections.
         * To approve the membership request from a specific user:
         */
        await client.approveGroupMembershipRequests(msg.from, { requesterIds: 'number@c.us' });
        /** The same for execution on group object (no need to provide the group ID): */
        const group = await msg.getChat();
        await group.approveGroupMembershipRequests({ requesterIds: 'number@c.us' });
        /** To approve several membership requests: */
        const approval = await client.approveGroupMembershipRequests(msg.from, {
            requesterIds: ['number1@c.us', 'number2@c.us']
        });
        /**
         * The example of the {@link approval} output:
         * [
         *   {
         *     requesterId: 'number1@c.us',
         *     message: 'Rejected successfully'
         *   },
         *   {
         *     requesterId: 'number2@c.us',
         *     error: 404,
         *     message: 'ParticipantRequestNotFoundError'
         *   }
         * ]
         *
         */
        console.log(approval);
        /** To approve all the existing membership requests (simply don't provide any user IDs): */
        await client.approveGroupMembershipRequests(msg.from);
        /** To change the sleep value to 300 ms: */
        await client.approveGroupMembershipRequests(msg.from, {
            requesterIds: ['number1@c.us', 'number2@c.us'],
            sleep: 300
        });
        /** To change the sleep value to random value between 100 and 300 ms: */
        await client.approveGroupMembershipRequests(msg.from, {
            requesterIds: ['number1@c.us', 'number2@c.us'],
            sleep: [100, 300]
        });
        /** To explicitly disable the sleep: */
        await client.approveGroupMembershipRequests(msg.from, {
            requesterIds: ['number1@c.us', 'number2@c.us'],
            sleep: null
        });
    }
});
```

### Event:
```js
client.on('group_membership_request', async (notification) => {
    /**
     * The example of the {@link notification} output:
     * {
     *     id: {
     *         fromMe: false,
     *         remote: 'groupId@g.us',
     *         id: '123123123132132132',
     *         participant: 'number@c.us',
     *         _serialized: 'false_groupId@g.us_123123123132132132_number@c.us'
     *     },
     *     body: '',
     *     type: 'created_membership_requests',
     *     timestamp: 1694456538,
     *     chatId: 'groupId@g.us',
     *     author: 'number@c.us',
     *     recipientIds: []
     * }
     *
     */
    console.log(notification);
    /** You can approve or reject the newly appeared membership request: */
    await client.approveGroupMembershipRequests(notification.chatId, notification.author);
    await client.rejectGroupMembershipRequests(notification.chatId, notification.author);
});
```

## To test this PR by yourself you can run one of the following commands: <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2516#pr-testing" id="pr-testing"/>

- **NPM**
```powershell
npm install github:alechkos/whatsapp-web.js#grp-memb-req
```
- **YARN**
```powershell
yarn add github:alechkos/whatsapp-web.js#grp-memb-req
```

## How Has This Been Tested (latest test on 25.09.2023) [_[Back to TOC]_](https://github.com/pedroslopez/whatsapp-web.js/pull/2516#toc) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2516#tests" id="tests"/>
The functionality has been tested with the code provided in usage example.

### Tested On: <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2516#env" id="env"/>

#### Types of accounts:
- Personal
- Buisness

#### Environment:
- Android 10
- Windows 10:
    - WWebJS **v1.22.2-alpha.1**
    - WWeb **v2.2333.11**, **v2.2340.11**
    - Puppeteer **v18.2.1**
    - Node **v18.17.1**
    - Chrome **v117.0.5938.92**

<details><summary>

### If you encounter any issues while testing this PR, please provide in a comment (click to expand): <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2516#pr-testing-issue" id="pr-testing-issue"/>
</summary>

> [!IMPORTANT]
> **You have to [reapply](https://github.com/pedroslopez/whatsapp-web.js/pull/2516#pr-testing) the PR each time it is changed (new commits were pushed since your last application)**

1. The code you've used without any sensitive information (use [syntax highlighting](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting) for more readability)
4. The library version
5. The WWeb version: `console.log(await client.getWWebVersion());`
6. The browser (Chrome/Chromium)
7. The error you got
</details>

## Types of Changes [_[Back to TOC]_](https://github.com/pedroslopez/whatsapp-web.js/pull/2516#toc) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2516#types-of-changes" id="types-of-changes"/>
- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project
- [X] I have updated the usage example accordingly (example.js)
- [X] I have updated the documentation accordingly (index.d.ts)