### PR TITLE
Fix: RemoteAuth unzip .zip file properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "mime": "^3.0.0",
     "node-fetch": "^2.6.5",
     "node-webpmux": "^3.1.0",
-    "puppeteer": "^13.0.0"
+    "puppeteer": "^13.0.0",
+    "adm-zip": "^0.5.10"
   },
   "devDependencies": {
     "@types/node-fetch": "^2.5.12",

--- a/src/authStrategies/RemoteAuth.js
+++ b/src/authStrategies/RemoteAuth.js
@@ -3,12 +3,12 @@
 /* Require Optional Dependencies */
 try {
     var fs = require('fs-extra');
-    var unzipper = require('unzipper');
     var archiver = require('archiver');
+    var AdmZip = require('adm-zip');
 } catch {
     fs = undefined;
-    unzipper = undefined;
     archiver = undefined;
+    AdmZip = undefined;
 }
 
 const path = require('path');
@@ -154,13 +154,14 @@ class RemoteAuth extends BaseAuthStrategy {
     }
 
     async unCompressSession(compressedSessionPath) {
-        var stream = fs.createReadStream(compressedSessionPath);
         await new Promise((resolve, reject) => {
-            stream.pipe(unzipper.Extract({
-                path: this.userDataDir
-            }))
-                .on('error', err => reject(err))
-                .on('finish', () => resolve());
+            const zip = new AdmZip(compressedSessionPath);
+            zip.extractAllToAsync(this.userDataDir, true, false, (err) => {
+                if(err)
+                { reject(err); }
+                else
+                { resolve(); }
+            });
         });
         await fs.promises.unlink(compressedSessionPath);
     }


### PR DESCRIPTION
# Maintain RemoteAuth working properly

## Description

After authenticated and throwing the "remote_session_saved" event. However, when we try to recover the session, it fails and whatsapp immediately redirect to the QR code page.

This hotfix:
- Substitute **unzipper** to **adm-zip** library.
- Add **amd-zip** to dependencies.
- Re-write `unCompressSession(compressedSessionPath)` function in **RemoteAuth.js** to work with **adm-zip** library.

## Motivation and Context

Keep the RemoteAuth strategy working concisely and consistently.

## How Has This Been Tested

### Does your WhatsApp account have multidevice enabled?

- [x] Yes
- [ ] No

### Environment

- Node.js Version: v18.17.1
- Phone OS: Android
- WhatsApp Web version: 2.2333.11
- whatsapp-web.js version v1.22.1 and v1.22.2-alpha.0
- OS: Linux

### Code changes

#### Old

```javascript
async unCompressSession(compressedSessionPath) {
    var stream = fs.createReadStream(compressedSessionPath);
    await new Promise((resolve, reject) => {
        stream.pipe(unzipper.Extract({
            path: this.userDataDir
        }))
            .on('error', err => reject(err))
            .on('finish', () => resolve());
    });
    await fs.promises.unlink(compressedSessionPath);
}
```

#### New

```javascript
async unCompressSession(compressedSessionPath) {
    await new Promise((resolve, reject) => {
        const zip = new AdmZip(compressedSessionPath);
        zip.extractAllToAsync(this.userDataDir, true, false, (err) => {
            if(err)
            { reject(err); }
            else
            { resolve(); }
        });
    });
    await fs.promises.unlink(compressedSessionPath);
}
```

### Test workflow

#### Requirements

- Install **Adm-Zip** library.
```shell
npm i adm-zip
```
- Install **wwebjs-mongo** plugin or any other plugin you want.
```shell
npm i wwebjs-mongo
```
- Use RemoteAuth as an authentication strategy.

#### Test Steps

1. Replace in RemoteAuth.js file ***old*** code with the new one cited in **Code Changes** section.
2. Starts the application, scans the QR code and waits for the `client.on('remote_session_saved')` event to fire.
3. After saving your session, shout down the application and restart it.
4. Observe if application will restore previous session.

## Types of changes

- [x] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).