### PR TITLE
fix: location options adjustments

### DIFF
--- a/src/structures/Location.js
+++ b/src/structures/Location.js
@@ -31,30 +31,14 @@ class Location {
         this.longitude = longitude;
 
         /**
-         * Name for the location
-         * @type {string|undefined}
+         * Location full options
+         * @type {LocationSendOptions}
          */
-        this.name = options.name;
-
-        /**
-         * Location address
-         * @type {string|undefined}
-         */
-        this.address = options.address;
-
-        /**
-         * URL address to be shown within a location message
-         * @type {string|undefined}
-         */
-        this.url = options.url;
-
-        /**
-         * Location full description
-         * @type {string|undefined}
-         */
-        this.description = this.name && this.address
-            ? `${this.name}\n${this.address}`
-            : this.name || this.address || '';
+        this.options = {
+            address: options.address,
+            name: options.name,
+            url: options.url,
+        };
     }
 }
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

PR adjusts the values ​​of the locations object to suit its primary typing.

The Location class constructor now exports the three keys in the options object:

  1. Latitude
  2. Longitude
  3. options
      1. address
      2. name
      3. url 
      
These adjustments are to be fair and faithful to the location typing, modified by @alechkos in PR #2339.

<!--- Describe your changes in detail -->

## Related Issue

<!--- Optional --->
<!--- If there is an issue link it here: -->

## Motivation and Context

I updated the lib and when I ran the build, I saw that ts issued an error due to the new typing of the options key. I adjusted the code based on the new typing, but I was surprised to learn that the new typing did not represent the real value obtained in the location key. So I decided to fix it.

<!--- Optional --->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).



