### PR TITLE
fix: send docs without caption

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -440,7 +440,7 @@ declare namespace WAWebJS {
         /** User agent to use in puppeteer.
          * @default 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Safari/537.36' */
         userAgent?: string
-        /** Ffmpeg path to use when formating videos to webp while sending stickers 
+        /** Ffmpeg path to use when formatting videos to webp while sending stickers 
          * @default 'ffmpeg' */
         ffmpegPath?: string,
         /** Object with proxy autentication requirements @default: undefined */

--- a/src/Client.js
+++ b/src/Client.js
@@ -30,7 +30,7 @@ const NoAuth = require('./authStrategies/NoAuth');
  * @param {number} options.takeoverOnConflict - If another whatsapp web session is detected (another browser), take over the session in the current browser
  * @param {number} options.takeoverTimeoutMs - How much time to wait before taking over the session
  * @param {string} options.userAgent - User agent to use in puppeteer
- * @param {string} options.ffmpegPath - Ffmpeg path to use when formating videos to webp while sending stickers 
+ * @param {string} options.ffmpegPath - Ffmpeg path to use when formatting videos to webp while sending stickers 
  * @param {boolean} options.bypassCSP - Sets bypassing of page's Content-Security-Policy.
  * @param {object} options.proxyAuthentication - Proxy Authentication object.
  * 

--- a/src/Client.js
+++ b/src/Client.js
@@ -891,7 +891,7 @@ class Client extends EventEmitter {
 
 
             if (sendSeen) {
-                window.WWebJS.sendSeen(chatId);
+                await window.WWebJS.sendSeen(chatId);
             }
 
             const msg = await window.WWebJS.sendMessage(chat, message, options, sendSeen);

--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -176,9 +176,7 @@ exports.LoadUtils = () => {
                     forceGif: options.sendVideoAsGif
                 });
             
-            if (options.caption){
-                attOptions.caption = options.caption; 
-            }
+            attOptions.caption = options.caption;
             content = options.sendMediaAsSticker ? undefined : attOptions.preview;
             attOptions.isViewOnce = options.isViewOnce;
 


### PR DESCRIPTION
# Table of Contents

### - [Description](https://github.com/pedroslopez/whatsapp-web.js/pull/2660#description) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2660#description-b" id="description-b"/>

### - [Related Issues](https://github.com/pedroslopez/whatsapp-web.js/pull/2660#related-issues) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2660#related-issues-b" id="related-issues-b"/>

### - [Usage Example](https://github.com/pedroslopez/whatsapp-web.js/pull/2660#usage-example) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2660#usage-example-b" id="usage-example-b"/>

### - [I Want to Test this PR](https://github.com/pedroslopez/whatsapp-web.js/pull/2660#pr-testing) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2660#pr-testing-b" id="pr-testing-b"/>

### - [I Got an Error While Testing This PR ❌](https://github.com/pedroslopez/whatsapp-web.js/pull/2660#pr-issues) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2660#pr-issues-b" id="pr-issues-b"/>

### - [How Has the PR Been Tested](https://github.com/pedroslopez/whatsapp-web.js/pull/2660#tests) (latest test on 01.12.2023) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2660#tests-b" id="tests-b"/>
- [**The environment the PR was tested on**](https://github.com/pedroslopez/whatsapp-web.js/pull/2660#env)

### - [Types of Changes](https://github.com/pedroslopez/whatsapp-web.js/pull/2660#types-of-changes) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2660#types-of-changes-b" id="types-of-changes-b"/>

---

## [Description](https://github.com/pedroslopez/whatsapp-web.js/pull/2660#description-b) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2660#description" id="description"/>
**There is an issue when sending a document: if no caption is provided, the filename becomes the default caption.**
Additionally, even when the optional property caption is set to empty string:
```js
await client.sendMessage(chat, doc, { caption: '' })
```
the document is still being sent with a caption that is its filename.

The PR fixes that issue. Now, if a caption is not provided, the document will be sent without one.

---

## [Related Issues](https://github.com/pedroslopez/whatsapp-web.js/pull/2660#related-issues-b) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2660#related-issues" id="related-issues"/>
The PR closes #2649, closes #2536, closes #2097, closes #1849

---

## [Usage Example](https://github.com/pedroslopez/whatsapp-web.js/pull/2660#usage-example-b) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2660#usage-example" id="usage-example"/>

```js
const { MessageMedia } = require('whatsapp-web.js');

// client initialization...

client.on('ready', async () => {
    const doc = MessageMedia.fromFilePath('./path/to/file.extension');
    const chatId = 'XXXXXXXXXX@c.us'
    await client.sendMessage(chatId, doc); // The document will be sent without a caption
    await client.sendMessage(chatId, doc, { caption: 'some caption' }); // The document will be sent with a caption 'some caption'
});
```

---

## [To test this PR by yourself you can run one of the following commands:](https://github.com/pedroslopez/whatsapp-web.js/pull/2660#pr-testing-b) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2660#pr-testing" id="pr-testing"/>

- **NPM**
```powershell
npm install github:alechkos/whatsapp-web.js#send-withno-caption
```
- **YARN**
```powershell
yarn add github:alechkos/whatsapp-web.js#send-withno-caption
```

---

## [If you encounter any errors while testing this PR, please provide in a comment:](https://github.com/pedroslopez/whatsapp-web.js/pull/2660#pr-issues-b) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2660#pr-issues" id="pr-issues"/>

1. The code you've used without any sensitive information (use [syntax highlighting](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting) for more readability)
2. The error you got
3. The library version
4. The WWeb version: `console.log(await client.getWWebVersion());`
5. The browser (Chrome/Chromium)

> [!IMPORTANT]
> **You have to [reapply](https://github.com/pedroslopez/whatsapp-web.js/pull/2660#pr-testing) the PR each time it is changed (new commits were pushed since your last application)**

---

## [How Has The PR Been Tested](https://github.com/pedroslopez/whatsapp-web.js/pull/2660#tests-b) (latest test on 01.12.2023) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2660#tests" id="tests"/>
Tested with a code provided in usage example.

### Tested On: <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2660#env" id="env"/>

#### Types of accounts:
- Personal
- Buisness

#### Environment:
- Android 10:
    - WhatsApp: **latest**
    - WA Business: **latest**
- Windows 10:
    - WWebJS: **v1.23.1-alpha.0**
    - WWeb: **v2.2353.0**
    - Puppeteer: **v18.2.1**
    - Node: **v18.17.1**
    - Chrome: **latest**

---

## [Types of Changes](https://github.com/pedroslopez/whatsapp-web.js/pull/2660#types-of-changes-b) <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/2660#types-of-changes" id="types-of-changes"/>
- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix/feature that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project
- [ ] I have updated the usage example accordingly (example.js)
- [ ] I have updated the documentation accordingly (index.d.ts)





<!--
Link to PR: https://github.com/pedroslopez/whatsapp-web.js/pull/2660
-->