### PR TITLE
Fix TS compilation error "Statements are not allowed in ambient context" index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1422,7 +1422,7 @@ declare namespace WAWebJS {
             message: string;
             isInviteV4Sent: boolean,
         }
-    };
+    }
 
     /** An object that handles options for adding participants */
     export interface AddParticipantsOptions {
@@ -1446,7 +1446,7 @@ declare namespace WAWebJS {
          * @default ''
          */
         comment?: string
-    };
+    }
 
     /** An object that handles the information about the group membership request */
     export interface GroupMembershipRequest {


### PR DESCRIPTION


# PR Details

There is a TS compilation error `Statements are not allowed in ambient contexts` that is triggered due to invalid semicolons in index.d.ts.

## Description

Fixed by removing the semicolons.

closes #2734

## Motivation and Context

The modification introducing the issue is 2 month old... Why undetected before ? That's weird.

## How Has This Been Tested

`npm run build -- -w` a project with `import WAWebJS, {Client, LocalAuth, MessageMedia } from 'whatsapp-web.js';`

## Types of changes

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly (index.d.ts). (N/A)



