### PR TITLE
Temporary group message

### DIFF
--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -328,6 +328,33 @@ class GroupChat extends Chat {
     }
 
     /**
+     * Updates the group's temporary message setting.
+     * @param {int} [expiration] Sets the temporary message time (24h, 7d, 90d or disabled).
+     * - For 24 hours: expiration = 86400
+     * - For 7 days: expiration = 604800
+     * - For 90 days: expiration = 7776000
+     * - To disabled: expiration = 0
+     * @returns {Promise<boolean>} Returns true if the setting was properly updated. This can return false if the user does not have the necessary permissions.
+     */
+    async setGroupEphemeral(expiration) {
+        const success = await this.client.pupPage.evaluate(async (chatId, expiration) => {
+            const chatWid = window.Store.WidFactory.createWid(chatId);
+            try {
+                await window.Store.GroupUtils.setGroupProperty(chatWid, 'ephemeral', expiration);
+                return true;
+            } catch (err) {
+                if (err.name === 'ServerStatusCodeError') return false;
+                throw err;
+            }
+        }, this.id._serialized, expiration);
+
+        if (!success) return false;
+
+        this.groupMetadata.ephemeral = expiration;
+        return true;
+    }
+
+    /**
      * Deletes the group's picture.
      * @returns {Promise<boolean>} Returns true if the picture was properly deleted. This can return false if the user does not have the necessary permissions.
      */


### PR DESCRIPTION
# PR Details

I'm adding the ability to enable and change the time of a group's temporary message

## Description

I used the setGroupProperty module to implement this new functionality

I added the **setGroupEphemeral** method inside the **GroupChat**

How to use:

``` javascript 
let expiration = 604800; // For 7 days
chat.setGroupEphemeral(expiration);
```

On WhatsApp we have the following options:
24 hours, 7 days, 90 days and disabled

``` javascript 
// For 24 hours
chat.setGroupEphemeral(86400);

// For 7 days
chat.setGroupEphemeral(604800); 

// For 90 days
chat.setGroupEphemeral(7776000); 

// To disabled
chat.setGroupEphemeral(0);
```

## Motivation and Context

I wanted to try changing the group's temporary message setting and wanted to do this via the API, rather than manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Check list

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly (index.d.ts).