### PR TITLE
Add members settings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1523,6 +1523,11 @@ declare namespace WAWebJS {
         setSubject: (subject: string) => Promise<boolean>;
         /** Updates the group description */
         setDescription: (description: string) => Promise<boolean>;
+        /** Updates the group settings to only allow admins to add members.
+         * @param {boolean} [adminsOnly=true] Enable or disable this option 
+         * @returns {Promise<boolean>} Returns true if the setting was properly updated. This can return false if the user does not have the necessary permissions.
+         */
+        setAddMembersAdminsOnly: (adminsOnly?: boolean) => Promise<boolean>;
         /** Updates the group settings to only allow admins to send messages
          * @param {boolean} [adminsOnly=true] Enable or disable this option
          * @returns {Promise<boolean>} Returns true if the setting was properly updated. This can return false if the user does not have the necessary permissions.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1523,7 +1523,8 @@ declare namespace WAWebJS {
         setSubject: (subject: string) => Promise<boolean>;
         /** Updates the group description */
         setDescription: (description: string) => Promise<boolean>;
-        /** Updates the group settings to only allow admins to add members.
+        /**
+         * Updates the group setting to allow only admins to add members to the group.
          * @param {boolean} [adminsOnly=true] Enable or disable this option 
          * @returns {Promise<boolean>} Returns true if the setting was properly updated. This can return false if the user does not have the necessary permissions.
          */

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -293,7 +293,7 @@ class GroupChat extends Chat {
                 const response = await window.Store.GroupUtils.setGroupMemberAddMode(chatWid, 'member_add_mode', adminsOnly ? 0 : 1);
                 return response.name === 'SetMemberAddModeResponseSuccess';
             } catch (err) {
-                if(err.name === 'ServerStatusCodeError') return false;
+                if(err.name === 'SmaxParsingFailure') return false;
                 throw err;
             }
         }, this.id._serialized, adminsOnly);

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -282,6 +282,29 @@ class GroupChat extends Chat {
     }
     
     /**
+     * Updates the group settings to only allow admins to add members.
+     * @param {boolean} [adminsOnly=true] Enable or disable this option 
+     * @returns {Promise<boolean>} Returns true if the setting was properly updated. This can return false if the user does not have the necessary permissions.
+     */
+    async setAddMembersAdminsOnly(adminsOnly=true) {
+        const success = await this.client.pupPage.evaluate(async (chatId, adminsOnly) => {
+            const chatWid = window.Store.WidFactory.createWid(chatId);
+            try {
+                await window.Store.GroupUtils.setGroupMemberAddMode(chatWid, 'member_add_mode', adminsOnly ? 0 : 1);
+                return true;
+            } catch (err) {
+                if(err.name === 'ServerStatusCodeError') return false;
+                throw err;
+            }
+        }, this.id._serialized, adminsOnly);
+
+        if(!success) return false;
+
+        this.groupMetadata.memberAddMode = adminsOnly ? 'admin_add' : 'all_member_add';
+        return true;
+    }
+    
+    /**
      * Updates the group settings to only allow admins to send messages.
      * @param {boolean} [adminsOnly=true] Enable or disable this option 
      * @returns {Promise<boolean>} Returns true if the setting was properly updated. This can return false if the user does not have the necessary permissions.

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -282,26 +282,24 @@ class GroupChat extends Chat {
     }
     
     /**
-     * Updates the group settings to only allow admins to add members.
+     * Updates the group setting to allow only admins to add members to the group.
      * @param {boolean} [adminsOnly=true] Enable or disable this option 
      * @returns {Promise<boolean>} Returns true if the setting was properly updated. This can return false if the user does not have the necessary permissions.
      */
     async setAddMembersAdminsOnly(adminsOnly=true) {
-        const success = await this.client.pupPage.evaluate(async (chatId, adminsOnly) => {
-            const chatWid = window.Store.WidFactory.createWid(chatId);
+        const success = await this.client.pupPage.evaluate(async (groupId, adminsOnly) => {
+            const chatWid = window.Store.WidFactory.createWid(groupId);
             try {
-                await window.Store.GroupUtils.setGroupMemberAddMode(chatWid, 'member_add_mode', adminsOnly ? 0 : 1);
-                return true;
+                const response = await window.Store.GroupUtils.setGroupMemberAddMode(chatWid, 'member_add_mode', adminsOnly ? 0 : 1);
+                return response.name === 'SetMemberAddModeResponseSuccess';
             } catch (err) {
                 if(err.name === 'ServerStatusCodeError') return false;
                 throw err;
             }
         }, this.id._serialized, adminsOnly);
 
-        if(!success) return false;
-
-        this.groupMetadata.memberAddMode = adminsOnly ? 'admin_add' : 'all_member_add';
-        return true;
+        success && (this.groupMetadata.memberAddMode = adminsOnly ? 'admin_add' : 'all_member_add');
+        return success;
     }
     
     /**


### PR DESCRIPTION
Added a function `setAddMembersAdminsOnly`.
The function sets who can add members to the group: either only admins or all the group members. If turned on, only the group admins can add others to the group.