### PR TITLE
Fix "Inconsistency between Docs and Code for the Poll Object"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -906,7 +906,7 @@ declare namespace WAWebJS {
         rawData: object,
         pollName: string,
         /** Avaiaible poll voting options */
-        pollOptions: string[],
+        pollOptions: string[] | {name: string}[] | {name: string, localId: number}[],
         /** False for a single choice poll, true for a multiple choice poll */
         allowMultipleAnswers: boolean,
         /* 
@@ -1015,7 +1015,7 @@ declare namespace WAWebJS {
         }>
         options: PollSendOptions
 
-        constructor(pollName: string, pollOptions: Array<string>, options?: PollSendOptions)
+        constructor(pollName: string, pollOptions: string[] | {name: string}[] | {name: string, localId: number}[], options?: PollSendOptions)
     }
 
     export interface Label {

--- a/src/structures/Poll.js
+++ b/src/structures/Poll.js
@@ -11,7 +11,7 @@
 class Poll {
     /**
      * @param {string} pollName
-     * @param {Array<string>} pollOptions
+     * @param {Array<string> | Array<{name: string}> | Array<{name: string, localId: number}>} pollOptions
      * @param {PollSendOptions} options
      */
     constructor(pollName, pollOptions, options = {}) {
@@ -23,12 +23,18 @@ class Poll {
 
         /**
          * The array of poll options
-         * @type {Array.<{name: string, localId: number}>}
+         * @type {Array<{name: string, localId: number}>}
          */
-        this.pollOptions = pollOptions.map((option, index) => ({
-            name: option.trim(),
-            localId: index
-        }));
+        this.pollOptions = pollOptions.map((option, index) => {
+            if (typeof option === 'string') {
+                return { name: option.trim(), localId: index }
+            }
+            option['name'] = option['name'].trim() || `Option ${index + 1}`;
+            if (option['localId'] === undefined) {
+                option['localId'] = index;
+            }
+            return option;
+        });
 
         /**
          * The send options for the poll

--- a/src/structures/Poll.js
+++ b/src/structures/Poll.js
@@ -29,7 +29,7 @@ class Poll {
             if (typeof option === 'string') {
                 return { name: option.trim(), localId: index }
             }
-            option['name'] = option['name'].trim() || `Option ${index + 1}`;
+            option['name'] = option['name'].trim();
             if (option['localId'] === undefined) {
                 option['localId'] = index;
             }


### PR DESCRIPTION
# PR Details
According to the Documentation, the format for Poll Options should adhere to `Array.<{name: string, localId: number}>`. However, upon inspection of the constructor function of the [Poll.js](https://github.com/pedroslopez/whatsapp-web.js/blob/main/src/structures/Poll.js) file, it appears that the constructor function expects an `Array.<string>` format, while the poll options are not stored in this format.

This inconsistency between the provided documentation and the implemented code may lead to confusion for developers attempting to utilize the Poll functionality within the project. Clarification and alignment between the documentation and the codebase are necessary to ensure accurate usage and understanding by users.

## Description
I changed the constructor function of the [Poll](https://github.com/pedroslopez/whatsapp-web.js/blob/main/src/structures/Poll.js) to allow for `Array.<string>`, `Array.<{name: string}>` and `Array.<{name: string, localId: number}>`. 

## Related Issue
Issues: [#2839](https://github.com/pedroslopez/whatsapp-web.js/issues/2839)

## Motivation and Context
Ran into this issue, while coding with the documentation.

## How Has This Been Tested
I tested my changes with Poll-Options of forms:
- `Array.<string>`
- `Array.<{name: string}>`
- `Array.<{name: string, localId: number}>`

## Types of changes
- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly (index.d.ts).



