### PR TITLE
Update LocalWebCache.js

### DIFF
--- a/src/webCache/LocalWebCache.js
+++ b/src/webCache/LocalWebCache.js
@@ -30,10 +30,14 @@ class LocalWebCache extends WebCache {
     }
 
     async persist(indexHtml) {
-        // extract version from index (e.g. manifest-2.2206.9.json -> 2.2206.9)
-        const version = indexHtml.match(/manifest-([\d\\.]+)\.json/)[1];
-        if(!version) return;
-   
+        let version = "";
+        try {
+            // extract version from index (e.g. manifest-2.2206.9.json -> 2.2206.9)
+            version = indexHtml.match(/manifest-([\d\\.]+)\.json/)[1];
+
+        } catch(e){
+            version = "manifest";
+        }
         const filePath = path.join(this.path, `${version}.html`);
         fs.mkdirSync(this.path, { recursive: true });
         fs.writeFileSync(filePath, indexHtml);


### PR DESCRIPTION
# PR Details
Error on start
[LocalWebCache] _there is no number at manifest._

node .\example.js
c:\whatsapp-web\whats_test\src\webCache\LocalWebCache.js:34
        const version = indexHtml.match(/manifest-([\d\\.]+)\.json/)[1];


## Description

Fix error on start example.js

## Related Issue

don't found

## Motivation and Context
start app

## How Has This Been Tested
starting with: node .\example.js

## Types of changes

- [ ] Dependency change
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



