### PR TITLE
Fix: delete lines that remove data from this._data

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -295,12 +295,6 @@ class Message extends Base {
             this.allowMultipleAnswers = Boolean(!data.pollSelectableOptionsCount);
             this.pollInvalidated = data.pollInvalidated;
             this.isSentCagPollCreation = data.isSentCagPollCreation;
-
-            delete this._data.pollName;
-            delete this._data.pollOptions;
-            delete this._data.pollSelectableOptionsCount;
-            delete this._data.pollInvalidated;
-            delete this._data.isSentCagPollCreation;
         }
 
         return super._patch(data);


### PR DESCRIPTION
# PR Details

This PR removes lines in our codebase that delete specific properties from this._data. 
We want to keep the _data as similer to the original message as possiable


## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- Optional --->
<!--- If there is an issue link it here: -->

## Motivation and Context

<!--- Optional --->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



