### PR TITLE
Fix TypeError in LocalWebCache by handling null match results

### DIFF
--- a/src/webCache/LocalWebCache.js
+++ b/src/webCache/LocalWebCache.js
@@ -31,7 +31,9 @@ class LocalWebCache extends WebCache {
 
     async persist(indexHtml) {
         // extract version from index (e.g. manifest-2.2206.9.json -> 2.2206.9)
-        const version = indexHtml.match(/manifest-([\d\\.]+)\.json/)[1];
+        const versionMatchResult = indexHtml.match(/manifest-([\d\\.]+)\.json/);
+	const version = versionMatchResult ? versionMatchResult[1] : null;
+
         if(!version) return;
    
         const filePath = path.join(this.path, `${version}.html`);


### PR DESCRIPTION
This commit addresses a bug in the LocalWebCache.persist method where accessing a null match result could throw a TypeError. It introduces a null check before accessing the match array. This prevents runtime errors.
