### PR TITLE
Poll.js update for pollOptions

### DIFF
--- a/src/structures/Poll.js
+++ b/src/structures/Poll.js
@@ -26,7 +26,7 @@ class Poll {
          * @type {Array.<{name: string, localId: number}>}
          */
         this.pollOptions = pollOptions.map((option, index) => ({
-            name: option.trim(),
+            name: option.name.trim(),
             localId: index
         }));
 


### PR DESCRIPTION
# PR Details
<!--- Provide a general summary of your changes in the Title above -->
Update `Poll.js` to `pollOptions` when using `map()`.

## Description
<!--- Describe your changes in detail -->
The 'option' parameter is the array element object and cannot perform `trim()`. To do this, simply access the 'name' attribute, which is a string and contains the name of the poll option. An alternative solution could also use destructuring the parameters.

## Motivation and Context
<!--- Optional --->
<!--- Why is this change required? What problem does it solve? -->
When executing the following code snippet, the following error occurred:
```js
const qrcode = require('qrcode-terminal');

const { Client, LocalAuth, MessageMedia } = require('whatsapp-web.js');

const { Buttons, Poll } = require('whatsapp-web.js')

const wwebVersion = '2.2407.3';

const client = new Client({
    authStrategy: new LocalAuth(),
    webVersionCache: {
      type: 'remote',
      remotePath: `https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/${wwebVersion}.html`,
  }
});

client.on('ready', () => {
    console.log('Client is ready!');
});

client.on('qr', qr => {
    qrcode.generate(qr, {small: true});
});

client.on('message_create', async message => {
	if (message.body === 'Teste') {
        const poll = new Poll('consulta',[
            { name: 'SIM' },
            { name: 'NAO' }
        ])
        await client.sendMessage(message.from, poll)
	}
});

client.initialize();
```

```
/home/lucas/Documentos/Laboratórios/chatbot/node_modules/whatsapp-web.js/src/structures/Poll.js:29
            name: option.trim(),
                         ^

TypeError: option.trim is not a function
    at /home/lucas/Documentos/Laboratórios/chatbot/node_modules/whatsapp-web.js/src/structures/Poll.js:29:26
    at Array.map (<anonymous>)
    at new Poll (/home/lucas/Documentos/Laboratórios/chatbot/node_modules/whatsapp-web.js/src/structures/Poll.js:28:40)
    at Client.<anonymous> (/home/lucas/Documentos/Laboratórios/chatbot/index.js:58:22)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v21.6.1
```

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
I went to check how the Poll class was set up for pollOptions and realized that the option parameter refers to the array object and not a string, which is why trim() was causing this error.
<!--- Include details of your testing environment, and the tests you ran to -->
Below is some information about the environment and the machine used.
- OS: Debian GNU/Linux 12 (bookworm)
- Kernel release: 6.1.0-17-amd64
- Kernel vesion: # 1 SMP PREEMPT_DYNAMIC Debian 6.1.69-1 (2023-12-30) x86_64 GNU/Linux
- Machine: Dell Inspiron 3501
- CPU: Intel(R) Core(TM) i3-1005G1 CPU @ 1.20GHz
- Node version: Node.js v21.6.1
- NPM version: 10.4.0
- NVM version: 0.39.7

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).