### PR TITLE
Fix bug with the localwebcache persist method

### DIFF
--- a/src/webCache/LocalWebCache.js
+++ b/src/webCache/LocalWebCache.js
@@ -31,7 +31,7 @@ class LocalWebCache extends WebCache {
 
     async persist(indexHtml) {
         // extract version from index (e.g. manifest-2.2206.9.json -> 2.2206.9)
-        const version = indexHtml.match(/manifest-([\d\\.]+)\.json/)[1];
+        const version = indexHtml.match(/manifest-([\d\\.]+)\.json/)?.[1];
         if(!version) return;
    
         const filePath = path.join(this.path, `${version}.html`);


### PR DESCRIPTION
# PR Details

Fix `cannot read property of null error`

## Description

```
TypeError: Cannot read properties of null (reading '1')
    at LocalWebCache.persist (/.../node_modules/whatsapp-web.js/src/webCache/LocalWebCache.js:34:69)
```

## How Has This Been Tested

The simple example in the readme was able to run after this change

## Types of changes

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



