### PR TITLE
Fix window.Store.ProfilePic.profilePicFind is not a function error

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1209,7 +1209,7 @@ class Client extends EventEmitter {
         const profilePic = await this.pupPage.evaluate(async contactId => {
             try {
                 const chatWid = window.Store.WidFactory.createWid(contactId);
-                return await window.Store.ProfilePic.profilePicFind(chatWid);
+                return await window.Store.ProfilePic.requestProfilePicFromServer(chatWid);
             } catch (err) {
                 if(err.name === 'ServerStatusCodeError') return undefined;
                 throw err;

--- a/src/Client.js
+++ b/src/Client.js
@@ -1209,7 +1209,7 @@ class Client extends EventEmitter {
         const profilePic = await this.pupPage.evaluate(async contactId => {
             try {
                 const chatWid = window.Store.WidFactory.createWid(contactId);
-                return await window.Store.ProfilePic.requestProfilePicFromServer(chatWid);
+                return await (window.WWebJS.compareWwebVersions(window.Debug.VERSION, '<', '2.3000.0') ? window.Store.ProfilePic.profilePicFind(chatWid) : window.Store.ProfilePic.requestProfilePicFromServer(chatWid));
             } catch (err) {
                 if(err.name === 'ServerStatusCodeError') return undefined;
                 throw err;

--- a/src/Client.js
+++ b/src/Client.js
@@ -1209,7 +1209,9 @@ class Client extends EventEmitter {
         const profilePic = await this.pupPage.evaluate(async contactId => {
             try {
                 const chatWid = window.Store.WidFactory.createWid(contactId);
-                return await (window.WWebJS.compareWwebVersions(window.Debug.VERSION, '<', '2.3000.0') ? window.Store.ProfilePic.profilePicFind(chatWid) : window.Store.ProfilePic.requestProfilePicFromServer(chatWid));
+                return window.WWebJS.compareWwebVersions(window.Debug.VERSION, '<', '2.3000.0')
+                    ? await window.Store.ProfilePic.profilePicFind(chatWid)
+                    : await window.Store.ProfilePic.requestProfilePicFromServer(chatWid);
             } catch (err) {
                 if(err.name === 'ServerStatusCodeError') return undefined;
                 throw err;


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

Replace `window.Store.ProfilePic.profilePicFind` with `window.Store.ProfilePic.requestProfilePicFromServer`

## Description

<!--- Describe your changes in detail -->

The function

`window.Store.ProfilePic.profilePicFind`

is no longer available in v2.3x, and is replaced with

`window.Store.ProfilePic.requestProfilePicFromServer`

![image](https://github.com/pedroslopez/whatsapp-web.js/assets/56989187/403096e1-2ea8-4f6c-b75e-780f1da2d3ae)

## Related Issue

closes #3005

<!--- Optional --->
<!--- If there is an issue link it here: -->

## Motivation and Context

<!--- Optional --->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



