### PR TITLE
Implement bot invoking capabilities

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1073,6 +1073,8 @@ declare namespace WAWebJS {
         }[]
         /** Send 'seen' status */
         sendSeen?: boolean
+        /** Bot Wid when doing a bot mention like @Meta AI */
+        invokedBotWid?: string
         /** Media to be sent */
         media?: MessageMedia
         /** Extra options */

--- a/src/Client.js
+++ b/src/Client.js
@@ -826,6 +826,7 @@ class Client extends EventEmitter {
      * @property {GroupMention[]} [groupMentions] - An array of object that handle group mentions
      * @property {string[]} [mentions] - User IDs to mention in the message
      * @property {boolean} [sendSeen=true] - Mark the conversation as seen after sending the message
+     * @property {string} [invokedBotWid=undefined] - Bot Wid when doing a bot mention like @Meta AI
      * @property {string} [stickerAuthor=undefined] - Sets the author of the sticker, (if sendMediaAsSticker is true).
      * @property {string} [stickerName=undefined] - Sets the name of the sticker, (if sendMediaAsSticker is true).
      * @property {string[]} [stickerCategories=undefined] - Sets the categories of the sticker, (if sendMediaAsSticker is true). Provide emoji char array, can be null.
@@ -862,6 +863,7 @@ class Client extends EventEmitter {
             parseVCards: options.parseVCards === false ? false : true,
             mentionedJidList: options.mentions || [],
             groupMentions: options.groupMentions,
+            invokedBotWid: options.invokedBotWid,
             extraOptions: options.extra
         };
 

--- a/src/util/Injected/Store.js
+++ b/src/util/Injected/Store.js
@@ -53,6 +53,8 @@ exports.ExposeStore = () => {
     window.Store.QueryExist = window.require('WAWebQueryExistsJob').queryWidExists;
     window.Store.ReplyUtils = window.require('WAWebMsgReply');
     window.Store.Settings = window.require('WAWebUserPrefsGeneral');
+    window.Store.BotSecret = window.require("WAWebBotMessageSecret");
+    window.Store.BotProfiles = window.require("WAWebBotProfileCollection");
     
     window.Store.ForwardUtils = {
         ...window.require("WAWebForwardMessagesToChat")

--- a/src/util/Injected/Store.js
+++ b/src/util/Injected/Store.js
@@ -53,11 +53,11 @@ exports.ExposeStore = () => {
     window.Store.QueryExist = window.require('WAWebQueryExistsJob').queryWidExists;
     window.Store.ReplyUtils = window.require('WAWebMsgReply');
     window.Store.Settings = window.require('WAWebUserPrefsGeneral');
-    window.Store.BotSecret = window.require("WAWebBotMessageSecret");
-    window.Store.BotProfiles = window.require("WAWebBotProfileCollection");
+    window.Store.BotSecret = window.require('WAWebBotMessageSecret');
+    window.Store.BotProfiles = window.require('WAWebBotProfileCollection');
     
     window.Store.ForwardUtils = {
-        ...window.require("WAWebForwardMessagesToChat")
+        ...window.require('WAWebForwardMessagesToChat')
     };
 
     window.Store.StickerTools = {


### PR DESCRIPTION
# PR Details

Allows Meta AI and bot mentions to work with +1 numbers.

## Description

This patch allows to call WhatsApp bots by mentioning them.

You can find all bot wid's by using my pastebin: https://pastebin.com/raw/z9AidmRF

Or by running this at whatsapp web console:

```
bots = ''
window.require("WAWebBotProfileCollection").BotProfileCollection._models.forEach(b => bots += b.__x_name + ` - ` +  b.__x_description + ` ` + b.__x_id._serialized + '\n')
console.log(bots)
```

## Motivation and Context

I wanted to create a proxy for people who don't have access to @Meta AI bots.
Someone outside from US can use my bot to call the @Meta AI.

## How Has This Been Tested

```bash
npm install --save "git://github.com/MatMercer/whatsapp-web.js.git#bot-invoke-patch"
```

```js
const botId = '13135550002@c.us';
const text = `@${botId} Hello there!`;
const opt = { mentions: [botId], invokedBotWid: botId };
await chat.sendMessage(text, opt);
```

![image](https://github.com/pedroslopez/whatsapp-web.js/assets/14908759/875d98cc-f61b-4383-a3c6-5ca1710c4afd)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).

