### PR TITLE
fix getInviteCode for group (#3007)

### DIFF
--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -359,7 +359,11 @@ class GroupChat extends Chat {
     async getInviteCode() {
         const codeRes = await this.client.pupPage.evaluate(async chatId => {
             const chatWid = window.Store.WidFactory.createWid(chatId);
-            return window.Store.GroupInvite.queryGroupInviteCode(chatWid);
+            if(window.WWebJS.compareWwebVersions(window.Debug.VERSION, '>', '2.3000.0')){
+                return window.Store.GroupInvite.queryGroupInviteCode(chatWid, true);
+            } else {
+                return window.Store.GroupInvite.queryGroupInviteCode(chatWid);
+            }
         }, this.id._serialized);
 
         return codeRes.code;
@@ -372,12 +376,7 @@ class GroupChat extends Chat {
     async revokeInvite() {
         const codeRes = await this.client.pupPage.evaluate(chatId => {
             const chatWid = window.Store.WidFactory.createWid(chatId);
-            
-            if(window.WWebJS.compareWwebVersions(window.Debug.VERSION, '>', '2.3000.0')){
-                return window.Store.GroupInvite.queryGroupInviteCode(chatWid, true); 
-            } else {
-                return window.Store.GroupInvite.queryGroupInviteCode(chatWid);  
-            } 
+            return window.Store.GroupInvite.resetGroupInviteCode(chatWid); 
         }, this.id._serialized);
 
         return codeRes.code;

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -359,14 +359,18 @@ class GroupChat extends Chat {
     async getInviteCode() {
         const codeRes = await this.client.pupPage.evaluate(async chatId => {
             const chatWid = window.Store.WidFactory.createWid(chatId);
-            if(window.WWebJS.compareWwebVersions(window.Debug.VERSION, '>', '2.3000.0')){
-                return window.Store.GroupInvite.queryGroupInviteCode(chatWid, true);
-            } else {
-                return window.Store.GroupInvite.queryGroupInviteCode(chatWid);
+            try {
+                return window.WWebJS.compareWwebVersions(window.Debug.VERSION, '>=', '2.3000.0')
+                    ? window.Store.GroupInvite.queryGroupInviteCode(chatWid, true)
+                    : window.Store.GroupInvite.queryGroupInviteCode(chatWid);
+            }
+            catch (err) {
+                if(err.name === 'ServerStatusCodeError') return undefined;
+                throw err;
             }
         }, this.id._serialized);
 
-        return codeRes.code;
+        return codeRes?.code;
     }
     
     /**

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -372,7 +372,12 @@ class GroupChat extends Chat {
     async revokeInvite() {
         const codeRes = await this.client.pupPage.evaluate(chatId => {
             const chatWid = window.Store.WidFactory.createWid(chatId);
-            return window.Store.GroupInvite.resetGroupInviteCode(chatWid);
+            
+            if(window.WWebJS.compareWwebVersions(window.Debug.VERSION, '>', '2.3000.0')){
+                return window.Store.GroupInvite.queryGroupInviteCode(chatWid, true); 
+            } else {
+                return window.Store.GroupInvite.queryGroupInviteCode(chatWid);  
+            } 
         }, this.id._serialized);
 
         return codeRes.code;

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -376,7 +376,7 @@ class GroupChat extends Chat {
     async revokeInvite() {
         const codeRes = await this.client.pupPage.evaluate(chatId => {
             const chatWid = window.Store.WidFactory.createWid(chatId);
-            return window.Store.GroupInvite.resetGroupInviteCode(chatWid); 
+            return window.Store.GroupInvite.resetGroupInviteCode(chatWid);
         }, this.id._serialized);
 
         return codeRes.code;

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -361,8 +361,8 @@ class GroupChat extends Chat {
             const chatWid = window.Store.WidFactory.createWid(chatId);
             try {
                 return window.WWebJS.compareWwebVersions(window.Debug.VERSION, '>=', '2.3000.0')
-                    ? window.Store.GroupInvite.queryGroupInviteCode(chatWid, true)
-                    : window.Store.GroupInvite.queryGroupInviteCode(chatWid);
+                    ? await window.Store.GroupInvite.queryGroupInviteCode(chatWid, true)
+                    : await window.Store.GroupInvite.queryGroupInviteCode(chatWid);
             }
             catch (err) {
                 if(err.name === 'ServerStatusCodeError') return undefined;


### PR DESCRIPTION
# PR Details

Fixes #3007 due to new method definition in 2.3xxxx. Now requires second parameter to be true (c)

Is compatible to 2.24xx
 
## Description

fix getGroupInvite by adapting 

## Related Issue

#3007 

## Motivation and Context

fix issue. 

## How Has This Been Tested

tested on Version 2.3000.1013455223 and 2.2413.51. Simply by requesting a  invite code and on both.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



