### PR TITLE
fix: fixing function naming

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1250,7 +1250,7 @@ class Client extends EventEmitter {
         const profilePic = await this.pupPage.evaluate(async contactId => {
             try {
                 const chatWid = window.Store.WidFactory.createWid(contactId);
-                return await window.Store.ProfilePic.profilePicFind(chatWid);
+                return await window.Store.ProfilePic.requestProfilePicFromServer(chatWid);
             } catch (err) {
                 if(err.name === 'ServerStatusCodeError') return undefined;
                 throw err;


### PR DESCRIPTION
# PR Details
## Description

This PR is intending to fix an issue regarding the feature of getting the profile pic url for a given contact. The function `window.Store.ProfilePic.profilePicFind` changed it's name to `window.Store.ProfilePic.requestProfilePicFromServer`. It's signature have not changed so the naming was the only change needed to fix this problem.

## Motivation and Context

Calling this function was breaking the app because the actual function had it's name changed.

## How Has This Been Tested

I've tried to use the function and it worked as intended.

## Types of changes

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts). // Not needed



