### PR TITLE
fix delete on 2.3000

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -510,7 +510,11 @@ class Message extends Base {
             
             const canRevoke = window.Store.MsgActionChecks.canSenderRevokeMsg(msg) || window.Store.MsgActionChecks.canAdminRevokeMsg(msg);
             if (everyone && canRevoke) {
-                return window.Store.Cmd.sendRevokeMsgs(chat, [msg], { clearMedia: true, type: msg.id.fromMe ? 'Sender' : 'Admin' });
+                if (window.Debug.VERSION > 23000) {
+                    return window.Store.Cmd.sendRevokeMsgs(chat, { list: [msg], type: 'message' }, { clearMedia: true });
+                } else {
+                    return window.Store.Cmd.sendRevokeMsgs(chat, [msg], { clearMedia: true, type: msg.id.fromMe ? 'Sender' : 'Admin' });
+                }
             }
 
             return window.Store.Cmd.sendDeleteMsgs(chat, [msg], true);

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -510,7 +510,7 @@ class Message extends Base {
             
             const canRevoke = window.Store.MsgActionChecks.canSenderRevokeMsg(msg) || window.Store.MsgActionChecks.canAdminRevokeMsg(msg);
             if (everyone && canRevoke) {
-                if (window.Debug.VERSION > 23000) {
+                if (window.WWebJS.compareWwebVersions(window.Debug.VERSION, '>', '2.3000.0')) {
                     return window.Store.Cmd.sendRevokeMsgs(chat, { list: [msg], type: 'message' }, { clearMedia: true });
                 } else {
                     return window.Store.Cmd.sendRevokeMsgs(chat, [msg], { clearMedia: true, type: msg.id.fromMe ? 'Sender' : 'Admin' });

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -510,7 +510,7 @@ class Message extends Base {
             
             const canRevoke = window.Store.MsgActionChecks.canSenderRevokeMsg(msg) || window.Store.MsgActionChecks.canAdminRevokeMsg(msg);
             if (everyone && canRevoke) {
-                if (window.WWebJS.compareWwebVersions(window.Debug.VERSION, '>', '2.3000.0')) {
+                if (window.WWebJS.compareWwebVersions(window.Debug.VERSION, '>=', '2.3000.0')) {
                     return window.Store.Cmd.sendRevokeMsgs(chat, { list: [msg], type: 'message' }, { clearMedia: true });
                 } else {
                     return window.Store.Cmd.sendRevokeMsgs(chat, [msg], { clearMedia: true, type: msg.id.fromMe ? 'Sender' : 'Admin' });


### PR DESCRIPTION
# PR Details

This is a fix for message delete on 2.3000.x

## Description

The expected object to delete a msg has changed. 

## Related Issue

https://github.com/pedroslopez/whatsapp-web.js/issues/3047

## How Has This Been Tested

Tested on my bot. seanesbo on Discord also agreed it works.
Did not test on < 2.3000.x

## Types of changes

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).



