### PR TITLE
Update LocalWebCache.js

### DIFF
--- a/src/webCache/LocalWebCache.js
+++ b/src/webCache/LocalWebCache.js
@@ -28,15 +28,19 @@ class LocalWebCache extends WebCache {
             return null;
         }
     }
-
+    
     async persist(indexHtml) {
-        // extract version from index (e.g. manifest-2.2206.9.json -> 2.2206.9)
-        const version = indexHtml.match(/manifest-([\d\\.]+)\.json/)[1];
-        if(!version) return;
-   
-        const filePath = path.join(this.path, `${version}.html`);
-        fs.mkdirSync(this.path, { recursive: true });
-        fs.writeFileSync(filePath, indexHtml);
+      // extract version from index (e.g. manifest-2.2206.9.json -> 2.2206.9)
+      const match = indexHtml.match(/manifest-([\d\\.]+)\.json/);
+      if (!match || !match[1]) {
+        console.error("Failed to extract version from indexHtml");
+        return;
+      }
+      const version = match[1];
+
+      const filePath = path.join(this.path, `${version}.html`);
+      fs.mkdirSync(this.path, { recursive: true });
+      fs.writeFileSync(filePath, indexHtml);
     }
 }
 


### PR DESCRIPTION
Fixed bug 

/whatsapp-web.js/src/webCache/LocalWebCache.js:34
        const version = indexHtml.match(/manifest-([\d\\.]+)\.json/)[1];
                                                                    ^

TypeError: Cannot read properties of null (reading '1')

# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- Optional --->
<!--- If there is an issue link it here: -->

## Motivation and Context

<!--- Optional --->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



