### PR TITLE
fix: regex to extract version (LocalAuth)

### DIFF
--- a/src/webCache/LocalWebCache.js
+++ b/src/webCache/LocalWebCache.js
@@ -31,7 +31,7 @@ class LocalWebCache extends WebCache {
 
     async persist(indexHtml) {
         // extract version from index (e.g. manifest-2.2206.9.json -> 2.2206.9)
-        const version = indexHtml.match(/manifest-([\d\\.]+)\.json/)[1];
+        const version = indexHtml.match(/manifest-([\d\\.]+)\.json/)?.[1];
         if(!version) return;
    
         const filePath = path.join(this.path, `${version}.html`);


### PR DESCRIPTION
# PR Details

- Actual localAuth contains error, regex return null and this may crash app.

## Description

Actually i'm using node 18 and typescript.
When execute a simple inicialize script provided on officially docs web this crashed.

Script: 
![image](https://github.com/pedroslopez/whatsapp-web.js/assets/47331594/0b6c8f0c-2623-4be0-b871-2bcc591cd90a)

Error:
![image](https://github.com/pedroslopez/whatsapp-web.js/assets/47331594/f4457009-a419-4798-a0f4-3bd9d2674fba)

