### PR TITLE
Update LocalWebCache.js

### DIFF
--- a/src/webCache/LocalWebCache.js
+++ b/src/webCache/LocalWebCache.js
@@ -31,7 +31,8 @@ class LocalWebCache extends WebCache {
 
     async persist(indexHtml) {
         // extract version from index (e.g. manifest-2.2206.9.json -> 2.2206.9)
-        const version = indexHtml.match(/manifest-([\d\\.]+)\.json/)[1];
+        const matchResult = indexHtml.match(/manifest-([\d\\.]+)\.json/);
+        const version = matchResult ? matchResult[1] : null;
         if(!version) return;
    
         const filePath = path.join(this.path, `${version}.html`);


### PR DESCRIPTION
# PR Details

Evitar error en caso de datos nulos 

## Description
Puede dar un error "TypeError: Cannot read properties of null (reading '1')" en LocalWebCache.js que indica que la función indexHtml.match() está devolviendo null en lugar de un array de coincidencias. 

Esto sucede porque la expresión regular /manifest-([\d\\.]+)\.json/ no encuentra ninguna coincidencia en el contenido de indexHtml.


