### PR TITLE
Webpack exodus fix reaction private chats

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -718,7 +718,8 @@ class Client extends EventEmitter {
                         const msgKey = reaction.id;
                         const parentMsgKey = reaction.reactionParentKey;
                         const timestamp = reaction.reactionTimestamp / 1000;
-                        const senderUserJid = reaction.author._serialized;
+                        const sender = reaction.author ?? reaction.from;
+                        const senderUserJid = sender._serialized;
 
                         return {...reaction, msgKey, parentMsgKey, senderUserJid, timestamp };
                     }));


### PR DESCRIPTION
# PR Details

This PR fixes message_reaction event on WWeb >= 2.3000.1014111620 on private chats.

## Description

WWeb 2.3000.1014111620 uses a different objects when objects on group chats and private chats.

## Related Issue
https://github.com/pedroslopez/whatsapp-web.js/issues/3063

## Types of changes

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



