### PR TITLE
Error to send audio and video whatsapp version 2.3000x

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "mime": "^3.0.0",
     "node-fetch": "^2.6.9",
     "node-webpmux": "3.1.7",
-    "puppeteer": "^18.2.1"
+    "puppeteer": "22.12.1"
   },
   "devDependencies": {
     "@types/node-fetch": "^2.5.12",


### PR DESCRIPTION

# PR Details

## Description

Updated the Puppeteer library to resolve issues with sending audio and video on WhatsApp version 2.30000x. The previous version of the library did not allow proper sending of these media types. After the update, sending audio and video started working normally.

## Related Issue

## Motivation and Context

This change is necessary to fix the issue of sending audio and video on WhatsApp version 2.30000x. The Puppeteer library update resolved the problem, allowing these media types to be sent correctly.

## How Has This Been Tested

The update was tested in the development environment by verifying the sending of audio and video. Manual tests were conducted to ensure that both media types were sent successfully without errors.

## Types of changes

- [x] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).
