### PR TITLE
fix: Updated params structure in createGroup function

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1399,10 +1399,12 @@ class Client extends EventEmitter {
 
             try {
                 createGroupResult = await window.Store.GroupUtils.createGroup(
-                    title,
+                    {
+                        title,
+                        messageTimer,
+                        parentGroupWid
+                    },
                     participantWids,
-                    messageTimer,
-                    parentGroupWid
                 );
             } catch (err) {
                 return 'CreateGroupError: An unknown error occupied while creating a group';


### PR DESCRIPTION
# PR Details

In a recent update of WA Web,  the params structure of createGroup was modified to an object. As a result, the createGroup function was failing.

this patch fixes that

## Description

```
createGroupResult = await window.Store.GroupUtils.createGroup(
                    title,
                    participantWids,
                    messageTimer,
                    parentGroupWid
                );
```

was modified to

```
createGroupResult = await window.Store.GroupUtils.createGroup(
                    {title, parentGroupId, messageTimer},
                    participantWids,
                );
```

## Related Issue

No issue raised so far

## Motivation and Context



## How Has This Been Tested

Tested in my local environment
- WA version: 2.3000.x
- OS: Windows
- Browser: Chrome

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).



