### PR TITLE
Fix remote auth unzip on nodejs > 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
   "optionalDependencies": {
     "archiver": "^5.3.1",
     "fs-extra": "^10.1.0",
-    "unzipper": "^0.10.11"
+    "unzipper": "^0.12.2"
   }
 }


### PR DESCRIPTION
# PR Details

This PR fixes an error when restoring the session in the remote authentication method when using nodejs in version > 16

## Description

Error details:

ProtocolError: Protocol error (Runtime.callFunctionOn): Execution context was destroyed.

## Related Issue

#3181 #2530 #2452 #1681 #2038 

## Motivation and Context

When using nodejs in versions higher than 16, in the remote authentication method the session is not restored.

## How Has This Been Tested

Tested on node versions > 16 on Ubuntu and Windows

## Types of changes

- [x] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



