### PR TITLE
Fix vote_update event

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = {
     ClientInfo: require('./src/structures/ClientInfo'),
     Location: require('./src/structures/Location'),
     Poll: require('./src/structures/Poll'),
+    PollVote: require('./src/structures/PollVote'),
     ProductMetadata: require('./src/structures/ProductMetadata'),
     List: require('./src/structures/List'),
     Buttons: require('./src/structures/Buttons'),

--- a/src/Client.js
+++ b/src/Client.js
@@ -920,6 +920,9 @@ class Client extends EventEmitter {
         } else if (content instanceof Poll) {
             internalOptions.poll = content;
             content = '';
+            setTimeout(async () => {
+                await this.interface.openChatWindow(chatId);
+            }, 3000);
         } else if (content instanceof Contact) {
             internalOptions.contactCard = content.id._serialized;
             content = '';
@@ -957,7 +960,7 @@ class Client extends EventEmitter {
             const msg = await window.WWebJS.sendMessage(chat, message, options, sendSeen);
             return window.WWebJS.getMessageModel(msg);
         }, chatId, content, internalOptions, sendSeen);
-
+        
         return new Message(this, newMessage);
     }
     

--- a/src/structures/PollVote.js
+++ b/src/structures/PollVote.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const Message = require('./Message');
+const Base = require('./Base');
+
+/**
+ * Selected poll option structure
+ * @typedef {Object} SelectedPollOption
+ * @property {number} id The local selected or deselected option ID
+ * @property {string} name The option name
+ */
+
+/**
+ * Represents a Poll Vote on WhatsApp
+ * @extends {Base}
+ */
+class PollVote extends Base {
+    constructor(client, data) {
+        super(client);
+
+        if (data) this._patch(data);
+    }
+
+    _patch(data) {
+        /**
+         * The person who voted
+         * @type {string}
+         */
+        this.voter = data.sender;
+
+        /**
+         * The selected poll option(s)
+         * If it's an empty array, the user hasn't selected any options on the poll,
+         * may occur when they deselected all poll options
+         * @type {SelectedPollOption[]}
+         */
+        this.selectedOptions =
+            data.selectedOptionLocalIds.length > 0
+                ? data.selectedOptionLocalIds.map((e) => ({
+                    name: data.parentMessage.pollOptions.find((x) => x.localId === e).name,
+                    localId: e
+                }))
+                : [];
+
+        /**
+         * Timestamp the option was selected or deselected at
+         * @type {number}
+         */
+        this.interractedAtTs = data.senderTimestampMs;
+
+        /**
+         * The poll creation message associated with the poll vote
+         * @type {Message}
+         */
+        this.parentMessage = new Message(this.client, data.parentMessage);
+
+        return super._patch(data);
+    }
+}
+
+module.exports = PollVote;

--- a/src/structures/index.js
+++ b/src/structures/index.js
@@ -20,4 +20,5 @@ module.exports = {
     Payment: require('./Payment'),
     Reaction: require('./Reaction'),
     Poll: require('./Poll'),
+    PollVote: require('./PollVote'),
 };

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -65,7 +65,8 @@ exports.Events = {
     STATE_CHANGED: 'change_state',
     BATTERY_CHANGED: 'change_battery',
     INCOMING_CALL: 'call',
-    REMOTE_SESSION_SAVED: 'remote_session_saved'
+    REMOTE_SESSION_SAVED: 'remote_session_saved',
+    VOTE_UPDATE: 'vote_update',
 };
 
 /**

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -433,6 +433,15 @@ exports.LoadUtils = () => {
         return msg;
     };
 
+    window.WWebJS.getPollVoteModel = (vote) => {
+        const _vote = vote.serialize();
+        if (vote.parentMsgKey) {
+            const msg = window.Store.Msg.get(vote.parentMsgKey);
+            msg && (_vote.parentMessage = window.WWebJS.getMessageModel(msg));
+            return _vote;
+        }
+        return null;
+    };
 
     window.WWebJS.getChatModel = async chat => {
 


### PR DESCRIPTION
# PR Details

Fixing poll_update event to work in webpack-exodus

## Description

Fixing poll_update event to work in webpack-exodus

## Related Issue

## Motivation and Context

## How Has This Been Tested

**SENDING THE POLL**
```
const poll = new Poll('Which pet do you prefer?', ['Cat', 'Dog']);
const msgPoll = await client.sendMessage(chatId, poll);
```

**LISTENING THE EVENT**
```
client.on('vote_update', (vote) => {
      console.log(vote);
});
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).
