### PR TITLE
Fix version extraction in LocalWebCache.js to handle null match

### DIFF
--- a/src/webCache/LocalWebCache.js
+++ b/src/webCache/LocalWebCache.js
@@ -6,7 +6,7 @@ const { WebCache, VersionResolveError } = require('./WebCache');
 /**
  * LocalWebCache - Fetches a WhatsApp Web version from a local file store
  * @param {object} options - options
- * @param {string} options.path - Path to the directory where cached versions are saved, default is: "./.wwebjs_cache/" 
+ * @param {string} options.path - Path to the directory where cached versions are saved, default is: "./.wwebjs_cache/"
  * @param {boolean} options.strict - If true, will throw an error if the requested version can't be fetched. If false, will resolve to the latest version.
  */
 class LocalWebCache extends WebCache {
@@ -19,7 +19,7 @@ class LocalWebCache extends WebCache {
 
     async resolve(version) {
         const filePath = path.join(this.path, `${version}.html`);
-        
+
         try {
             return fs.readFileSync(filePath, 'utf-8');
         }
@@ -29,13 +29,28 @@ class LocalWebCache extends WebCache {
         }
     }
 
+    /**
+     * Save the HTML content and its version information.
+     * 
+     * @param {string} indexHtml - The HTML content to be saved.
+     */
     async persist(indexHtml) {
-        // extract version from index (e.g. manifest-2.2206.9.json -> 2.2206.9)
-        const version = indexHtml.match(/manifest-([\d\\.]+)\.json/)[1];
-        if(!version) return;
-   
+        // Use a regular expression to find the version in the manifest file name
+        const match = indexHtml.match(/manifest-([\d\\.]+)\.json/);
+
+        // If the version is found, extract it from the match result
+        const version = match ? match[1] : null;
+
+        // If no version is found, exit the function
+        if (!version) return;
+
+        // Create the file path for saving the HTML content
         const filePath = path.join(this.path, `${version}.html`);
+
+        // Ensure the directory exists, create it if necessary
         fs.mkdirSync(this.path, { recursive: true });
+
+        // Write the HTML content to the file
         fs.writeFileSync(filePath, indexHtml);
     }
 }


### PR DESCRIPTION
This pull request addresses an issue where the version extraction in LocalWebCache.js can throw an error if the regex match returns null. This fix ensures that the code safely handles null matches, preventing a TypeError.

# PR Details

## Description

This change updates the version extraction logic in the `persist` method to safely handle cases where the regex match returns null. This prevents the TypeError caused by trying to access properties of null.

## Related Issue

<!--- Optional --->
<!--- If there is an issue link it here: -->

## Motivation and Context

This change is required to make the version extraction process more robust and to prevent crashes when the manifest version is not found in the index.html.

## How Has This Been Tested

This change has been tested by running the modified code and ensuring that it handles cases where the version is not found in the index.html without throwing errors.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
