### PR TITLE
fix getMessageById exception handling

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1034,7 +1034,7 @@ class Client extends EventEmitter {
             if(msg) return window.WWebJS.getMessageModel(msg);
 
             const params = messageId.split('_');
-            if(params.length !== 3) throw new Error('Invalid serialized message id specified');
+            if(params.length !== 3 && params.length == !4) throw new Error('Invalid serialized message id specified');
 
             let messagesObject = await window.Store.Msg.getMessagesById([messageId]);
             if (messagesObject && messagesObject.messages.length) msg = messagesObject.messages[0];


### PR DESCRIPTION
# PR Details

Updates client.js to handle Group Messages with invalid wids.

## Description

GetMessageBy id throws an error when the number of parameters of the message ID after splitting  it's "_" it's different from 3. Example: fromMe_sender@c.us_messageId.  
However, group messages have 4 parameters, so it throws an exception when it receives it: 
Example: fromMe_idGroup@g.us_messageId_sender@c.us .
So i fixed it in order to allow 4 parameters without throwing the error.

## Types of changes

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts)
