### PR TITLE
Add warning for outdated 2.x cache versions

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -764,6 +764,9 @@ class Client extends EventEmitter {
         const webCache = WebCacheFactory.createWebCache(webCacheType, webCacheOptions);
 
         const requestedVersion = this.options.webVersion;
+if (requestedVersion && requestedVersion.startsWith("2.")){
+    console.log(`[Warning] You are trying to use an outdated web.whatsapp version (${requestedVersion}). Only versions >3.0 are supported now. Consider removing webcache & webVersionCache from client creation.`)
+}
         const versionContent = await webCache.resolve(requestedVersion);
 
         if(versionContent) {


### PR DESCRIPTION
# PR Details

Just warn users trying to use outdated cache versions. Many new users get stuck and we get a spam of help requests on the discord that could be solved by a simple warning

## Description

Just log a [warning] line when detect any 2.x version

## Motivation and Context

Dozens of help requests spam in discord

## How Has This Been Tested

Warning works, tested locally with:
```env
CACHED_WAWEB_VERSION_TO_USE=2.2410.1
CACHE_TYPE=remote
REMOTE_PATH= https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/2.2410.1.html
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).



