### PR TITLE
fix: TypeError in Group Invite Handling Due to in Operator on Strings

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -182,8 +182,8 @@ class Message extends Base {
             inviteCodeExp: data.inviteCodeExp,
             groupId: data.inviteGrp,
             groupName: data.inviteGrpName,
-            fromId: '_serialized' in data.from ? data.from._serialized : data.from,
-            toId: '_serialized' in data.to ? data.to._serialized : data.to
+            fromId: typeof data.from === 'object' && '_serialized' in data.from ? data.from._serialized : data.from,
+            toId: typeof data.to === 'object' && '_serialized' in data.to ? data.to._serialized : data.to
         } : undefined;
 
         /**


### PR DESCRIPTION
## Description

This PR addresses an issue that occurs when the `group.addParticipants` method is called with `autoSendInviteV4` set to `true`. Specifically, the error **"Page error: Error: TypeError: Cannot use 'in' operator to search for '_serialized' in {number}@c.us"** arises when calling this method. The root cause is that the code attempts to use the in operator on a string, which is not allowed in JavaScript.

#### Usage code example
```ts
const result = await group.addParticipants(participantIds, {
    autoSendInviteV4: true,
    comment: inviteMessage
});
```

The code above led to the following error at the `pupPage` 'pageerror' error handler:
```
Page error: Error: TypeError: Cannot use 'in' operator to search for '_serialized' in {number}@c.us
```

#### Solution
To resolve this issue, the code was modified to include a type check before using the in operator. This ensures that the operator is only applied to objects, preventing the error when participantIds are strings.

## Related Issue

N/A

## Motivation and Context

This change is required to prevent the TypeError that occurs when the in operator is used on strings. The error disrupts the flow of adding participants to a group, especially when autoSendInviteV4 is enabled. By fixing this bug, the library will handle both string and object types for participant IDs more robustly.

## How Has This Been Tested

The changes were tested by simulating the scenario where participantIds includes strings formatted as {number}@c.us. The updated logic successfully prevents the TypeError and allows participants to be added without issue. The test environment included both cases: participantIds as strings and as objects containing the _serialized property.

## Types of changes

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).



