### PR TITLE
fix: sendMessage with quoted message id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ typings/
 
 # local version cache
 .wwebjs_cache/
+
+# IDE's
+.idea
+.vscode

--- a/src/Client.js
+++ b/src/Client.js
@@ -720,8 +720,8 @@ class Client extends EventEmitter {
                 }
             });
             window.Store.Chat.on('change:unreadCount', (chat) => {window.onChatUnreadCountEvent(chat);});
-            window.Store.PollVote.on('add', (vote) => {
-                const pollVoteModel = window.WWebJS.getPollVoteModel(vote);
+            window.Store.PollVote.on('add', async (vote) => {
+                const pollVoteModel = await window.WWebJS.getPollVoteModel(vote);
                 pollVoteModel && window.onPollVoteEvent(pollVoteModel);
             });
 

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -44,7 +44,13 @@ exports.LoadUtils = () => {
         }
         let quotedMsgOptions = {};
         if (options.quotedMessageId) {
-            let quotedMessage = window.Store.Msg.get(options.quotedMessageId);
+            let quotedMessage = await window.Store.Msg.getMessagesById([options.quotedMessageId]);
+
+            if (quotedMessage['messages'].length != 1) {
+                throw new Error('Could not get the quoted message.');
+            }
+
+            quotedMessage = quotedMessage['messages'][0];
 
             // TODO remove .canReply() once all clients are updated to >= v2.2241.6
             const canReply = window.Store.ReplyUtils ? 

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -4,7 +4,7 @@ exports.LoadUtils = () => {
     window.WWebJS = {};
 
     window.WWebJS.forwardMessage = async (chatId, msgId) => {
-        let msg = window.Store.Msg.get(msgId);
+        const msg = window.Store.Msg.get(msgId) || (await window.Store.Msg.getMessagesById([msgId]))?.messages?.[0];
         let chat = window.Store.Chat.get(chatId);
 
         if (window.compareWwebVersions(window.Debug.VERSION, '>', '2.3000.0')) {
@@ -439,14 +439,13 @@ exports.LoadUtils = () => {
         return msg;
     };
 
-    window.WWebJS.getPollVoteModel = (vote) => {
+    window.WWebJS.getPollVoteModel = async (vote) => {
         const _vote = vote.serialize();
-        if (vote.parentMsgKey) {
-            const msg = window.Store.Msg.get(vote.parentMsgKey);
-            msg && (_vote.parentMessage = window.WWebJS.getMessageModel(msg));
-            return _vote;
-        }
-        return null;
+        if (!vote.parentMsgKey) return null;
+        const msg =
+            window.Store.Msg.get(msgId) || (await window.Store.Msg.getMessagesById([vote.parentMsgKey]))?.messages?.[0];
+        msg && (_vote.parentMessage = window.WWebJS.getMessageModel(msg));
+        return _vote;
     };
 
     window.WWebJS.getChatModel = async chat => {
@@ -464,7 +463,9 @@ exports.LoadUtils = () => {
         
         res.lastMessage = null;
         if (res.msgs && res.msgs.length) {
-            const lastMessage = chat.lastReceivedKey ? window.Store.Msg.get(chat.lastReceivedKey._serialized) : null;
+            const lastMessage = chat.lastReceivedKey
+                ? window.Store.Msg.get(chat.lastReceivedKey._serialized) || (await window.Store.Msg.getMessagesById([chat.lastReceivedKey._serialized]))?.messages?.[0]
+                : null;
             if (lastMessage) {
                 res.lastMessage = window.WWebJS.getMessageModel(lastMessage);
             }
@@ -1007,11 +1008,10 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.pinUnpinMsgAction = async (msgId, action, duration) => {
-        const message = window.Store.Msg.get(msgId);
+        const message = window.Store.Msg.get(msgId) || (await window.Store.Msg.getMessagesById([msgId]))?.messages?.[0];
         if (!message) return false;
         const response = await window.Store.pinUnpinMsg(message, action, duration);
-        if (response.messageSendResult === 'OK') return true;
-        return false;
+        return response.messageSendResult === 'OK';
     };
 
 };

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -443,7 +443,7 @@ exports.LoadUtils = () => {
         const _vote = vote.serialize();
         if (!vote.parentMsgKey) return null;
         const msg =
-            window.Store.Msg.get(msgId) || (await window.Store.Msg.getMessagesById([vote.parentMsgKey]))?.messages?.[0];
+            window.Store.Msg.get(vote.parentMsgKey) || (await window.Store.Msg.getMessagesById([vote.parentMsgKey]))?.messages?.[0];
         msg && (_vote.parentMessage = window.WWebJS.getMessageModel(msg));
         return _vote;
     };

--- a/src/util/InterfaceController.js
+++ b/src/util/InterfaceController.js
@@ -49,7 +49,7 @@ class InterfaceController {
      */
     async openChatWindowAt(msgId) {
         await this.pupPage.evaluate(async msgId => {
-            let msg = await window.Store.Msg.get(msgId);
+            const msg = window.Store.Msg.get(msgId) || (await window.Store.Msg.getMessagesById([msgId]))?.messages?.[0];
             let chat = await window.Store.Chat.find(msg.id.remote);
             let searchContext = await window.Store.SearchContext(chat,msg);
             await window.Store.Cmd.openChatAt(chat, searchContext);
@@ -62,7 +62,7 @@ class InterfaceController {
      */
     async openMessageDrawer(msgId) {
         await this.pupPage.evaluate(async msgId => {
-            let msg = await window.Store.Msg.get(msgId);
+            const msg = window.Store.Msg.get(msgId) || (await window.Store.Msg.getMessagesById([msgId]))?.messages?.[0];
             await window.Store.Cmd.msgInfoDrawer(msg);
         }, msgId);
     }


### PR DESCRIPTION
Now using `window.Store.Msg.getMessagesById` instead of `window.Store.Msg.get`

# PR Details
This PR fixes the exception that was thrown when using `client.sendMessage()` with a `quotedMessageId` in the `MessageSendOptions` parameter.

## Description
It seemed like `window.Store.get()` couldn't get a message, even with a valid serialized chat message id.

The `window.Store.Msg.getMessagesById` function was taken from here:
https://github.com/pedroslopez/whatsapp-web.js/blob/066d8fa75ebc13b9cc74cfcd18ffd847b79be998/src/Client.js#L1039

## Related Issue
closes #3259

## Motivation and Context
This will solve the problem of being unable to send messages with a quote attached. 

## How Has This Been Tested

I've tested this version with my local Node.js install (system/os details can be found in the mentioned issue).

I've tried sending a couple of messages in private and group chats. With both messages from me and others. It has also been tested on a clean install (without auth).

## Types of changes

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).



