### PR TITLE
fix: getMessageById false error with group chat message id

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1034,7 +1034,7 @@ class Client extends EventEmitter {
             if(msg) return window.WWebJS.getMessageModel(msg);
 
             const params = messageId.split('_');
-            if(params.length !== 3) throw new Error('Invalid serialized message id specified');
+            if (params.length !== 3 && params.length !== 4) throw new Error('Invalid serialized message id specified');
 
             let messagesObject = await window.Store.Msg.getMessagesById([messageId]);
             if (messagesObject && messagesObject.messages.length) msg = messagesObject.messages[0];


### PR DESCRIPTION
Messages from Group Chats will have 4 elements in the `params` variable, instead of the 3 for private messages. That's because the `params` variable splits the string by `_`. Group chat messages will have 3 `_` characters instead of 2 for private chat messages.

This updates the check to account for group chat messages (which have 4 parameters instead of 3).

# PR Details
When calling `Client.getMessageById()` with a group chat message id, it will throw a false error. 

## Description
The code checks if the `params` array length is 3. For private chat messages, this works fine. Group chat messages have an extra `_`, causing the params array to have 4 items instead of the expected 3. This will throw an error, even though the serialized id is valid.

Private Chat Message Id:
`false_3XXXXXXXX55@c.us_3AEB0XXXXXXXXXXXX4BA`

Group Chat Message Id:
`false_1XXXXXXXXXXXX299@g.us_XXXXXXA24C17127F4BD2_XXXX970@c.us`

## Related Issue
N/A

## Motivation and Context
This solves the problem of not being able to get any group message by its serialized id.

## How Has This Been Tested
I've tested this version with my local Node.js install (system/os details can be found in the mentioned issue).

### Environment
- OS: macOS Sonoma 14.3.1
- Phone OS: iOS 15.x
- whatsapp-web.js version: 1.25.0
- WhatsApp Web version: 2.3000.1016069290
- Node.js Version: 18.17.0

## Types of changes
- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).