### PR TITLE
fix: resolve 'onPollVoteEvent' binding issue after logout and reconnect

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -685,17 +685,17 @@ class Client extends EventEmitter {
                  */
                 this.emit(Events.MESSAGE_CIPHERTEXT, new Message(this, msg));
             });
-        }
 
-        await this.pupPage.exposeFunction('onPollVoteEvent', (vote) => {
-            const _vote = new PollVote(this, vote);
-            /**
-             * Emitted when some poll option is selected or deselected,
-             * shows a user's current selected option(s) on the poll
-             * @event Client#vote_update
-             */
-            this.emit(Events.VOTE_UPDATE, _vote);
-        });
+            await this.pupPage.exposeFunction('onPollVoteEvent', (vote) => {
+                const _vote = new PollVote(this, vote);
+                /**
+                 * Emitted when some poll option is selected or deselected,
+                 * shows a user's current selected option(s) on the poll
+                 * @event Client#vote_update
+                 */
+                this.emit(Events.VOTE_UPDATE, _vote);
+            });
+        }
 
         await this.pupPage.evaluate(() => {
             window.Store.Msg.on('change', (msg) => { window.onChangeMessageEvent(window.WWebJS.getMessageModel(msg)); });


### PR DESCRIPTION
This PR addresses a bug where attempting to reconnect after logging out would cause the application to fail with the error:

`Failed to add page binding with name onPollVoteEvent: window['onPollVoteEvent'] already exists!`


# PR Details
- Fixed error: 'Failed to add page binding with name onPollVoteEvent: window["onPollVoteEvent"] already exists!'
- The error occurred after logging out and attempting to reconnect.
- Connection would get stuck in 'authenticated' state and never reach 'ready'.
