### PR TITLE
fix: openChatWindow

### DIFF
--- a/src/util/InterfaceController.js
+++ b/src/util/InterfaceController.js
@@ -16,7 +16,7 @@ class InterfaceController {
     async openChatWindow(chatId) {
         await this.pupPage.evaluate(async chatId => {
             const chatWid = window.Store.WidFactory.createWid(chatId);
-            const chat = window.Store.Chat.get(chatId) || await window.Store.Chat.find(chatWid);
+            const chat = window.Store.Chat.get(chatWid) || await window.Store.Chat.find(chatWid);
             await window.Store.Cmd.openChatBottom(chat);
         }, chatId);
     }

--- a/src/util/InterfaceController.js
+++ b/src/util/InterfaceController.js
@@ -16,7 +16,7 @@ class InterfaceController {
     async openChatWindow(chatId) {
         await this.pupPage.evaluate(async chatId => {
             const chatWid = window.Store.WidFactory.createWid(chatId);
-            const chat = window.Store.Chat.get(chat) || await window.Store.Chat.find(chatWid);
+            const chat = window.Store.Chat.get(chatId) || await window.Store.Chat.find(chatWid);
             await window.Store.Cmd.openChatBottom(chat);
         }, chatId);
     }


### PR DESCRIPTION
# PR Details

The PR fixes an issue where the InterfaceController.openChatWindow function throws an error:
`Evaluation failed: ReferenceError: Cannot access 'chat' before initialization`

## Types of changes

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).



