### PR TITLE
fix: pass client reference correctly

### DIFF
--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -79,7 +79,7 @@ class Chat extends Base {
          * Last message fo chat
          * @type {Message}
          */
-        this.lastMessage = data.lastMessage ? new Message(super.client, data.lastMessage) : undefined;
+        this.lastMessage = data.lastMessage ? new Message(this.client, data.lastMessage) : undefined;
         
         return super._patch(data);
     }


### PR DESCRIPTION
# PR Details

## Description

The PR fixes an issue with incorrect reference passing of a `Client` object in the `Chat` class at the following line:
```js
this.lastMessage = data.lastMessage ? new Message(super.client, data.lastMessage) : undefined;
```
Especially this part:
```js
new Message(super.client, data.lastMessage)
```
Here the `super` keyword is used in the `Chat` class to access the `client` property.
Because the `client` property is defined with `Object.defineProperty` in the `Base` class, it cannot be accessed with `super.client`.
Instead, `super` only looks at properties defined on the prototype chain (`Base.prototype`), not on the instance itself.
As a result, this will return `undefined` which will leed to an error:
```js
TypeError: Cannot read properties of undefined (reading 'pupPage')
```

## Related Issue

closes #3241

## How Has This Been Tested

```js
// client initialization...
const chats = await client.getChats();
const messageInfo = await chats[0].lastMessage.getInfo(); // no error is thrown here as expected
```

## To test this PR by yourself you can run one of the following commands:

- **NPM**
```powershell
npm install github:alechkos/whatsapp-web.js#fix-client-undefined
```
- **YARN**
```powershell
yarn add github:alechkos/whatsapp-web.js#fix-client-undefined
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).