### PR TITLE
fix: change the logic of wweb version retrieving

### DIFF
--- a/tools/version-checker/update-version
+++ b/tools/version-checker/update-version
@@ -1,32 +1,69 @@
 #!/usr/bin/env node
 
 const fs = require('fs');
-const fetch = require('node-fetch');
+const puppeteer = require('puppeteer');
 
-const getLatestVersion = async () => { 
-    const response = await fetch('https://web.whatsapp.com/', {
-        headers: {
-            'user-agent':
-                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36',
-            'accept-language': 'en-US,en;q=1',
-            'sec-fetch-mode': 'navigate',
-            'cache-control': 'no-cache',
-            cookie: 'wa_lang_pref=en;wa_build=c',
-            pragma: 'no-cache',
-        },
+const args = [
+    '--autoplay-policy=user-gesture-required',
+    '--disable-background-networking',
+    '--disable-background-timer-throttling',
+    '--disable-backgrounding-occluded-windows',
+    '--disable-breakpad',
+    '--disable-client-side-phishing-detection',
+    '--disable-component-update',
+    '--disable-default-apps',
+    '--disable-dev-shm-usage',
+    '--disable-domain-reliability',
+    '--disable-extensions',
+    '--disable-features=AudioServiceOutOfProcess',
+    '--disable-hang-monitor',
+    '--disable-ipc-flooding-protection',
+    '--disable-notifications',
+    '--disable-offer-store-unmasked-wallet-cards',
+    '--disable-popup-blocking',
+    '--disable-print-preview',
+    '--disable-prompt-on-repost',
+    '--disable-renderer-backgrounding',
+    '--disable-speech-api',
+    '--disable-sync',
+    '--disable-gpu',
+    '--disable-accelerated-2d-canvas',
+    '--hide-scrollbars',
+    '--ignore-gpu-blacklist',
+    '--metrics-recording-only',
+    '--mute-audio',
+    '--no-default-browser-check',
+    '--no-first-run',
+    '--no-pings',
+    '--no-zygote',
+    '--password-store=basic',
+    '--use-gl=swiftshader',
+    '--use-mock-keychain',
+    '--disable-setuid-sandbox',
+    '--no-sandbox',
+    '--disable-blink-features=AutomationControlled',
+    '--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36'
+];
+
+const getLatestVersion = async () => {
+    const browser = await puppeteer.launch({
+        args: args
+    });
+    const page = await browser.newPage();
+    await page.goto('https://web.whatsapp.com', {
+        waitUntil: 'load',
+        timeout: 0,
+        referer: 'https://whatsapp.com/',
     });
 
-    const text = await response.text();
-    
-    if (text) {
-        const matches = text.match(/"client_revision"\s*:\s*(\d+)/) || [];
+    await page.waitForFunction(() => window.require && window.require('WAWebBuildConstants'));
 
-        if (matches[1]) {
-            return `2.3000.${matches[1]}`;
-        }
-    }
+    const version = await page.evaluate(() => {
+        return window.require('WAWebBuildConstants').VERSION_STR;
+    });
 
-    return null;
+    await browser.close();
+    return version;
 };
 
 const getCurrentVersion = () => {

--- a/tools/version-checker/update-version
+++ b/tools/version-checker/update-version
@@ -3,10 +3,30 @@
 const fs = require('fs');
 const fetch = require('node-fetch');
 
-const getLatestVersion = async (currentVersion) => { 
-    const res = await fetch(`https://web.whatsapp.com/check-update?version=${currentVersion}&platform=web`);
-    const data = await res.json();
-    return data.currentVersion;
+const getLatestVersion = async () => { 
+    const response = await fetch('https://web.whatsapp.com/', {
+        headers: {
+            'user-agent':
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36',
+            'accept-language': 'en-US,en;q=1',
+            'sec-fetch-mode': 'navigate',
+            'cache-control': 'no-cache',
+            cookie: 'wa_lang_pref=en;wa_build=c',
+            pragma: 'no-cache',
+        },
+    });
+
+    const text = await response.text();
+    
+    if (text) {
+        const matches = text.match(/"client_revision"\s*:\s*(\d+)/) || [];
+
+        if (matches[1]) {
+            return `2.3000.${matches[1]}`;
+        }
+    }
+
+    return null;
 };
 
 const getCurrentVersion = () => {
@@ -40,12 +60,12 @@ const updateVersion = async (oldVersion, newVersion) => {
 
 (async () => {
     const currentVersion = getCurrentVersion();
-    const version = await getLatestVersion(currentVersion);
+    const version = (await getLatestVersion()) ?? currentVersion;
 
     console.log(`Current version: ${currentVersion}`);
     console.log(`Latest version: ${version}`);
 
-    if(currentVersion !== version) {
+    if (currentVersion !== version) {
         console.log('Updating files...');
         await updateVersion(currentVersion, version);
         console.log('Updated!');


### PR DESCRIPTION
# PR Details

The PR fixes an issue where the WhatsApp Web version is stuck on v2.2413.51 in #2616 and does not automatically update the version in [`Constants.js`](https://github.com/pedroslopez/whatsapp-web.js/blob/6e5325867df81f08be43638c895e88d27dbace59/src/util/Constants.js#L10), [`README.md`](https://github.com/pedroslopez/whatsapp-web.js/edit/main/README.md) and [`.version`](https://github.com/pedroslopez/whatsapp-web.js/blob/main/tools/version-checker/.version).

## How Has This Been Tested

Tested on a private repository created specially for this:

<details><summary>

#### The `update-version` (click to expand)
</summary>

```js
#!/usr/bin/env node

const puppeteer = require('puppeteer');
const args = [
    '--autoplay-policy=user-gesture-required',
    '--disable-background-networking',
    '--disable-background-timer-throttling',
    '--disable-backgrounding-occluded-windows',
    '--disable-breakpad',
    '--disable-client-side-phishing-detection',
    '--disable-component-update',
    '--disable-default-apps',
    '--disable-dev-shm-usage',
    '--disable-domain-reliability',
    '--disable-extensions',
    '--disable-features=AudioServiceOutOfProcess',
    '--disable-hang-monitor',
    '--disable-ipc-flooding-protection',
    '--disable-notifications',
    '--disable-offer-store-unmasked-wallet-cards',
    '--disable-popup-blocking',
    '--disable-print-preview',
    '--disable-prompt-on-repost',
    '--disable-renderer-backgrounding',
    '--disable-speech-api',
    '--disable-sync',
    '--disable-gpu',
    '--disable-accelerated-2d-canvas',
    '--hide-scrollbars',
    '--ignore-gpu-blacklist',
    '--metrics-recording-only',
    '--mute-audio',
    '--no-default-browser-check',
    '--no-first-run',
    '--no-pings',
    '--no-zygote',
    '--password-store=basic',
    '--use-gl=swiftshader',
    '--use-mock-keychain',
    '--disable-setuid-sandbox',
    '--no-sandbox',
    '--disable-blink-features=AutomationControlled',
    '--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36'
];

const getWWebVersion = async () => {
    const browser = await puppeteer.launch({
        args: args
    });
    const page = await browser.newPage();
    await page.goto('https://web.whatsapp.com', {
        waitUntil: 'load',
        timeout: 0,
        referer: 'https://whatsapp.com/',
    });

    await page.waitForFunction(() => window.require && window.require('WAWebBuildConstants'));

    const versionString = await page.evaluate(() => {
        return window.require('WAWebBuildConstants').VERSION_STR;
    });

    await browser.close();
    return versionString;
};

(async () => {
    console.log(`Current version: ${await getWWebVersion()}`);
})();
```
</details>

<details><summary>

#### The `update.yml` workflow (click to expand)
</summary>

```yml
name: Update

on:
  workflow_dispatch:

jobs:
  update:
    runs-on: ubuntu-latest
    defaults:
      run:
        working-directory: .

    steps:
      - uses: actions/checkout@v2
      - name: Install node v16
        uses: actions/setup-node@v2
        with:
          node-version: '16'
      - name: Install dependencies
        run: npm install
      - name: Make update-version executable
        run: chmod +x ./update-version
      - name: Run Updater
        run: ./update-version
```
</details>

<details><summary>

#### The output (click to expand)
</summary>
<p align="center">
  <img src="https://github.com/user-attachments/assets/5d0f4f0f-e310-44de-8e9c-902e02fac6de"/>
</p>
</details>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).