### PR TITLE
fix: enable docs generation before the release

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "mocha tests --recursive --timeout 5000",
     "test-single": "mocha",
     "shell": "node --experimental-repl-await ./shell.js",
-    "generate-docs": "node_modules/.bin/jsdoc --configure .jsdoc.json --verbose"
+    "generate-docs": "npx jsdoc --configure .jsdoc.json --verbose"
   },
   "repository": {
     "type": "git",

--- a/tools/publish
+++ b/tools/publish
@@ -70,6 +70,8 @@ npm version $VERSION_ARGS || exit 1
 
 git push && git push --tags || exit 1
 
+npm install
+
 npm run generate-docs
 
 git add .


### PR DESCRIPTION
# PR Details

It's important to automatically generate documentation for new functionality before each release.
The PR fixes an issue where the `node_modules/.bin/jsdoc` is not found during the release publishing process:
```bash
> whatsapp-web.js@1.26.0 generate-docs
> node_modules/.bin/jsdoc --configure .jsdoc.json --verbose

sh: 1: node_modules/.bin/jsdoc: not found
```

<details><summary>

### Action screenshot  (click to expand)
</summary>

[Link to action](https://github.com/pedroslopez/whatsapp-web.js/actions/runs/10929944843/job/30341779020)
<p align="center">
  <img src="https://github.com/user-attachments/assets/506bad22-85c8-4088-a394-275adc1f9cdb"/>
</p>
</details>

## How Has This Been Tested

Tested locally by installing dependencies and generating docs:
```cmd
:: using cmd
npm install && npm run generate-docs
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



