### PR TITLE
feat: Show error when createGroup fails

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1416,7 +1416,7 @@ class Client extends EventEmitter {
                     participantWids
                 );
             } catch (err) {
-                return 'CreateGroupError: An unknown error occupied while creating a group';
+                return 'CreateGroupError: The following error occurred while creating a group:\n' + err;
             }
 
             for (const participant of createGroupResult.participants) {


### PR DESCRIPTION
# PR Details

The error output has been added to the general error message: "CreateGroupError: An unknown error occurred while creating a group" in the createGroup function. 

## Description

In case of an error createGroup now outputs:

> CreateGroupError: The following error occurred while creating a group:
> <Content of error>

## Related Issue(s)

## Motivation and Context

This is necessary because createGroup can sometimes fail due to rate limits on WhatsApp's side and the user of the library does not know why it fails.  See https://github.com/pedroslopez/whatsapp-web.js/issues/3238

## How Has This Been Tested

Produced error in the try catch (Line 1403) and checked the output formatting.

### Environment

<!-- Include details of your testing environment: -->
- Machine OS: Mac
- Library Version: 1.26.1-alpha.2
- Node Version: 10.8.1

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).
- [x] I have updated the usage example accordingly (example.js)