### PR TITLE
feat: add participant field to MessageId interface for group messages

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1008,6 +1008,11 @@ declare namespace WAWebJS {
         remote: string,
         id: string,
         _serialized: string,
+        participant?: {
+            server: string,
+            user: string,
+            _serialized: string
+        }
     }
 
     /** Options for sending a location */


### PR DESCRIPTION
# PR Details

Add optional participant field to the MessageId interface for group messages

## Description

This PR adds an optional participant field to the MessageId interface. The participant field is used when the message is part of a group, and it includes details about the participant who sent the message. The field contains the server, user, and _serialized properties.

## Motivation and Context

Currently, the MessageId interface does not reflect the structure of group messages, which include the participant field. This change will allow developers to access group message participant details directly when handling group messages.

## How Has This Been Tested

This change was tested by sending and receiving both private and group messages. In private messages, the participant field is absent, while in group messages, the participant field is present.

### Environment

- Machine OS: Ubuntu 24.04.1 LTS
- Library Version: 1.26.1-alpha.2
- Node Version: 20.16.0

## Types of changes

- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly (index.d.ts).
- [X] I have updated the usage example accordingly (example.js)