### PR TITLE
Add 4 retries for fs.promises.rm

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -538,7 +538,8 @@ declare namespace WAWebJS {
         public dataPath?: string;
         constructor(options?: {
             clientId?: string,
-            dataPath?: string
+            dataPath?: string,
+            rmMaxRetries?: number
         })
     }
     
@@ -552,7 +553,8 @@ declare namespace WAWebJS {
             store: Store,
             clientId?: string,
             dataPath?: string,
-            backupSyncIntervalMs: number
+            backupSyncIntervalMs: number,
+            rmMaxRetries?: number
         })
     }
 

--- a/src/authStrategies/LocalAuth.js
+++ b/src/authStrategies/LocalAuth.js
@@ -9,9 +9,10 @@ const BaseAuthStrategy = require('./BaseAuthStrategy');
  * @param {object} options - options
  * @param {string} options.clientId - Client id to distinguish instances if you are using multiple, otherwise keep null if you are using only one instance
  * @param {string} options.dataPath - Change the default path for saving session files, default is: "./.wwebjs_auth/" 
+ * @param {number} options.rmMaxRetries - Sets the maximum number of retries for removing the session directory
 */
 class LocalAuth extends BaseAuthStrategy {
-    constructor({ clientId, dataPath }={}) {
+    constructor({ clientId, dataPath, rmMaxRetries }={}) {
         super();
 
         const idRegex = /^[-_\w]+$/i;
@@ -21,6 +22,7 @@ class LocalAuth extends BaseAuthStrategy {
 
         this.dataPath = path.resolve(dataPath || './.wwebjs_auth/');
         this.clientId = clientId;
+        this.rmMaxRetries = rmMaxRetries ?? 4;
     }
 
     async beforeBrowserInitialized() {
@@ -44,7 +46,7 @@ class LocalAuth extends BaseAuthStrategy {
 
     async logout() {
         if (this.userDataDir) {
-            await fs.promises.rm(this.userDataDir, { recursive: true, force: true })
+            await fs.promises.rm(this.userDataDir, { recursive: true, force: true, maxRetries: this.rmMaxRetries })
                 .catch((e) => {
                     throw new Error(e);
                 });


### PR DESCRIPTION
# PR Details

<!-- Provide here a general summary of your changes. -->

## Description

Time to time it's possible to get some errors when logout - probably due to chrome process locking some files.

`fs.promises.rm` has `maxRetries` option for that https://nodejs.org/api/fs.html#fspromisesrmpath-options
We can set it to `4`, giving us 4 retries with about 1s max delay (100+200+300+400=1,000ms)

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [X] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)