### PR TITLE
Upgrade unzipper version

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
   "optionalDependencies": {
     "archiver": "^5.3.1",
     "fs-extra": "^10.1.0",
-    "unzipper": "^0.10.11"
+    "unzipper": "^0.12.3"
   }
 }


### PR DESCRIPTION
# PR Details

I only upgraded the unzipper dependency version

## Description
The reason is that remote session doesn't work because the current version is trying to use "fstream" which is discontinued.


## Related Issue(s)
No related issues.

## Motivation and Context
I want to implement a solution that depends on the "remote session" feature.

## How Has This Been Tested
Changed the dependency installing it directly at the node_modules of my project and it works properly now.

### Environment

- Machine OS: MacOS Sequoia 15.0
- Library Version: 1.26.0
- WhatsApp Web Version: 
I found another error here
```bash 821 |     /**
822 |      * Returns the version of WhatsApp Web currently being run
823 |      * @returns {Promise<string>}
824 |      */
825 |     async getWWebVersion() {
826 |         return await this.pupPage.evaluate(() => {
                                ^
TypeError: null is not an object (evaluating 'this.pupPage.evaluate')
      at <my_project_dir>/node_modules/whatsapp-web.js/src/Client.js:826:27
      at getWWebVersion (<my_project_dir>/node_modules/whatsapp-web.js/src/Client.js:825:28)
```

- Puppeteer Version: 18.2.1
- Browser Type and Version: headless
- Node Version: Bun v1.1.29

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [x] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)