### PR TITLE
Fix isGroup

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -451,11 +451,11 @@ exports.LoadUtils = () => {
     window.WWebJS.getChatModel = async chat => {
 
         let res = chat.serialize();
-        res.isGroup = chat.isGroup;
         res.formattedTitle = chat.formattedTitle;
-        res.isMuted = chat.mute && chat.mute.isMuted;
+        res.isMuted = chat.muteExpiration == 0 ? false : true;
 
         if (chat.groupMetadata) {
+            res.isGroup = true;
             const chatWid = window.Store.WidFactory.createWid((chat.id._serialized));
             await window.Store.GroupMetadata.update(chatWid);
             res.groupMetadata = chat.groupMetadata.serialize();

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -451,6 +451,7 @@ exports.LoadUtils = () => {
     window.WWebJS.getChatModel = async chat => {
 
         let res = chat.serialize();
+        res.isGroup = false;
         res.formattedTitle = chat.formattedTitle;
         res.isMuted = chat.muteExpiration == 0 ? false : true;
 


### PR DESCRIPTION
# PR Details

This PR solves the problem with Group Chats

## Description

This PR solves the problem with Group Chats isGroup property
I identified two main changes in the Meta chat object that affected this, isGroup and isMute are missing, so I did a shift based on groupmetadata to determine whether the chat is a group and used muteExpiration to determine if the chat is muted.

## Related Issue(s)
[https://github.com/pedroslopez/whatsapp-web.js/issues/3378](3378)

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)