### PR TITLE
[Draft] Click in hydratedButtons and dynamicReplyButtons

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -132,6 +132,9 @@ declare namespace WAWebJS {
         /** Send a message to a specific chatId */
         sendMessage(chatId: string, content: MessageContent, options?: MessageSendOptions): Promise<Message>
         
+        /** Send a message to a specific chatId */
+        clickButtonInChat(chatId: string, buttonTitle: string): Promise<HTMLElement|null>
+        
         /** Searches for messages */
         searchMessages(query: string, options?: { chatId?: string, page?: number, limit?: number }): Promise<Message[]>
 
@@ -1450,6 +1453,8 @@ declare namespace WAWebJS {
         mute: (unmuteDate?: Date) => Promise<void>,
         /** Send a message to this chat */
         sendMessage: (content: MessageContent, options?: MessageSendOptions) => Promise<Message>,
+        /** Send a message to a specific chatId */
+        clickButtonInChat: (chatId: string, buttonTitle: string) => Promise<HTMLElement|null>,
         /** Set the message as seen */
         sendSeen: () => Promise<void>,
         /** Simulate recording audio in chat. This will last for 25 seconds */

--- a/src/Client.js
+++ b/src/Client.js
@@ -961,7 +961,7 @@ class Client extends EventEmitter {
             const chat = await window.Store.Chat.find(chatWid);
 
             if (!chat) {
-                throw new Error(`Chat com ID ${chatId} não encontrado.`);
+                throw new Error(`Chat with ID ${chatId} not found.`);
             }
 
             await window.Store.Cmd.openChatBottom(chat);
@@ -973,7 +973,7 @@ class Client extends EventEmitter {
             return null;
         }
         console.log(`Button with the title "${buttonTitle}" was clicked in chat ${chatId}.`);
-        
+
         return button;
     }
     

--- a/src/Client.js
+++ b/src/Client.js
@@ -947,6 +947,35 @@ class Client extends EventEmitter {
 
         return new Message(this, newMessage);
     }
+
+    /**
+     * Clicks the last button with a specific title in a given chat
+     * @param {string} chatId - The ID of the chat where the button is located
+     * @param {string} buttonTitle - The title of the button to click
+     * @returns {Promise<HTMLElement|null>} The button element that was clicked, or null if not found
+     */
+    async clickButtonInChat(chatId, buttonTitle) {
+        
+        const button = await this.pupPage.evaluate(async (chatId, buttonTitle) => {
+            const chatWid = window.Store.WidFactory.createWid(chatId);
+            const chat = await window.Store.Chat.find(chatWid);
+
+            if (!chat) {
+                throw new Error(`Chat com ID ${chatId} não encontrado.`);
+            }
+
+            await window.Store.Cmd.openChatBottom(chat);
+            return await window.WWebJS.clickButtonInChat(chat, buttonTitle);
+        }, chatId, buttonTitle);
+
+        if (!button) {
+            console.warn(`Nenhum botão com título "${buttonTitle}" foi encontrado no chat ${chatId}.`);
+            return null;
+        }
+
+        console.log(`Botão com título "${buttonTitle}" foi clicado no chat ${chatId}.`);
+        return button;
+    }
     
     /**
      * Searches for messages

--- a/src/Client.js
+++ b/src/Client.js
@@ -969,11 +969,11 @@ class Client extends EventEmitter {
         }, chatId, buttonTitle);
 
         if (!button) {
-            console.warn(`Nenhum botão com título "${buttonTitle}" foi encontrado no chat ${chatId}.`);
+            console.warn(`No button with the title "${buttonTitle}" was found in chat ${chatId}.`);
             return null;
         }
-
-        console.log(`Botão com título "${buttonTitle}" foi clicado no chat ${chatId}.`);
+        console.log(`Button with the title "${buttonTitle}" was clicked in chat ${chatId}.`);
+        
         return button;
     }
     

--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -95,6 +95,15 @@ class Chat extends Base {
     }
 
     /**
+     * Clicks the last button with a specific title in a given chat
+     * @param {string} buttonTitle - The title of the button to click
+     * @returns {Promise<HTMLElement|null>} The button element that was clicked, or null if not found
+     */
+    async clickButtonInChat(buttonTitle) {
+        return this.client.clickButtonInChat(this.id._serialized, buttonTitle);
+    }
+
+    /**
      * Set the message as seen
      * @returns {Promise<Boolean>} result
      */

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -31,13 +31,31 @@ exports.LoadUtils = () => {
             throw new Error(`Chat com ID ${chat.id} não encontrado.`);
         }
 
-        const buttons = Array.from(document.querySelectorAll('button')).filter(button => {
+        const hydratedButtons = Array.from(document.querySelectorAll('button')).filter(button => {
             const span = button.querySelector('span');
             return span && span.textContent.trim() === buttonTitle;
         });
         
-        const lastButton = buttons[buttons.length - 1];
-        lastButton.click();
+        const dynamicReplyButtons = Array.from(document.querySelectorAll('div[role="button"]')).filter(button => {
+            const span = button.querySelector('span');
+            return span && span.textContent.trim() === buttonTitle;
+        });
+        
+        let lastButton = null;
+        
+        if (hydratedButtons.length !== 0) {
+            lastButton = hydratedButtons[hydratedButtons.length - 1];
+        }
+        
+        if (dynamicReplyButtons.length !== 0) {
+            lastButton = dynamicReplyButtons[dynamicReplyButtons.length - 1];
+        }
+        
+        if (lastButton) {
+            lastButton.click();
+        } else {
+            console.warn('Nenhum botão encontrado com o título:', buttonTitle);
+        }        
         
         return lastButton;
     };

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -44,11 +44,11 @@ exports.LoadUtils = () => {
         let lastButton = null;
         
         if (hydratedButtons.length !== 0) {
-            lastButton = hydratedButtons[hydratedButtons.length - 1];
+            lastButton = hydratedButtons[hydratedButtons.length - 1]; // Only get the last, need to improve to some ID
         }
         
         if (dynamicReplyButtons.length !== 0) {
-            lastButton = dynamicReplyButtons[dynamicReplyButtons.length - 1];
+            lastButton = dynamicReplyButtons[dynamicReplyButtons.length - 1]; // Only get the last, need to improve to some ID
         }
         
         if (lastButton) {

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -24,6 +24,24 @@ exports.LoadUtils = () => {
 
     };
 
+    window.WWebJS.clickButtonInChat = async (chat, buttonTitle) => {
+        const chatObj = window.Store.Chat.get(chat.id);
+        
+        if (!chatObj) {
+            throw new Error(`Chat com ID ${chat.id} não encontrado.`);
+        }
+
+        const buttons = Array.from(document.querySelectorAll('button')).filter(button => {
+            const span = button.querySelector('span');
+            return span && span.textContent.trim() === buttonTitle;
+        });
+        
+        const lastButton = buttons[buttons.length - 1];
+        lastButton.click();
+        
+        return lastButton;
+    };
+
     window.WWebJS.sendMessage = async (chat, content, options = {}) => {
         let attOptions = {};
         if (options.attachment) {

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -28,7 +28,7 @@ exports.LoadUtils = () => {
         const chatObj = window.Store.Chat.get(chat.id);
         
         if (!chatObj) {
-            throw new Error(`Chat com ID ${chat.id} não encontrado.`);
+            throw new Error(`Chat with ID ${chat.id} not found.`);
         }
 
         const hydratedButtons = Array.from(document.querySelectorAll('button')).filter(button => {
@@ -54,7 +54,7 @@ exports.LoadUtils = () => {
         if (lastButton) {
             lastButton.click();
         } else {
-            console.warn('Nenhum botão encontrado com o título:', buttonTitle);
+            console.warn('No button found with the title:', buttonTitle);
         }        
         
         return lastButton;


### PR DESCRIPTION
# PR Details

I created a way to click in te last hydratedButtons or dynamicReplyButtons, but my code is really bad! Have any way to improve this implementation?


## Related Issue(s)

https://github.com/pedroslopez/whatsapp-web.js/issues/2156

## How Has This Been Tested

```js

const listener = (message) => {
  const buttons = message._data.hydratedButtons || message._data.dynamicReplyButtons
  
  if (message._data.from === contact.id._serialized && buttons.length != 0) {
      this.onAction(buttons, message, contact);
  }
};
                    
async onAction(buttons, message, contact) {       
  const displayText = (buttons[0].buttonText || buttons[0].quickReplyButton).displayText
  await this.client.clickButtonInChat(contact.id._serialized, displayText);
}
```

- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)