### PR TITLE
Update LocalAuth.js

### DIFF
--- a/src/authStrategies/LocalAuth.js
+++ b/src/authStrategies/LocalAuth.js
@@ -44,10 +44,12 @@ class LocalAuth extends BaseAuthStrategy {
 
     async logout() {
         if (this.userDataDir) {
-            await fs.promises.rm(this.userDataDir, { recursive: true, force: true })
-                .catch((e) => {
-                    throw new Error(e);
-                });
+			setTimeout(() => {
+				fs.promises.rm(this.userDataDir, { recursive: true, force: true })
+					.catch((e) => {
+						throw new Error(e);
+					});
+			}, 5000);
         }
     }
 


### PR DESCRIPTION
# PR Details

There is an error when the user unlinks a device, because it cannot delete the `chrome_debug.log` file which is busy/locked.

## Description

Prevent error when deleting busy files:
Error: EBUSY: resource busy or locked, unlink '...\.wwebjs_auth\session\Default\chrome_debug.log'