### PR TITLE
Fix Group getInviteCode

### DIFF
--- a/src/util/Injected/Store.js
+++ b/src/util/Injected/Store.js
@@ -122,7 +122,8 @@ exports.ExposeStore = () => {
     };
     window.Store.GroupInvite = {
         ...window.require('WAWebGroupInviteJob'),
-        ...window.require('WAWebGroupQueryJob')
+        ...window.require('WAWebGroupQueryJob'),
+        ...window.require('WAWebMexFetchGroupInviteCodeJob')
     };
     window.Store.GroupInviteV4 = {
         ...window.require('WAWebGroupInviteV4Job'),

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -460,6 +460,7 @@ exports.LoadUtils = () => {
             const chatWid = window.Store.WidFactory.createWid((chat.id._serialized));
             await window.Store.GroupMetadata.update(chatWid);
             res.groupMetadata = chat.groupMetadata.serialize();
+            res.isReadOnly = chat.groupMetadata.announce;
         }
         
         res.lastMessage = null;


### PR DESCRIPTION
# PR Details

The PR fixes an issue where the group.getInviteCode() function throws an error: The function: window.Store.GroupInvite.queryGroupInviteCode no longer exists.

## Description

It was necessary to add a new required module and change the method getInviteCode to use the new method to get the group invite code. 

## Related Issue(s)

[#3490](https://github.com/pedroslopez/whatsapp-web.js/issues/3490)

## How Has This Been Tested

   ```
 const groupChat = await client.getChatById('xxxxxxxxxxxxxxxxx@g.us');
 const codeInvite = await groupChat.getInviteCode();
  console.log(codeInvite);
```

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [X] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)