### PR TITLE
Fix Group getInviteCode

### DIFF
--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -381,9 +381,9 @@ class GroupChat extends Chat {
         const codeRes = await this.client.pupPage.evaluate(async chatId => {
             const chatWid = window.Store.WidFactory.createWid(chatId);
             try {
-                return window.compareWwebVersions(window.Debug.VERSION, '>=', '2.3000.0')
-                    ? await window.Store.GroupInvite.queryGroupInviteCode(chatWid, true)
-                    : await window.Store.GroupInvite.queryGroupInviteCode(chatWid);
+                return window.compareWwebVersions(window.Debug.VERSION, '>=', '2.3000.1020730154')
+                    ? await window.Store.GroupInvite.fetchMexGroupInviteCode(chatId)
+                    : await window.Store.GroupInvite.queryGroupInviteCode(chatWid, true);
             }
             catch (err) {
                 if(err.name === 'ServerStatusCodeError') return undefined;
@@ -391,7 +391,9 @@ class GroupChat extends Chat {
             }
         }, this.id._serialized);
 
-        return codeRes?.code;
+        return codeRes?.code
+            ? codeRes?.code
+            : codeRes;
     }
     
     /**

--- a/src/util/Injected/Store.js
+++ b/src/util/Injected/Store.js
@@ -122,7 +122,8 @@ exports.ExposeStore = () => {
     };
     window.Store.GroupInvite = {
         ...window.require('WAWebGroupInviteJob'),
-        ...window.require('WAWebGroupQueryJob')
+        ...window.require('WAWebGroupQueryJob'),
+        ...window.require('WAWebMexFetchGroupInviteCodeJob')
     };
     window.Store.GroupInviteV4 = {
         ...window.require('WAWebGroupInviteV4Job'),


### PR DESCRIPTION
# PR Details

The PR fixes an issue where the group.getIviteCode() function throws an error: _The function: window.Store.GroupInvite.queryGroupInviteCode no longer exists._

## Description

This PR solve the problem with group.getInvite()

## Related Issue(s)

[#3490](https://github.com/pedroslopez/whatsapp-web.js/issues/3490)

## How Has This Been Tested

```
// client initialization...

client.once('ready', async () => {
    const groupChat = await client.getChatById("xxxxxxxxxxxxxxxx@g.us");
    const codeInvite = await groupChat.getInviteCode();
    console.log(codeInvite);
});
```

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [X] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)