### PR TITLE
Fix sending vcard as string

### DIFF
--- a/src/util/Injected/Store.js
+++ b/src/util/Injected/Store.js
@@ -69,6 +69,8 @@ exports.ExposeStore = () => {
     window.Store.UserConstructor = window.require('WAWebWid');
     window.Store.Validators = window.require('WALinkify');
     window.Store.VCard = window.require('WAWebFrontendVcardUtils');
+    window.Store.VCardParser = window.require('WAWebVcardParsingUtils');
+    window.Store.VCardNameGetter = window.require('WAWebVcardGetNameFromParsed');
     window.Store.WidFactory = window.require('WAWebWidFactory');
     window.Store.ProfilePic = window.require('WAWebContactProfilePicThumbBridge');
     window.Store.PresenceUtils = window.require('WAWebPresenceChatAction');

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -135,11 +135,11 @@ exports.LoadUtils = () => {
         } else if (options.parseVCards && typeof (content) === 'string' && content.startsWith('BEGIN:VCARD')) {
             delete options.parseVCards;
             try {
-                const parsed = window.Store.VCard.parseVcard(content);
+                const parsed = window.Store.VCardParser.parseVcard(content);
                 if (parsed) {
                     vcardOptions = {
                         type: 'vcard',
-                        vcardFormattedName: window.Store.VCard.vcardGetNameFromParsed(parsed)
+                        vcardFormattedName: window.Store.VCardNameGetter.vcardGetNameFromParsed(parsed)
                     };
                 }
             } catch (_) {


### PR DESCRIPTION
# PR Details

Whatsapp updated the vCard code structure by splitting vCard methods into multiple modules:
WAWebFrontendVcardUtils – Converts ContactModel to vCard
WAWebVcardParsingUtils – Parses vCard from a string
WAWebVcardGetNameFromParsed – Retrieves name from parsed vCard

## Description

Added the new modules to `Store.js` and updated `Utils.js` to use these modules accordingly.

## Related Issue(s)

## Motivation and Context
Previously, sending a vCard as a content string was broken due to changes in Whatsapp's vCard structure.
This update restores compatibility by aligning with the new module structure.

## How Has This Been Tested


### Environment

<!-- Include details of your testing environment: -->
- Machine OS: 
- Phone OS:
- Library Version: 
- WhatsApp Web Version: 
- Puppeteer Version:
- Browser Type and Version: 
- Node Version: 

## Types of changes

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x ] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).
- [x] I have updated the usage example accordingly (example.js)