### PR TITLE
Fix the Location declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1026,7 +1026,10 @@ declare namespace WAWebJS {
     export class Location {
         latitude: string;
         longitude: string;
-        options?: LocationSendOptions;
+        name?: string;
+        address?: string;
+        url?: string;
+        description?: string;
         
         constructor(latitude: number, longitude: number, options?: LocationSendOptions)
     }

--- a/src/structures/Location.js
+++ b/src/structures/Location.js
@@ -6,6 +6,7 @@
  * @property {string} [name] Location name
  * @property {string} [address] Location address
  * @property {string} [url] URL address to be shown within a location message
+ * @property {string} [description] Location full description
  */
 
 /**


### PR DESCRIPTION
# PR Details

Fix the Location declaration in `index.d.ts` and `Location.js`

## Description

In the declaration of the `Locations` class, the `options?: LocationSendOptions` attribute was replaced with four new attributes: `name?: string`, `address?: string`, `url?: string`, and `description?: string`, in accordance with the implementation of this class.

## Motivation and Context

The actual attributes of the class do not match those declared in `index.d.ts`, which leads to unexpected behavior when trying to access the `options` attribute. To work around this issue, it becomes necessary to use `// @ts-ignore`.

## Types of changes

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).
- [x] I have updated the usage example accordingly (example.js)