### PR TITLE
Fix self message delete

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -503,8 +503,11 @@ class Message extends Base {
         await this.client.pupPage.evaluate(async (msgId, everyone) => {
             const msg = window.Store.Msg.get(msgId) || (await window.Store.Msg.getMessagesById([msgId]))?.messages?.[0];
             let chat = await window.Store.Chat.find(msg.id.remote);
-            
             const canRevoke = window.Store.MsgActionChecks.canSenderRevokeMsg(msg) || window.Store.MsgActionChecks.canAdminRevokeMsg(msg);
+            const isSelfMsg = msg.from.user === msg.id.remote.user && msg.id.fromMe;
+            if(isSelfMsg) {
+                return window.Store.Cmd.sendDeleteMsgs(chat, { list: [msg], type: 'message' });
+            }
             if (everyone && canRevoke) {
                 if (window.compareWwebVersions(window.Debug.VERSION, '>=', '2.3000.0')) {
                     return window.Store.Cmd.sendRevokeMsgs(chat, { list: [msg], type: 'message' }, { clearMedia: true });


### PR DESCRIPTION
# PR Details

Self Message delete fixed

## Description

The self message sent in own chat cannot be deleted due to error


## How Has This Been Tested

tested in shell:
$ const message = await client.sendMessage('MYSELFNUMBER@c.us', 'todelete')
$ await message.delete()

### Environment

Machine OS: Docker + Amazon Linux 2023
Phone OS: Android
Library Version: 1.27.0
WhatsApp Web Version: 2.3000.1022278655
Puppeteer Version: 18.2.1
Browser Type and Version: Chromium
Node Version: ^20

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)