### PR TITLE
feat: partial `@­lid` support

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -467,6 +467,9 @@ exports.LoadUtils = () => {
             res.isGroup = true;
             const chatWid = window.Store.WidFactory.createWid((chat.id._serialized));
             await window.Store.GroupMetadata.update(chatWid);
+            chat.groupMetadata.participants._models
+                .filter(x => x.id._serialized.endsWith('@lid'))
+                .forEach(x => { x.id = x.contact.phoneNumber; });
             res.groupMetadata = chat.groupMetadata.serialize();
             res.isReadOnly = chat.groupMetadata.announce;
         }

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -562,7 +562,10 @@ exports.LoadUtils = () => {
 
     window.WWebJS.getContact = async contactId => {
         const wid = window.Store.WidFactory.createWid(contactId);
-        const contact = await window.Store.Contact.find(wid);
+        let contact = await window.Store.Contact.find(wid);
+        if (contact.id._serialized.endsWith('@lid')) {
+            contact.id = contact.phoneNumber;
+        }
         const bizProfile = await window.Store.BusinessProfile.fetchBizProfile(wid);
         bizProfile.profileOptions && (contact.businessProfile = bizProfile);
         return window.WWebJS.getContactModel(contact);


### PR DESCRIPTION
# PR Details

## Description

**The PR adds partial (at the moment) support for `@­lid`'s.**

## Related Issues

fixes #3519
fixes #3566

---

## Usage Example <a href="https://github.com/pedroslopez/whatsapp-web.js/pull/3571#usage-example" id="usage-example"/>

```js
// client initialization...

client.on('ready', async () => {
    let someGroup = await client.getChatById('...@g.us');

    console.log(someGroup.participants);

    /* Expected output:
    
    [
        {
            id: {
                server: 'c.us',
                user: '...',
                _serialized: '...@c.us' // Instead of '...@­lid'
            },
            ...
        },
        ...
    ]
    */
});

client.on('message', async (msg) => {
    let contact = await msg.getContact();

    console.log(contact); // Expected contact id: '...@c.us', instead of '...@lid'
});
```

---

## To try this PR by yourself you can run one of the following commands:

- **NPM**
```powershell
npm install github:alechkos/whatsapp-web.js#lid-support
```
- **YARN**
```powershell
yarn add github:alechkos/whatsapp-web.js#lid-support
```

---

## How Has The PR Been Tested

Tested with a code provided in [usage example](https://github.com/pedroslopez/whatsapp-web.js/pull/3571#usage-example).

---

## Types of Changes
- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix/feature that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project
- [ ] I have updated the usage example accordingly (example.js)
- [ ] I have updated the documentation accordingly (index.d.ts)





<!--
Link to PR: https://github.com/pedroslopez/whatsapp-web.js/pull/3571
-->