### PR TITLE
fix: change mentionedIds type from ChatId[] to string[] in Message

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -995,11 +995,7 @@ declare namespace WAWebJS {
         /** Indicates whether there are group mentions in the message body */
         groupMentions: {
             groupSubject: string;
-            groupJid: {
-                server: string;
-                user: string;
-                _serialized: string;
-            };
+            groupJid: string;
         }[],
         /** Unix timestamp for when the message was created */
         timestamp: number,

--- a/index.d.ts
+++ b/index.d.ts
@@ -991,7 +991,7 @@ declare namespace WAWebJS {
         /** MediaKey that represents the sticker 'ID' */
         mediaKey?: string,
         /** Indicates the mentions in the message body. */
-        mentionedIds: ChatId[],
+        mentionedIds: string[],
         /** Indicates whether there are group mentions in the message body */
         groupMentions: {
             groupSubject: string;

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -187,25 +187,15 @@ class Message extends Base {
         } : undefined;
 
         /**
-         * @typedef {Object} Mention
-         * @property {string} server
-         * @property {string} user
-         * @property {string} _serialized
-         */
-
-        /**
          * Indicates the mentions in the message body.
-         * @type {Mention[]}
+         * @type {string[]}
          */
         this.mentionedIds = data.mentionedJidList || [];
 
         /**
          * @typedef {Object} GroupMention
          * @property {string} groupSubject The name  of the group
-         * @property {Object} groupJid The group ID
-         * @property {string} groupJid.server
-         * @property {string} groupJid.user
-         * @property {string} groupJid._serialized
+         * @property {string} groupJid The group ID
          */
 
         /**


### PR DESCRIPTION
# PR Details

Fixes an incorrect type definition for the mentionedIds property in the index.d.ts file.

## Description

Changed the type of the mentionedIds property from ChatId[] to string[] in index.d.ts.
This change reflects the actual runtime output of the library, which returns an array of strings (user IDs), not typed ChatIds.

![image_2025-06-02_171501776](https://github.com/user-attachments/assets/64edac7c-19f7-4fbf-9b7a-7973fe4f738d)

## Related Issue(s)

None explicitly reported.


## Motivation and Context

The current type ChatId[] is misleading and causes type errors or confusion in TypeScript projects. In practice, mentionedIds returns an array of strings representing user IDs, so this change improves developer experience and type safety. I myself lost 20 minutes to understand type is not correct. I realized it after seeing the output in console😶.

### Environment

- Library Version: 1.3.0
- Node Version: v22.16.0

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly (index.d.ts).
- [X] I have updated the usage example accordingly (example.js)