### PR TITLE
fix: `window.WWebJS.getChatModel`

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -558,7 +558,7 @@ exports.LoadUtils = () => {
             const chatWid = window.Store.WidFactory.createWid(chat.id._serialized);
             await window.Store.GroupMetadata.update(chatWid);
             chat.groupMetadata.participants._models
-                .filter(x => x.id._serialized.endsWith('@lid'))
+                .filter(x => x.id?._serialized?.endsWith('@lid'))
                 .forEach(x => { x.id = x.contact.phoneNumber; });
             model.groupMetadata = chat.groupMetadata.serialize();
             model.isReadOnly = chat.groupMetadata.announce;

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -559,7 +559,7 @@ exports.LoadUtils = () => {
             await window.Store.GroupMetadata.update(chatWid);
             chat.groupMetadata.participants._models
                 .filter(x => x.id?._serialized?.endsWith('@lid'))
-                .forEach(x => { x.id = x.contact.phoneNumber; });
+                .forEach(x => x.contact?.phoneNumber && (x.id = x.contact.phoneNumber));
             model.groupMetadata = chat.groupMetadata.serialize();
             model.isReadOnly = chat.groupMetadata.announce;
         }


### PR DESCRIPTION
### The PR fixes an error thrown in `window.WWebJS.getChatModel` in `.filter(x => x.id._serialized.endsWith('@lid'))` where `x.id` is `undefined`.

fixes #3584