### PR TITLE
fix: `GroupChat.setPicture`

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -849,13 +849,13 @@ exports.LoadUtils = () => {
 
         const chatWid = window.Store.WidFactory.createWid(chatid);
         try {
-            const collection = window.Store.ProfilePicThumb.get(chatid);
-            if (!collection.canSet()) return;
+            const collection = window.Store.ProfilePicThumb.get(chatid) || await window.Store.ProfilePicThumb.find(chatId);
+            if (!collection?.canSet()) return false;
 
             const res = await window.Store.GroupUtils.sendSetPicture(chatWid, thumbnail, profilePic);
             return res ? res.status === 200 : false;
         } catch (err) {
-            if(err.name === 'ServerStatusCodeError') return false;
+            if (err.name === 'ServerStatusCodeError') return false;
             throw err;
         }
     };

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -843,13 +843,13 @@ exports.LoadUtils = () => {
         });
     };
 
-    window.WWebJS.setPicture = async (chatid, media) => {
+    window.WWebJS.setPicture = async (chatId, media) => {
         const thumbnail = await window.WWebJS.cropAndResizeImage(media, { asDataUrl: true, mimetype: 'image/jpeg', size: 96 });
         const profilePic = await window.WWebJS.cropAndResizeImage(media, { asDataUrl: true, mimetype: 'image/jpeg', size: 640 });
 
-        const chatWid = window.Store.WidFactory.createWid(chatid);
+        const chatWid = window.Store.WidFactory.createWid(chatId);
         try {
-            const collection = window.Store.ProfilePicThumb.get(chatid) || await window.Store.ProfilePicThumb.find(chatId);
+            const collection = window.Store.ProfilePicThumb.get(chatId) || await window.Store.ProfilePicThumb.find(chatId);
             if (!collection?.canSet()) return false;
 
             const res = await window.Store.GroupUtils.sendSetPicture(chatWid, thumbnail, profilePic);


### PR DESCRIPTION
# PR Details

Fix for the `GroupChat.setPicture` function.

## Description

The PR fixes an issue where the object returned from `ProfilePicThumb` is `undefined` when it's not present in the cache.

## How Has This Been Tested

```js
// client initialization...

client.on('ready', async () => {
    const pic = MessageMedia.fromFilePath(pathToFile);
    console.log(await (await client.getChatById(chatId)).setPicture(pic)); // true
});
```

## You can try the fix by running one of the following commands:
- **NPM**
```powershell
npm install github:alechkos/whatsapp-web.js#fix-set-grp-picture
```
- **YARN**
```powershell
yarn add github:alechkos/whatsapp-web.js#fix-set-grp-picture
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] My code follows the code style of this project.