### PR TITLE
Fixed client.sendMessage(chatId, message) no response return #3609

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -28,7 +28,7 @@ exports.LoadUtils = () => {
 
         let mediaOptions = {};
         if (options.media) {
-            mediaOptions =  options.sendMediaAsSticker && !isChannel
+            mediaOptions = options.sendMediaAsSticker && !isChannel
                 ? await window.WWebJS.processStickerData(options.media)
                 : await window.WWebJS.processMediaData(options.media, {
                     forceSticker: options.sendMediaAsSticker,
@@ -63,7 +63,7 @@ exports.LoadUtils = () => {
                     throw new Error('Could not get the quoted message.');
                 }
             }
-            
+
             delete options.ignoreQuoteErrors;
             delete options.quotedMessageId;
         }
@@ -163,7 +163,7 @@ exports.LoadUtils = () => {
                     preview = preview.data;
                     preview.preview = true;
                     preview.subtype = 'url';
-                    options = {...options, ...preview};
+                    options = { ...options, ...preview };
                 }
             }
         }
@@ -265,7 +265,7 @@ exports.LoadUtils = () => {
             ...botOptions,
             ...extraOptions
         };
-        
+
         // Bot's won't reply if canonicalUrl is set (linking)
         if (botOptions) {
             delete message.canonicalUrl;
@@ -302,13 +302,24 @@ exports.LoadUtils = () => {
         }
 
         await window.Store.SendMessage.addAndSendMsgToChat(chat, message);
-        return window.Store.Msg.get(newMsgKey._serialized);
+
+        const waitForMsg = async (msgId, attempts = 10, delay = 100) => {
+            for (let i = 0; i < attempts; i++) {
+                const msg = window.Store.Msg.get(msgId);
+                if (msg) return msg;
+                await new Promise(res => setTimeout(res, delay));
+            }
+            return null;
+        };
+
+        return await waitForMsg(newMsgId._serialized);
+
     };
-	
+
     window.WWebJS.editMessage = async (msg, content, options = {}) => {
         const extraOptions = options.extraOptions || {};
         delete options.extraOptions;
-        
+
         if (options.mentionedJidList) {
             options.mentionedJidList = await Promise.all(
                 options.mentionedJidList.map(async (id) => {
@@ -400,11 +411,11 @@ exports.LoadUtils = () => {
             isPtt: forceVoice,
             asDocument: forceDocument
         };
-      
+
         if (forceMediaHd && file.type.indexOf('image/') === 0) {
             mediaParams.maxDimension = 2560;
         }
-      
+
         const mediaPrep = window.Store.MediaPrep.prepRawMedia(opaqueData, mediaParams);
         const mediaData = await mediaPrep.waitForPrep();
         const mediaObject = window.Store.MediaObject.getOrCreateMediaObject(mediaData.filehash);
@@ -764,17 +775,17 @@ exports.LoadUtils = () => {
         chatId = window.Store.WidFactory.createWid(chatId);
 
         switch (state) {
-        case 'typing':
-            await window.Store.ChatState.sendChatStateComposing(chatId);
-            break;
-        case 'recording':
-            await window.Store.ChatState.sendChatStateRecording(chatId);
-            break;
-        case 'stop':
-            await window.Store.ChatState.sendChatStatePaused(chatId);
-            break;
-        default:
-            throw 'Invalid chatstate';
+            case 'typing':
+                await window.Store.ChatState.sendChatStateComposing(chatId);
+                break;
+            case 'recording':
+                await window.Store.ChatState.sendChatStateRecording(chatId);
+                break;
+            case 'stop':
+                await window.Store.ChatState.sendChatStatePaused(chatId);
+                break;
+            default:
+                throw 'Invalid chatstate';
         }
 
         return true;
@@ -843,7 +854,7 @@ exports.LoadUtils = () => {
 
         options = Object.assign({ size: 640, mimetype: media.mimetype, quality: .75, asDataUrl: false }, options);
 
-        const img = await new Promise ((resolve, reject) => {
+        const img = await new Promise((resolve, reject) => {
             const img = new Image();
             img.onload = () => resolve(img);
             img.onerror = reject;
@@ -898,11 +909,11 @@ exports.LoadUtils = () => {
             const res = await window.Store.GroupUtils.requestDeletePicture(chatWid);
             return res ? res.status === 200 : false;
         } catch (err) {
-            if(err.name === 'ServerStatusCodeError') return false;
+            if (err.name === 'ServerStatusCodeError') return false;
             throw err;
         }
     };
-    
+
     window.WWebJS.getProfilePicThumbToBase64 = async (chatWid) => {
         const profilePicCollection = await window.Store.ProfilePicThumb.find(chatWid);
 
@@ -1030,7 +1041,7 @@ exports.LoadUtils = () => {
         }));
 
         const groupJid = window.Store.WidToJid.widToGroupJid(groupWid);
-        
+
         const _getSleepTime = (sleep) => {
             if (!Array.isArray(sleep) || (sleep.length === 2 && sleep[0] === sleep[1])) {
                 return sleep;
@@ -1122,7 +1133,7 @@ exports.LoadUtils = () => {
         const response = await window.Store.pinUnpinMsg(message, action, duration);
         return response.messageSendResult === 'OK';
     };
-    
+
     window.WWebJS.getStatusModel = status => {
         const res = status.serialize();
         delete res._msgs;

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -312,7 +312,7 @@ exports.LoadUtils = () => {
             return null;
         };
 
-        return await waitForMsg(newMsgId._serialized);
+        return await waitForMsg(newMsgKey._serialized);
 
     };
 


### PR DESCRIPTION
# PR Details

## Description

This PR introduces a fix to the `sendMessage` method to address a critical issue where the function may return `undefined` immediately after attempting to send a message. This often causes errors when calling `getMessageModel()` due to trying to access `.serialize` on an undefined object.

The issue occurs because `Store.Msg.get(msgId)` is called immediately after sending the message via `addAndSendMsgToChat()`, without waiting for the message to be properly registered in the message store.

The fix implements a lightweight polling mechanism (`waitForMsg`) that retries fetching the message from the store until it becomes available, or until a short timeout is reached.

## Related Issue(s)

<!-- Uncomment the line below and replace with issue number if applicable -->
<!-- closes #XXXX -->

## Motivation and Context

This change is required to prevent runtime errors when sending messages, particularly in high-speed or concurrent environments where the message object may not be immediately available in the internal store after sending.

It also improves stability and reliability when using `sendMessage` in automated environments or integrations.

## How Has This Been Tested

- Patched and tested in a production-level implementation that interacts with `sendMessage`.
- Verified message availability using WhatsApp Web store objects directly via Puppeteer.
- Confirmed error no longer occurs after applying the retry mechanism.

### Environment

- Machine OS: Windows 11
- Phone OS: Android 13
- Library Version: whatsapp-web.js v1.23.0 (patched)
- WhatsApp Web Version: 2.2412.54
- Puppeteer Version: 21.3.8
- Browser Type and Version: Chromium 124
- Node Version: 20.x

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js).
