### PR TITLE
Fix TS2371 error in requestPairingCode type declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -160,7 +160,7 @@ declare namespace WAWebJS {
          * @param showNotification - Show notification to pair on phone number
          * @returns {Promise<string>} - Returns a pairing code in format "ABCDEFGH"
          */
-        requestPairingCode(phoneNumber: string, showNotification = true): Promise<string>
+        requestPairingCode(phoneNumber: string, showNotification?: boolean): Promise<string>
 
         /** Force reset of connection state for the client */
         resetState(): Promise<void>


### PR DESCRIPTION
# PR Details

Fixes a TypeScript declaration error in the `requestPairingCode` method.

## Description

The `.d.ts` file included a default parameter in the method signature:

```
requestPairingCode(phoneNumber: string, showNotification = true): Promise<string>;
```

This syntax is invalid in TypeScript declaration files and causes the following build error in projects using TypeScript:

```
TS2371: A parameter initializer is only allowed in a function or constructor implementation.
```

The fix is to change the declaration to:

```
requestPairingCode(phoneNumber: string, showNotification?: boolean): Promise<string>;
```

This preserves the optional behavior while fixing the type error.

## Related Issue(s)

Closes #3371

## Motivation and Context

Many users (myself included) are unable to compile TypeScript projects that depend on `whatsapp-web.js`. This fix resolves the issue cleanly without affecting runtime functionality.

## How Has This Been Tested

Built a simple Node.js + TypeScript app using this local change. The compilation now succeeds.

### Environment

- Machine OS: Windows 11
- Phone OS: Android 15
- Library Version: 1.31.0
- Node Version: 22.x

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js) — not needed for this type-level fix.
