### PR TITLE
Fix send seen chat

### DIFF
--- a/src/util/Injected/Store.js
+++ b/src/util/Injected/Store.js
@@ -99,6 +99,7 @@ exports.ExposeStore = () => {
     window.Store.AddonReactionTable = window.require('WAWebAddonReactionTableMode').reactionTableMode;
     window.Store.ChatGetters = window.require('WAWebChatGetters');
     window.Store.UploadUtils = window.require('WAWebUploadManager');
+    window.Store.WAWebStreamModel = window.require('WAWebStreamModel');
     
     window.Store.Settings = {
         ...window.require('WAWebUserPrefsGeneral'),

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -17,6 +17,7 @@ exports.LoadUtils = () => {
     window.WWebJS.sendSeen = async (chatId) => {
         const chat = await window.WWebJS.getChat(chatId, { getAsModel: false });
         if (chat) {
+            window.Store.WAWebStreamModel.Stream.markAvailable();
             await window.Store.SendSeen.sendSeen(chat);
             return true;
         }


### PR DESCRIPTION
Now the app requires `Stream` to be `available` when you `sendSeen` (aka read messages) in the chat.
We can do it by calling `markAvailable` on `WAWebStreamModel`

:information_source: `sendPresenceAvailable` doesn't set `Stream` as `available`, so may be we'll need to rewrite `sendPresenceAvailable` as well to use the stream model (it sends the available presence tag and mark the stream as available)

It fixes #3540, fixes #2777
