### PR TITLE
Fix CreateGroup and addParticipant

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1555,8 +1555,17 @@ class Client extends EventEmitter {
 
             for (const participant of participants) {
                 const pWid = window.Store.WidFactory.createWid(participant);
-                if ((await window.Store.QueryExist(pWid))?.wid) participantWids.push(pWid);
-                else failedParticipants.push(participant);
+                if ((await window.Store.QueryExist(pWid))?.wid){
+                    const participantArg = { 
+                        phoneNumber: pWid.server == 'lid' 
+                            ? window.Store.LidUtils.getPhoneNumber(pWid)
+                            : pWid 
+                    };
+                    participantWids.push(participantArg);
+                } 
+                else{
+                    failedParticipants.push(participant);
+                }
             }
 
             parentGroupId && (parentGroupWid = window.Store.WidFactory.createWid(parentGroupId));


### PR DESCRIPTION
# PR Details

Fix to create groups passing a list of participants

## Description

People are struggling to create groups by passing a list of participants

## Related Issue(s)

Fixes #3666, fixes #3644

## Motivation and Context

<!-- Optional --->
<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

```js
// client initialization...

client.on('ready', async () => {

    const createGroup = await client.createGroup("TEST Group",['xxxxx@lid','xxxx@c.us']);
});
```

## You can try the fix by running one of the following commands:

- NPM
`npm install github:BenyFilho/whatsapp-web.js#fix-createGroup-addParticipant`

- YARN
`yarn add github:BenyFilho/whatsapp-web.js#fix-createGroup-addParticipant`


## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).