### PR TITLE
fix(types): update mentions type in MessageEditOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1296,8 +1296,8 @@ declare namespace WAWebJS {
     export interface MessageEditOptions {
         /** Show links preview. Has no effect on multi-device accounts. */
         linkPreview?: boolean
-        /** Contacts that are being mentioned in the message */
-        mentions?: Contact[]
+        /** User IDs of user that will be mentioned in the message */
+        mentions?: string[]
         /** Extra options */
         extra?: any
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1296,7 +1296,7 @@ declare namespace WAWebJS {
     export interface MessageEditOptions {
         /** Show links preview. Has no effect on multi-device accounts. */
         linkPreview?: boolean
-        /** User IDs of user that will be mentioned in the message */
+        /** User IDs of users that being mentioned in the message */
         mentions?: string[]
         /** Extra options */
         extra?: any


### PR DESCRIPTION
# PR Details

Update the MessageEditOptions types for `mentions` which doesn't require a `Contact` array of objects anymore  https://github.com/pedroslopez/whatsapp-web.js/pull/2166

## Description

N/A

## Related Issue(s)

https://github.com/pedroslopez/whatsapp-web.js/pull/2166

## Motivation and Context

N/A

## How Has This Been Tested

Types were out of date with updated code, so no further test necessary.

### Environment

<!-- Include details of your testing environment: -->
- Machine OS: Mac
- Phone OS: <!-- The operation system of a phone you used to check the the PR functionality on. -->
- Library Version: 1.31.0
- WhatsApp Web Version: 2.3000.1025611204
- Puppeteer Version:
- Browser Type and Version: <!-- Chromium XX | Google Chrome XX | other (provide the type and version) -->
- Node Version: 11.2.0

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [ ] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)