### PR TITLE
fix: return poll vote reactions

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -767,13 +767,15 @@ class Client extends EventEmitter {
                 const ogPollVoteMethod = pollVoteModule.bulkUpsert;
                 pollVoteModule.bulkUpsert = ((...args) => {
                     window.onPollVoteEvent(args[0].map(vote => {
+                        
                         const msgKey = vote.id;
-                        const parentMsgKey = vote.reactionParentKey;
-                        const timestamp = vote.reactionTimestamp / 1000;
+                        const parentMsgKey = vote.pollUpdateParentKey;
+                        const timestamp = vote.t / 1000;
                         const sender = vote.author ?? vote.from;
                         const senderUserJid = sender._serialized;
+                        const parentMessage = window.Store.Msg.get(parentMsgKey._serialized);
 
-                        return {...vote, msgKey, parentMsgKey, senderUserJid, timestamp };
+                        return {...vote, msgKey, parentMsgKey, senderUserJid, timestamp,parentMessage };
                     }));
 
                     return ogPollVoteMethod(...args);

--- a/src/Client.js
+++ b/src/Client.js
@@ -706,14 +706,15 @@ class Client extends EventEmitter {
             this.emit(Events.MESSAGE_CIPHERTEXT, new Message(this, msg));
         });
 
-        await exposeFunctionIfAbsent(this.pupPage, 'onPollVoteEvent', (vote) => {
-            const _vote = new PollVote(this, vote);
-            /**
-             * Emitted when some poll option is selected or deselected,
-             * shows a user's current selected option(s) on the poll
-             * @event Client#vote_update
-             */
-            this.emit(Events.VOTE_UPDATE, _vote);
+        await exposeFunctionIfAbsent(this.pupPage, 'onPollVoteEvent', (votes) => {
+            for (const vote of votes) {
+                /**
+                 * Emitted when some poll option is selected or deselected,
+                 * shows a user's current selected option(s) on the poll
+                 * @event Client#vote_update
+                 */
+                this.emit(Events.VOTE_UPDATE, vote);
+            }
         });
 
         await this.pupPage.evaluate(() => {

--- a/src/Client.js
+++ b/src/Client.js
@@ -741,10 +741,6 @@ class Client extends EventEmitter {
                 }
             });
             window.Store.Chat.on('change:unreadCount', (chat) => {window.onChatUnreadCountEvent(chat);});
-            /* window.Store.PollVote.on('add', async (vote) => {
-                const pollVoteModel = await window.WWebJS.getPollVoteModel(vote);
-                pollVoteModel && window.onPollVoteEvent(pollVoteModel);
-            }); */
 
             if (window.compareWwebVersions(window.Debug.VERSION, '>=', '2.3000.1014111620')) {
                 const module = window.Store.AddonReactionTable;
@@ -762,24 +758,6 @@ class Client extends EventEmitter {
 
                     return ogMethod(...args);
                 }).bind(module);
-
-                /* const pollVoteModule = window.Store.AddonPollVoteTable;
-                const ogPollVoteMethod = pollVoteModule.bulkUpsert;
-                pollVoteModule.bulkUpsert = ((...args) => {
-                    window.onPollVoteEvent(args[0].map(vote => {
-                        
-                        const msgKey = vote.id;
-                        const parentMsgKey = vote.pollUpdateParentKey;
-                        const timestamp = vote.t / 1000;
-                        const sender = vote.author ?? vote.from;
-                        const senderUserJid = sender._serialized;
-                        const parentMessage = window.Store.Msg.get(parentMsgKey._serialized) || (await window.Store.Msg.getMessagesById([parentMsgKey._serialized]))?.messages?.[0];
-
-                        return {...vote, msgKey, parentMsgKey, senderUserJid, timestamp,parentMessage };
-                    }));
-
-                    return ogPollVoteMethod(...args);
-                }).bind(pollVoteModule); */
 
                 const pollVoteModule = window.Store.AddonPollVoteTable;
                 const ogPollVoteMethod = pollVoteModule.bulkUpsert;

--- a/src/Client.js
+++ b/src/Client.js
@@ -713,7 +713,7 @@ class Client extends EventEmitter {
                  * shows a user's current selected option(s) on the poll
                  * @event Client#vote_update
                  */
-                this.emit(Events.VOTE_UPDATE, vote);
+                this.emit(Events.VOTE_UPDATE, new PollVote(this, vote));
             }
         });
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -801,6 +801,7 @@ class Client extends EventEmitter {
                         return {
                             ...vote,
                             msgKey,
+                            sender,
                             parentMsgKey,
                             senderUserJid,
                             timestamp,

--- a/src/structures/PollVote.js
+++ b/src/structures/PollVote.js
@@ -34,25 +34,22 @@ class PollVote extends Base {
          * may occur when they deselected all poll options
          * @type {SelectedPollOption[]}
          */
-        if(data.selectedOptionLocalIds.length > 0){
-            
+        if (data.selectedOptionLocalIds.length > 0) {
             if(data.parentMessage) { // temporary failsafe
                 this.selectedOptions = data.selectedOptionLocalIds.map((e) => ({
                     name: data.parentMessage.pollOptions.find((x) => x.localId === e).name,
                     localId: e
                 }));
-            }else{
+            } else {
                 this.selectedOptions = data.selectedOptionLocalIds.map((e) => ({
                     name: undefined,
                     localId: e
                 }));
             }
-        }else{
+        } else {
             this.selectedOptions = [];
         }
         
-        
-
         /**
          * Timestamp the option was selected or deselected at
          * @type {number}

--- a/src/structures/PollVote.js
+++ b/src/structures/PollVote.js
@@ -34,13 +34,24 @@ class PollVote extends Base {
          * may occur when they deselected all poll options
          * @type {SelectedPollOption[]}
          */
-        this.selectedOptions =
-            data.selectedOptionLocalIds.length > 0
-                ? data.selectedOptionLocalIds.map((e) => ({
+        if(data.selectedOptionLocalIds.length > 0){
+            
+            if(data.parentMessage) { // temporary failsafe
+                this.selectedOptions = data.selectedOptionLocalIds.map((e) => ({
                     name: data.parentMessage.pollOptions.find((x) => x.localId === e).name,
                     localId: e
-                }))
-                : [];
+                }));
+            }else{
+                this.selectedOptions = data.selectedOptionLocalIds.map((e) => ({
+                    name: undefined,
+                    localId: e
+                }));
+            }
+        }else{
+            this.selectedOptions = [];
+        }
+        
+        
 
         /**
          * Timestamp the option was selected or deselected at
@@ -53,6 +64,12 @@ class PollVote extends Base {
          * @type {Message}
          */
         this.parentMessage = new Message(this.client, data.parentMessage);
+
+        /**
+         * The poll creation message id
+         * @type {Object}
+         */
+        this.parentMsgKey =  data.parentMsgKey;
 
         return super._patch(data);
     }

--- a/src/util/Injected/Store.js
+++ b/src/util/Injected/Store.js
@@ -96,6 +96,7 @@ exports.ExposeStore = () => {
     window.Store.DeviceList = window.require('WAWebApiDeviceList');
     window.Store.HistorySync = window.require('WAWebSendNonMessageDataRequest');
     window.Store.AddonReactionTable = window.require('WAWebAddonReactionTableMode').reactionTableMode;
+    window.Store.AddonPollVoteTable = window.require('WAWebAddonPollVoteTableMode').pollVoteTableMode;
     window.Store.PinnedMsgUtils = window.require('WAWebPinInChatSchema');
     window.Store.ChatGetters = window.require('WAWebChatGetters');
     window.Store.PinnedMsgUtils = window.require('WAWebSendPinMessageAction');

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -522,15 +522,6 @@ exports.LoadUtils = () => {
         return msg;
     };
 
-    window.WWebJS.getPollVoteModel = async (vote) => {
-        const _vote = vote.serialize();
-        if (!vote.parentMsgKey) return null;
-        const msg =
-            window.Store.Msg.get(vote.parentMsgKey) || (await window.Store.Msg.getMessagesById([vote.parentMsgKey]))?.messages?.[0];
-        msg && (_vote.parentMessage = window.WWebJS.getMessageModel(msg));
-        return _vote;
-    };
-
     window.WWebJS.getChat = async (chatId, { getAsModel = true } = {}) => {
         const isChannel = /@\w*newsletter\b/.test(chatId);
         const chatWid = window.Store.WidFactory.createWid(chatId);


### PR DESCRIPTION
# PR Details

## Description

The PR fixes the event trigger for poll votes.
Implemented by @tuyuribr and me.

## How Has This Been Tested

```js
const { /*...*/, Poll } = require('whatsapp-web.js');

client.on('ready', async () => {
    // First send the poll as usual:
    let chatId = '123456789@g.us';
    await client.sendMessage(chatId, new Poll('Winter or Summer?', ['Winter', 'Summer']);
});

// And listen to votes:
client.on('vote_update', (vote) => {
    console.log(vote, '\n');
});

client.initialize();
```

## Related Issue(s)

fixes #3456

## You can try the fix by running one of the following commands:
- **NPM**
```powershell
npm install github:alechkos/whatsapp-web.js#fix-poll-vote-event
```
- **YARN**
```powershell
yarn add github:alechkos/whatsapp-web.js#fix-poll-vote-event
```

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)