### PR TITLE
feat: Add getStaredMessages and getMessagesByType functionalities to chat and channel.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1696,7 +1696,7 @@ declare namespace WAWebJS {
         /** Gets instances of all pinned messages in a chat */
         getPinnedMessages: () => Promise<[Message]|[]>
         /** Gets instances of all stared messages in a chat*/
-        getStaredMessages: () => Promise<[Message]|[]>
+        getStaredMessages: (searchOptions: MessageSearchOptions) => Promise<[Message]|[]>
         /** Gets instances of all messages in a chat by it's type*/
         getMessagesByType: (searchOptions: MessageSearchByTypeOptions) => Promise<[Message]|[]>
         /** Sync history conversation of the Chat */
@@ -1774,7 +1774,7 @@ declare namespace WAWebJS {
         /** Deletes the channel you created */
         deleteChannel(): Promise<boolean>;
         /** Gets instances of all stared messages in a channel*/
-        getStaredMessages: () => Promise<[Message]|[]>;
+        getStaredMessages: (searchOptions: MessageSearchOptions) => Promise<[Message]|[]>;
         /** Gets instances of all messages in a channel by it's type*/
         getMessagesByType: (searchOptions: MessageSearchByTypeOptions) => Promise<[Message]|[]>;
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1697,6 +1697,8 @@ declare namespace WAWebJS {
         getPinnedMessages: () => Promise<[Message]|[]>
         /** Gets instances of all stared messages in a chat*/
         getStaredMessages: () => Promise<[Message]|[]>
+        /** Gets instances of all messages in a chat by it's type*/
+        getMessagesByType: (searchOptions: MessageSearchByTypeOptions) => Promise<[Message]|[]>
         /** Sync history conversation of the Chat */
         syncHistory: () => Promise<boolean>
     }
@@ -1771,6 +1773,10 @@ declare namespace WAWebJS {
         transferChannelOwnership(newOwnerId: string, options?: TransferChannelOwnershipOptions): Promise<boolean>;
         /** Deletes the channel you created */
         deleteChannel(): Promise<boolean>;
+        /** Gets instances of all stared messages in a channel*/
+        getStaredMessages: () => Promise<[Message]|[]>;
+        /** Gets instances of all messages in a channel by it's type*/
+        getMessagesByType: (searchOptions: MessageSearchByTypeOptions) => Promise<[Message]|[]>;
     }
 
     /** Options for transferring a channel ownership to another user */
@@ -1801,10 +1807,19 @@ declare namespace WAWebJS {
          * Set this to Infinity to load all messages.
          */
         limit?: number
+
         /**
         * Return only messages from the bot number or vise versa. To get all messages, leave the option undefined.
         */
         fromMe?: boolean
+    }
+
+    export interface MessageSearchByTypeOptions extends MessageSearchOptions {
+        /**
+         * The message type to return, if undefined then returns the all the messages. 
+         */
+        messageFormat?: MessageTypes
+        
     }
 
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1818,7 +1818,7 @@ declare namespace WAWebJS {
         /**
          * The message type to return, if undefined then returns the all the messages. 
          */
-        messageFormat?: MessageTypes
+        messageType?: MessageTypes
         
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1815,7 +1815,7 @@ declare namespace WAWebJS {
 
     export interface MessageSearchByTypeOptions extends MessageSearchOptions {
         /**
-         * The message type to return, if undefined then returns the all the messages. 
+         * The message type to return, if undefined then returns an empty array. 
          */
         messageType?: MessageTypes
         

--- a/index.d.ts
+++ b/index.d.ts
@@ -1695,6 +1695,8 @@ declare namespace WAWebJS {
         changeLabels: (labelIds: Array<string | number>) => Promise<void>
         /** Gets instances of all pinned messages in a chat */
         getPinnedMessages: () => Promise<[Message]|[]>
+        /** Gets instances of all stared messages in a chat*/
+        getStaredMessages: () => Promise<[Message]|[]>
         /** Sync history conversation of the Chat */
         syncHistory: () => Promise<boolean>
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1807,7 +1807,6 @@ declare namespace WAWebJS {
          * Set this to Infinity to load all messages.
          */
         limit?: number
-
         /**
         * Return only messages from the bot number or vise versa. To get all messages, leave the option undefined.
         */

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -380,7 +380,7 @@ class Channel extends Base {
     }
 
     /**
-     * Gets instances of all stared messages in a chat
+     * Gets instances of all stared messages in a channel
      * @param {Object} searchOptions Options for searching. Includes limit and fromMe.
      * @param {Number} [searchOptions.limit] The amount of messages to return. If no limit is specified, the available messages will be returned. Note that the actual number of returned messages may be smaller if there aren't enough messages in the conversation. Set this to Infinity to load all messages.
      * @param {Boolean} [searchOptions.fromMe] Return only messages from the bot number or vise versa. To get all messages, leave the option undefined.
@@ -411,7 +411,7 @@ class Channel extends Base {
     }
 
     /**
-     * Fetches messages by their type in a chat
+     * Fetches messages by their type in a channel
      * @param {Object} searchOptions Options for searching. Includes limit, fromMe and messageType. If the searchOptions is undefined then it returns empty array.
      * @param {Number} [searchOptions.limit] The amount of messages to return. If no limit is specified, the available messages will be returned. Note that the actual number of returned messages may be smaller if there aren't enough messages in the conversation. Set this to Infinity to load all messages.
      * @param {Boolean} [searchOptions.fromMe] Return only messages from the bot number or vise versa. To get all messages, leave the option undefined.

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -380,11 +380,20 @@ class Channel extends Base {
     }
 
     /**
-     * Gets instances of all stared messages in a channel
+     * Gets instances of all stared messages in a chat
+     * @param {Object} searchOptions Options for searching. Includes limit and fromMe.
+     * @param {Number} [searchOptions.limit] The amount of messages to return. If no limit is specified, the available messages will be returned. Note that the actual number of returned messages may be smaller if there aren't enough messages in the conversation. Set this to Infinity to load all messages.
+     * @param {Boolean} [searchOptions.fromMe] Return only messages from the bot number or vise versa. To get all messages, leave the option undefined.
      * @returns {Promise<[Message]|[]>} 
      */
-    async getStaredMessages() {
-        const messages = await this.fetchMessages({fromMe: true});
+    async getStaredMessages(searchOptions) {
+        let messages
+
+        if (searchOptions == undefined) {
+            messages = await this.fetchMessages();
+        } else {
+            messages = await this.fetchMessages({limit: searchOptions.limit, fromMe: searchOptions.fromMe});
+        }
 
         if (messages.length == 0) {
             return [];
@@ -402,26 +411,26 @@ class Channel extends Base {
     }
 
     /**
-     * Fetches messages by their type in a channel
-     * @param {Object} searchOptions Options for searching. Includes limit, fromMe and messageType.
+     * Fetches messages by their type in a chat
+     * @param {Object} searchOptions Options for searching. Includes limit, fromMe and messageType. If the searchOptions is undefined then it returns empty array.
      * @param {Number} [searchOptions.limit] The amount of messages to return. If no limit is specified, the available messages will be returned. Note that the actual number of returned messages may be smaller if there aren't enough messages in the conversation. Set this to Infinity to load all messages.
      * @param {Boolean} [searchOptions.fromMe] Return only messages from the bot number or vise versa. To get all messages, leave the option undefined.
-     * @param {MessageTypes} [searchOptions.messageType] Returns only the messages of a certain type. If undefined returns all messages fetched.
+     * @param {MessageTypes} [searchOptions.messageType] The type of the message to be returned. If undefined returns empty array.
      * @returns {Promise<[Message]|[]>}
      */
     async getMessagesByType(searchOptions) {
-        const messages = await this.fetchMessages({limit: searchOptions.limit , messageType: searchOptions.messageType});
-        
-        if (messages.length == 0 || searchOptions.messageType == undefined) {
+        if (searchOptions == undefined) return [];
+        if (searchOptions.messageType == undefined) return [];
+
+        let messages = await this.fetchMessages({limit: searchOptions.limit, fromMe: searchOptions.fromMe});
+
+        if (messages.length == 0) {
             return messages;
         }
 
         let subArray = new Array();
 
         for (let message of messages) {
-            if (message.type == undefined) {
-                continue;
-            }
             if (message.type == searchOptions.messageType) {
                 subArray.push(message);
             }   

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { MessageTypes } = require('../util/Constants');
 const Base = require('./Base');
 const Message = require('./Message');
 
@@ -376,6 +377,57 @@ class Channel extends Base {
                 throw err;
             }
         }, this.id._serialized, action);
+    }
+
+    /**
+     * Gets instances of all stared messages in a channel
+     * @returns {Promise<[Message]|[]>} 
+     */
+    async getStaredMessages() {
+        const messages = await this.fetchMessages({fromMe: true});
+
+        if (messages.length == 0) {
+            return [];
+        }
+
+        let staredMessages = new Array();
+
+        for (let message of messages) {
+            if (message.isStarred) {
+                staredMessages.push(message);
+            }
+        }
+
+        return staredMessages;
+    }
+
+    /**
+     * Fetches messages by their type in a channel
+     * @param {Object} searchOptions Options for searching. Includes limit, fromMe and messageType.
+     * @param {Number} [searchOptions.limit] The amount of messages to return. If no limit is specified, the available messages will be returned. Note that the actual number of returned messages may be smaller if there aren't enough messages in the conversation. Set this to Infinity to load all messages.
+     * @param {Boolean} [searchOptions.fromMe] Return only messages from the bot number or vise versa. To get all messages, leave the option undefined.
+     * @param {MessageTypes} [searchOptions.messageType] Returns only the messages of a certain type. If undefined returns all messages fetched.
+     * @returns {Promise<[Message]|[]>}
+     */
+    async getMessagesByType(searchOptions) {
+        const messages = await this.fetchMessages({limit: searchOptions.limit , messageType: searchOptions.messageType});
+        
+        if (messages.length == 0 || searchOptions.messageType == undefined) {
+            return messages;
+        }
+
+        let subArray = new Array();
+
+        for (let message of messages) {
+            if (message.type == undefined) {
+                continue;
+            }
+            if (message.type == searchOptions.messageType) {
+                subArray.push(message);
+            }   
+        }
+
+        return subArray;
     }
 }
 

--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { MessageTypes } = require('../util/Constants');
 const Base = require('./Base');
 const Message = require('./Message');
 
@@ -295,6 +296,10 @@ class Chat extends Base {
         return this.client.syncHistory(this.id._serialized);
     }
 
+    /**
+     * Gets instances of all stared messages in a chat
+     * @returns {Promise<[Message]|[]>} 
+     */
     async getStaredMessages() {
         const messages = await this.fetchMessages({fromMe: true});
 
@@ -306,11 +311,40 @@ class Chat extends Base {
 
         for (let message of messages) {
             if (message.isStarred) {
-                staredMessages.push(message)
+                staredMessages.push(message);
             }
         }
 
         return staredMessages;
+    }
+
+    /**
+     * Fetches messages by their type in a chat
+     * @param {Object} searchOptions Options for searching. Includes limit, fromMe and messageType.
+     * @param {Number} [searchOptions.limit] The amount of messages to return. If no limit is specified, the available messages will be returned. Note that the actual number of returned messages may be smaller if there aren't enough messages in the conversation. Set this to Infinity to load all messages.
+     * @param {Boolean} [searchOptions.fromMe] Return only messages from the bot number or vise versa. To get all messages, leave the option undefined.
+     * @param {MessageTypes} [searchOptions.messageType] Returns only the messages of a certain type. If undefined returns all messages fetched.
+     * @returns {Promise<[Message]|[]>}
+     */
+    async getMessagesByType(searchOptions) {
+        const messages = await this.fetchMessages({limit: searchOptions.limit , messageType: searchOptions.messageType});
+        
+        if (messages.length == 0 || searchOptions.messageType == undefined) {
+            return messages;
+        }
+
+        let subArray = new Array();
+
+        for (let message of messages) {
+            if (message.type == undefined) {
+                continue;
+            }
+            if (message.type == searchOptions.messageType) {
+                subArray.push(message);
+            }   
+        }
+
+        return subArray;
     }
 }
 

--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -294,6 +294,24 @@ class Chat extends Base {
     async syncHistory() {
         return this.client.syncHistory(this.id._serialized);
     }
+
+    async getStaredMessages() {
+        const messages = await this.fetchMessages({fromMe: true});
+
+        if (messages.length == 0) {
+            return [];
+        }
+
+        let staredMessages = new Array();
+
+        for (let message of messages) {
+            if (message.isStarred) {
+                staredMessages.push(message)
+            }
+        }
+
+        return staredMessages;
+    }
 }
 
 module.exports = Chat;

--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -298,10 +298,19 @@ class Chat extends Base {
 
     /**
      * Gets instances of all stared messages in a chat
+     * @param {Object} searchOptions Options for searching. Includes limit and fromMe.
+     * @param {Number} [searchOptions.limit] The amount of messages to return. If no limit is specified, the available messages will be returned. Note that the actual number of returned messages may be smaller if there aren't enough messages in the conversation. Set this to Infinity to load all messages.
+     * @param {Boolean} [searchOptions.fromMe] Return only messages from the bot number or vise versa. To get all messages, leave the option undefined.
      * @returns {Promise<[Message]|[]>} 
      */
-    async getStaredMessages() {
-        const messages = await this.fetchMessages({fromMe: true});
+    async getStaredMessages(searchOptions) {
+        let messages
+
+        if (searchOptions == undefined) {
+            messages = await this.fetchMessages();
+        } else {
+            messages = await this.fetchMessages({limit: searchOptions.limit, fromMe: searchOptions.fromMe});
+        }
 
         if (messages.length == 0) {
             return [];
@@ -320,25 +329,25 @@ class Chat extends Base {
 
     /**
      * Fetches messages by their type in a chat
-     * @param {Object} searchOptions Options for searching. Includes limit, fromMe and messageType.
+     * @param {Object} searchOptions Options for searching. Includes limit, fromMe and messageType. If the searchOptions is undefined then it returns empty array.
      * @param {Number} [searchOptions.limit] The amount of messages to return. If no limit is specified, the available messages will be returned. Note that the actual number of returned messages may be smaller if there aren't enough messages in the conversation. Set this to Infinity to load all messages.
      * @param {Boolean} [searchOptions.fromMe] Return only messages from the bot number or vise versa. To get all messages, leave the option undefined.
-     * @param {MessageTypes} [searchOptions.messageType] Returns only the messages of a certain type. If undefined returns all messages fetched.
+     * @param {MessageTypes} [searchOptions.messageType] The type of the message to be returned. If undefined returns empty array.
      * @returns {Promise<[Message]|[]>}
      */
     async getMessagesByType(searchOptions) {
-        const messages = await this.fetchMessages({limit: searchOptions.limit , messageType: searchOptions.messageType});
-        
-        if (messages.length == 0 || searchOptions.messageType == undefined) {
+        if (searchOptions == undefined) return [];
+        if (searchOptions.messageType == undefined) return [];
+
+        let messages = await this.fetchMessages({limit: searchOptions.limit, fromMe: searchOptions.fromMe});
+
+        if (messages.length == 0) {
             return messages;
         }
 
         let subArray = new Array();
 
         for (let message of messages) {
-            if (message.type == undefined) {
-                continue;
-            }
             if (message.type == searchOptions.messageType) {
                 subArray.push(message);
             }   


### PR DESCRIPTION
# PR Details

Summary: Adds support for getting stared messages and messages by their type in a chat or a channel.

## Description

- Introduced `getMessagesByType` and `getStaredMessages` option to  chat and channel.
- Both these functions call `fetchMessages` method of their class
- Introduced `MessageSearchByTypeOptions` interface which extends `MessageSearchOptions` adding `messageType` to the interface which is of type enum `MessageTypes` ().
- Documented the functions in the class and in `index.d.ts` with the interface just like the remaining.
- Imported `MessageTypes` enum for documentation in lines 335 of `Chat.js` and line 418 of `Channel.js`

## Related Issue(s)

#2837 enhancement

## Motivation and Context

Made these changes so that message could be fetched by their type, especially media related messages. 

[Issue](https://github.com/pedroslopez/whatsapp-web.js/issues/2837) that gave me the idea to get stared messages.

## How Has This Been Tested

```javascript
const { Client, LocalAuth, MessageTypes} = require('whatsapp-web.js');
const qrcode = require('qrcode-terminal');

const client = new Client({
    authStrategy : new LocalAuth({
        dataPath : 'session'
    })
});

client.on('ready', () => {
    console.log('Client is ready!');
});

client.on('qr', qr => {
    qrcode.generate(qr, {small: true});
});

client.initialize();

client.on('message_create', async (msg) => {
    let c = await (await msg.getChat()).getStaredMessages()
    let j = await (await msg.getChat()).getStaredMessages({fromMe: true})
    console.log("Undefined argument: " + c.length);
    console.log("from me: true " + j.length);
})

client.on('message_create', async (msg) => {
    let b = await (await msg.getChat()).getMessagesByType({fromMe: true, messageType: MessageTypes.TEXT})
    let f = await (await msg.getChat()).getMessagesByType({messageType: MessageTypes.TEXT})
    let j = await (await msg.getChat()).getMessagesByType({messageType: MessageTypes.TEXT, limit: 1})
    let m = await (await msg.getChat()).getMessagesByType();
    console.log("from me and text: " + b.length);
    console.log("Text : " + f.length);
    console.log("Limit: " + j.length);
    console.log("undefined message: " + m.length);
})
```
## You can try the changes by running one of the following commands:

- npm
```
npm install github:JestiferHarold/whatsapp-web.js
```
- yarn
```
yarn add github:JestiferHarold/whatsapp-web.js
```

### Environment

<!-- Include details of your testing environment: -->
- Machine OS: Windows 10
- Phone OS: Andriod
- Library Version: whatsapp-web.js@latest
- WhatsApp Web Version: 2.3000.1025721345
- Puppeteer Version: puppeteer@latest
- Browser Type and Version: Chromium (latest)
- Node Version: v22.17.1
## Types of changes

- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)