### PR TITLE
fix: Expose onCodeReceivedEvent function

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -144,17 +144,17 @@ class Client extends EventEmitter {
             }
 
             // Register qr/code events
+            await exposeFunctionIfAbsent(this.pupPage, 'onCodeReceivedEvent', async (code) => {
+                /**
+                * Emitted when a pairing code is received
+                * @event Client#code
+                * @param {string} code Code
+                * @returns {string} Code that was just received
+                */
+                this.emit(Events.CODE_RECEIVED, code);
+                return code;
+            });
             if (pairWithPhoneNumber.phoneNumber) {
-                await exposeFunctionIfAbsent(this.pupPage, 'onCodeReceivedEvent', async (code) => {
-                    /**
-                    * Emitted when a pairing code is received
-                    * @event Client#code
-                    * @param {string} code Code
-                    * @returns {string} Code that was just received
-                    */
-                    this.emit(Events.CODE_RECEIVED, code);
-                    return code;
-                });
                 this.requestPairingCode(pairWithPhoneNumber.phoneNumber, pairWithPhoneNumber.showNotification, pairWithPhoneNumber.intervalMs);
             } else {
                 let qrRetries = 0;


### PR DESCRIPTION
# PR Details

The `requestPairingCode` method is no longer works and throws `Evaluation failed: TypeError: window.onCodeReceivedEvent is not a function\n    at pptr://__puppeteer_evaluation_script__:20:27` error.

## Description

The `window.onCodeReceivedEvent` is being in injected only if the `pairWithPhoneNumber` option is passed to the Client instance.

## Related Issue(s)

Caused by https://github.com/pedroslopez/whatsapp-web.js/pull/3180

## Motivation and Context

The `requestPairingCode` method should work not only if new option is passed.

## How Has This Been Tested

Locally using my machine.

```
const { Client, LocalAuth } = require('whatsapp-web.js');
const client = new Client(
    {
        puppeteer: {
            args: ['--no-sandbox'],
            headless: false
        },
        authStrategy: new LocalAuth({ dataPath: "." }),
    }
);

client.on('ready', (code) => {
    client.requestPairingCode('38067XXXXXXX', true);
});

client.on('code', (code) => {
    console.log("Linking code:",code);
});

client.initialize();
```

## Types of changes

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly (index.d.ts).
- [X] I have updated the usage example accordingly (example.js)