### PR TITLE
fix: Add protocolMessageKey and fix revoked messages to preserve original before.id

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1086,7 +1086,10 @@ declare namespace WAWebJS {
         latestEditSenderTimestampMs?: number,
         /** Last edit message author */
         latestEditMsgKey?: MessageId,
-        /** Protocol message key */
+        /**
+         * Protocol message key.
+         * Can be used to retrieve the ID of an original message that was revoked.
+         */
         protocolMessageKey?: MessageId,
         /** Message buttons */
         dynamicReplyButtons?: object,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1086,6 +1086,8 @@ declare namespace WAWebJS {
         latestEditSenderTimestampMs?: number,
         /** Last edit message author */
         latestEditMsgKey?: MessageId,
+        /** Protocol message key */
+        protocolMessageKey?: MessageId,
         /** Message buttons */
         dynamicReplyButtons?: object,
         /** Selected button ID */

--- a/src/Client.js
+++ b/src/Client.js
@@ -468,6 +468,9 @@ class Client extends EventEmitter {
                 let revoked_msg;
                 if (last_message && msg.id.id === last_message.id.id) {
                     revoked_msg = new Message(this, last_message);
+
+                    if (message.protocolMessageKey)
+                        revoked_msg.id = { ...message.protocolMessageKey };                    
                 }
 
                 /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -258,7 +258,10 @@ class Message extends Base {
             this.latestEditMsgKey = data.latestEditMsgKey;
         }
         
-        /** Protocol message key */
+        /**
+         * Protocol message key.
+         * Can be used to retrieve the ID of an original message that was revoked.
+         */
         if (data.protocolMessageKey) {
             this.protocolMessageKey = data.protocolMessageKey;
         }

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -258,6 +258,11 @@ class Message extends Base {
             this.latestEditMsgKey = data.latestEditMsgKey;
         }
         
+        /** Protocol message key */
+        if (data.protocolMessageKey) {
+            this.protocolMessageKey = data.protocolMessageKey;
+        }
+
         /**
          * Links included in the message.
          * @type {Array<{link: string, isSuspicious: boolean}>}


### PR DESCRIPTION
* Add protocolMessageKey and fix revoke

# PR Details

<!-- Provide here a general summary of your changes. -->

## Description

This PR introduces support for the protocolMessageKey field in the Message model and fixes the handling of revoked messages.

When a message is revoked ("delete for everyone"), WhatsApp sends a protocolMessage referencing the original message that should be removed. That reference is exposed via protocolMessageKey.

Previously, revoked events did not provide the original message ID: both before and after had the same new ID created for the revoke message. This PR ensures that before.id is correctly patched with the protocolMessageKey, allowing it to reference the original message that was revoked.

<!-- Describe here your changes in detail. -->

## Related Issue(s)

<!-- Optional --->
<!-- If there is an issue related to the PR, link it here using a 'closes' keyword, for example: -->
<!-- closes #XXXX (where the XXXX is an issue number) -->
<!-- If there are multiple issues, link them as follows: -->
<!-- closes #XXXX closes #YYYY closes #ZZZZ -->
<!-- See more here: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
fixes #1178 

## Motivation and Context

Without this fix, listeners of the message_revoke_everyone event could not determine which message was actually deleted, even if they had previously stored the original message ID (e.g., in a database). By exposing protocolMessageKey and using it to normalize revoked messages, consumers of the library can now correctly identify the original message that was revoked.

<!-- Optional --->
<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!-- Please describe in detail how you tested your changes. -->

### Environment

<!-- Include details of your testing environment: -->
- Machine OS: Windows 11
- Phone OS: Android
- Library Version: latest (main)
- WhatsApp Web Version: latest
- Puppeteer Version: "^18.2.1"
- Browser Type and Version: Google Chrome 139.0.7258.128 
- Node Version:  v22.18.0

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).
- [x] I have updated the usage example accordingly (example.js)