### PR TITLE
fix Event Ready Again and SendMessage

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -234,7 +234,7 @@ class Client extends EventEmitter {
                      * @type {ClientInfo}
                      */
                 this.info = new ClientInfo(this, await this.pupPage.evaluate(() => {
-                    return { ...window.Store.Conn.serialize(), wid: window.Store.User.getMaybeMeUser() };
+                    return { ...window.Store.Conn.serialize(), wid: window.Store.User.getMaybeMePnUser() || window.Store.User.getMaybeMeLidUser() };
                 }));
 
                 this.interface = new InterfaceController(this);

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -839,7 +839,7 @@ exports.LoadUtils = () => {
 
     window.WWebJS.rejectCall = async (peerJid, id) => {
         peerJid = peerJid.split('@')[0] + '@s.whatsapp.net';
-        let userId = window.Store.User.getMaybeMeUser().user + '@s.whatsapp.net';
+        let userId = window.Store.User.getMaybeMePnUser().user + '@s.whatsapp.net';
         const stanza = window.Store.SocketWap.wap('call', {
             id: window.Store.SocketWap.generateId(),
             from: window.Store.SocketWap.USER_JID(userId),

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -242,7 +242,7 @@ exports.LoadUtils = () => {
         }
 
         const lidUser = window.Store.User.getMaybeMeLidUser();
-        const meUser = window.Store.User.getMaybeMeUser();
+        const meUser = window.Store.User.getMaybeMePnUser();
         const newId = await window.Store.MsgKey.newId();
         let from = chat.id.isLid() ? lidUser : meUser;
         let participant;


### PR DESCRIPTION
# PR Details

Fixing method change  window.Store.User.getMaybeMeUser()  to window.Store.User.getMaybeMePnUser() || window.Store.User.getMaybeMeLidUser()

**It doesn't matter what operating system it is. If you are having trouble, review your steps.**

## Description

Fixing method change  window.Store.User.getMaybeMeUser()  to window.Store.User.getMaybeMePnUser() || window.Store.User.getMaybeMeLidUser()

**It doesn't matter what operating system it is. If you are having trouble, review your steps.**

fixes #3749, closes #3743, closes #3746

## Usage Example

```js
// client initialization...

client.on('ready', async () => {

   console.log('Event ready fired!');

});
```

## You can try the fix by running one of the following commands:

- NPM
`npm install github:BenyFilho/whatsapp-web.js#fix_event_ready_again`

- YARN
`yarn add github:BenyFilho/whatsapp-web.js#fix_event_ready_again`

## Motivation and Context

Some people are struggling with it. 

## Types of changes

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)