### PR TITLE
Fix: Avoid error Dropping db read operation due to logout

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -218,6 +218,7 @@ class Client extends EventEmitter {
                 }
 
                 if (isCometOrAbove) {
+                    await new Promise(r => setTimeout(r, 10000)); // Avoid error "Dropping db read operation due to logout"
                     await this.pupPage.evaluate(ExposeStore);
                 } else {
                     // make sure all modules are ready before injection


### PR DESCRIPTION
### Title
Add 10s wait before exposing `Store` to avoid “Dropping db read operation due to logout”

### Summary
Introduce a 10-second delay before executing `ExposeStore` on Comet-or-above flows to allow the service/database to finish initializing, preventing the intermittent “Dropping db read operation due to logout” error.

### Main change
```js
await new Promise(r => setTimeout(r, 10000)); // Avoid error "Dropping db read operation due to logout"
```
- Location: `src/Client.js`, inside the `isCometOrAbove` branch, right before `await this.pupPage.evaluate(ExposeStore)`.

### Motivation
- On certain startups, injection happens before the service/DB is ready, causing the cited error and read drops.
- The delay ensures a stable environment before exposing `Store`.

### Technical details
- Affects only the `isCometOrAbove` path.
- The legacy path remains unchanged (already waits 2s before `ExposeLegacyStore`).
- No new APIs or signature changes.

### Impact
- Up to +10s initialization time on Comet in exchange for improved stability.
- Significantly reduces occurrences of “Dropping db read operation due to logout”.
- No public API behavior changes.

### How to test
- Start the client on a Comet-or-above environment.
- Verify:
  - The error “Dropping db read operation due to logout” does not appear.
  - `window.Store` is injected successfully.
  - `AUTHENTICATED` and `READY` events still fire as usual.

### Risks and mitigations
- Fixed 10s delay: if excessive for some environments, consider making it configurable (e.g., `options.exposeStoreDelayMs`) or replacing with a readiness-based wait (e.g., `waitForFunction`).
- No expected regressions in legacy flow.

### Checklist
- [x] Change applied and lint clean
- [x] Verified on Comet flow
- [ ] Consider making the delay configurable in a follow-up
- [ ] Add E2E tests if applicable

### Inline context
```js
await new Promise(r => setTimeout(r, 10000)); // Avoid error "Dropping db read operation due to logout"
```