### PR TITLE
feat: getPollVotes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1177,6 +1177,10 @@ declare namespace WAWebJS {
          */
         getPayment: () => Promise<Payment>,
         /**
+         * Get Poll Votes associated with the given message
+         */
+        getPollVotes: () => Promise<PollVote[]>,
+        /**
          * Gets the reactions associated with the given message
          */
         getReactions: () => Promise<ReactionList[]>,

--- a/index.d.ts
+++ b/index.d.ts
@@ -287,6 +287,9 @@ declare namespace WAWebJS {
          */
         transferChannelOwnership(channelId: string, newOwnerId: string, options?: TransferChannelOwnershipOptions): Promise<boolean>;
 
+        /** Get Poll Votes */
+        getPollVotes(messageId: string): Promise<PollVote[]>
+
         /** Generic event */
         on(event: string, listener: (...args: any) => void): this
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -2356,6 +2356,32 @@ class Client extends EventEmitter {
             }));
         }, userIds);
     }
+
+    /**
+     * Get Poll Votes
+     * @param {string} messageId
+     * @return {Promise<Array<PollVote>>} 
+     */
+    async getPollVotes(messageId) {
+        const msg = await this.getMessageById(messageId);
+        if (!msg) return [];
+        if (msg.type != 'poll_creation') throw 'Invalid usage! Can only be used with a pollCreation message';
+
+        const pollVotes = await this.pupPage.evaluate( async (msg) => {
+            const msgKey = window.Store.MsgKey.fromString(msg.id._serialized);
+            let pollVotes = await window.Store.PollsVotesSchema.getTable().equals(["parentMsgKey"], msgKey.toString());
+            
+            return pollVotes.map(item => {
+                const typedArray = new Uint8Array(item.selectedOptionLocalIds);
+                return {
+                    ...item,
+                    selectedOptionLocalIds: Array.from(typedArray)
+                };
+            });
+        }, msg);
+
+        return pollVotes.map((pollVote) => new PollVote(this.client, {...pollVote, parentMessage: msg}));
+    }
 }
 
 module.exports = Client;

--- a/src/Client.js
+++ b/src/Client.js
@@ -2369,7 +2369,7 @@ class Client extends EventEmitter {
 
         const pollVotes = await this.pupPage.evaluate( async (msg) => {
             const msgKey = window.Store.MsgKey.fromString(msg.id._serialized);
-            let pollVotes = await window.Store.PollsVotesSchema.getTable().equals(["parentMsgKey"], msgKey.toString());
+            let pollVotes = await window.Store.PollsVotesSchema.getTable().equals(['parentMsgKey'], msgKey.toString());
             
             return pollVotes.map(item => {
                 const typedArray = new Uint8Array(item.selectedOptionLocalIds);

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -742,6 +742,13 @@ class Message extends Base {
 
         return edittedEventMsg && new Message(this.client, edittedEventMsg);
     }
+    /**
+     * Returns the PollVote this poll message
+     * @returns {Promise<PollVote[]>}
+     */
+    async getPollVotes() {
+        return await this.client.getPollVotes(this.id._serialized);
+    }
 }
 
 module.exports = Message;

--- a/src/util/Injected/Store.js
+++ b/src/util/Injected/Store.js
@@ -103,6 +103,7 @@ exports.ExposeStore = () => {
     window.Store.UploadUtils = window.require('WAWebUploadManager');
     window.Store.WAWebStreamModel = window.require('WAWebStreamModel');
     window.Store.FindOrCreateChat = window.require('WAWebFindChatAction');
+    window.Store.PollsVotesSchema = require('WAWebPollsVotesSchema');
     
     window.Store.Settings = {
         ...window.require('WAWebUserPrefsGeneral'),


### PR DESCRIPTION
# PR Details

New feature getPollVotes

## Description

The PR add the method to getPollVotes, an alternative to retrieving all votes from a poll instead of using the event vote_update.

## Usage Example

```js
// client initialization...

client.on('ready', async () => {
    const votes = await client.getPollVotes(pollMsgId);
    console.log(votes);
    
    //OR
    
    const msg = await client.getMessageById(msgId);
    const votes = await msg.getPollVotes();
    console.log(votes);
});
```

## You can try the fix by running one of the following commands:

- NPM
`npm install github:BenyFilho/whatsapp-web.js#getPollVotes`

- YARN
`yarn add github:BenyFilho/whatsapp-web.js#getPollVotes`

## Types of changes

- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)