### PR TITLE
Fix: Avoid logout on accounts migrated to LID 1x1 model

### DIFF
--- a/src/util/Injected/Store.js
+++ b/src/util/Injected/Store.js
@@ -229,5 +229,5 @@ exports.ExposeStore = () => {
 
     window.injectToFunction({ module: 'WAWebE2EProtoUtils', function: 'typeAttributeFromProtobuf' }, (func, ...args) => { const [proto] = args; return proto.locationMessage || proto.groupInviteMessage ? 'text' : func(...args); });
 
-    window.injectToFunction({ module: 'WAWebLid1X1MigrationGating', function: 'Lid1X1MigrationUtils.isLidMigrated' }, () => false);
+    window.injectToFunction({ module: 'WAWebLid1X1MigrationGating', function: 'Lid1X1MigrationUtils.isLidMigrated' }, (func, ...args) => { try { return func(...args); } catch { return false; }});
 };


### PR DESCRIPTION
# PR Details

Fixes an issue where migrated WhatsApp accounts were being logged out immediately after login due to the `isLidMigrated` function being forced to always return `false`.

## Description

This PR updates the injection of `Lid1X1MigrationUtils.isLidMigrated` in `src/util/Injected/Store.js`.

Previously the code patched the function to always return `false`:

```js
window.injectToFunction(
  { module: 'WAWebLid1X1MigrationGating', function: 'Lid1X1MigrationUtils.isLidMigrated' },
  () => false
);
```

That worked for accounts that hadn't been migrated yet, but caused an immediate logout on accounts already using the new **LID 1x1** system.

Now, the injection attempts to call the original function first and only falls back to returning `false` if executing the original function fails. This preserves compatibility with non-migrated accounts while avoiding forced logouts on migrated accounts.

## Related Issue(s)

[#3809](https://github.com/pedroslopez/whatsapp-web.js/issues/3809)

## Motivation and Context

This prevents unnecessary logouts for accounts migrated to the LID 1x1 model, while keeping existing behavior for non-migrated accounts. It reduces disruption for users who are already on the migrated backend.

## How Has This Been Tested

- Tested login with multiple accounts (both migrated and non-migrated).
- Confirmed non-migrated accounts still connect as before.
- Confirmed migrated accounts no longer get logged out immediately after login.

### Environment

- Machine OS: Linux (Debian)
- Phone OS: iOS (tested on iOS 26)
- Library Version: 1.34.1
- WhatsApp Web Version: 2.3000.1027224352
- Puppeteer Version: 18.2.1
- Browser Type and Version: Chromium 140.0.7339.52
- Node Version: 22.18.0

## Types of changes

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js).
