### PR TITLE
Fix method saveOrEditAddressbookContact

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -242,7 +242,7 @@ declare namespace WAWebJS {
         syncHistory(chatId: string): Promise<boolean>
 
         /** Save new contact to user's addressbook or edit the existing one */
-        saveOrEditAddressbookContact(phoneNumber: string, firstName: string, lastName: string, syncToAddressbook?: boolean): Promise<ChatId>
+        saveOrEditAddressbookContact(phoneNumber: string, firstName: string, lastName: string, syncToAddressbook?: boolean): Promise<void>
 
         /**
          * Add or edit a customer note

--- a/src/Client.js
+++ b/src/Client.js
@@ -2317,7 +2317,7 @@ class Client extends EventEmitter {
      * @param {string} firstName 
      * @param {string} lastName 
      * @param {boolean} [syncToAddressbook = false] If set to true, the contact will also be saved to the user's address book on their phone. False by default
-     * @returns {Promise<import('..').ChatId>} Object in a wid format
+     * @returns {Promise<void>}
      */
     async saveOrEditAddressbookContact(phoneNumber, firstName, lastName, syncToAddressbook = false)
     {

--- a/src/Client.js
+++ b/src/Client.js
@@ -2324,6 +2324,8 @@ class Client extends EventEmitter {
         return await this.pupPage.evaluate(async (phoneNumber, firstName, lastName, syncToAddressbook) => {
             return await window.Store.AddressbookContactUtils.saveContactAction(
                 phoneNumber,
+                phoneNumber,
+                null,
                 null,
                 firstName,
                 lastName,


### PR DESCRIPTION
# PR Details

This PR fixes the method saveOrEditAddressbookContact.

## Description

This PR fixes the method saveOrEditAddressbookContact.

## Related Issues

closes https://github.com/pedroslopez/whatsapp-web.js/issues/3922

## How Has This Been Tested

```
// client initialization...

client.on('ready', async () => {
     await client.saveOrEditAddressbookContact(
        "17132222222",
        "John",
        "Doe",
        syncToAddressbook
    );
});
```

## You can try the fix by running one of the following commands:

- NPM
`npm install github:BenyFilho/whatsapp-web.js#fix_saveOrEditAddressbookContact`

- YARN
`yarn add github:BenyFilho/whatsapp-web.js#fix_saveOrEditAddressbookContact`

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)