### PR TITLE
change require to window.require

### DIFF
--- a/src/util/Injected/Store.js
+++ b/src/util/Injected/Store.js
@@ -103,7 +103,7 @@ exports.ExposeStore = () => {
     window.Store.FindOrCreateChat = window.require('WAWebFindChatAction');
     window.Store.CustomerNoteUtils = window.require('WAWebNoteAction');
     window.Store.BusinessGatingUtils = window.require('WAWebBizGatingUtils');
-    window.Store.PollsVotesSchema = require('WAWebPollsVotesSchema');
+    window.Store.PollsVotesSchema = window.require('WAWebPollsVotesSchema');
     
     window.Store.Settings = {
         ...window.require('WAWebUserPrefsGeneral'),


### PR DESCRIPTION
# PR Details

Fix missing `window.` prefix in `require('WAWebPollsVotesSchema')` call

## Description

In version 1.34.2, a new line was added to `src/util/Injected/Store.js` (line 106) that loads the `WAWebPollsVotesSchema` module. However, unlike all other module loads in the same file which use `window.require()`, this line mistakenly uses `require()` without the `window.` prefix.

This causes issues when bundling `whatsapp-web.js` with tools like Vite/Rollup in ESM format, as the bundler incorrectly interprets the `require()` call as a Node.js module import and attempts to convert it to an ESM `import` statement, resulting in a runtime error:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'WAWebPollsVotesSchema'
```

**The fix:**
Changed line 106 from:

```javascript
window.Store.PollsVotesSchema = require('WAWebPollsVotesSchema');
```

to:

```javascript
window.Store.PollsVotesSchema = window.require('WAWebPollsVotesSchema');
```

This makes it consistent with all other `window.require()` calls in the same file (lines 100–105, 109–111, etc.).

## Motivation and Context

This bug was introduced in version 1.34.2 and breaks compatibility with ESM-based build tools (Vite, Rollup, etc.) that bundle `whatsapp-web.js`. The inconsistency is clear when comparing line 106 with the surrounding lines — all other WhatsApp Web internal modules use `window.require()`, but this one line uses plain `require()`.
This is a simple typo/oversight that causes build failures for projects using modern JavaScript bundlers with ESM output format.

## How Has This Been Tested

Tested in an Electron application using `electron-vite` with ESM output format:

* **Before fix:** Application fails at runtime with
  `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'WAWebPollsVotesSchema'`
* **After fix:** Application builds and runs successfully with `whatsapp-web.js` 1.34.2

### Environment

* Machine OS: Windows 11
* Phone OS: Android
* Library Version: 1.34.2
* WhatsApp Web Version: 2.3000.x (latest)
* Puppeteer Version: (bundled with `whatsapp-web.js`)
* Browser Type and Version: Chromium (bundled with Puppeteer)
* Node Version: 24.x

## Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
* [x] My code follows the code style of this project.
