### PR TITLE
fix: update puppeteer dependency to version 24.28.0 and refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "mime": "^3.0.0",
     "node-fetch": "^2.6.9",
     "node-webpmux": "3.1.7",
-    "puppeteer": "^18.2.1"
+    "puppeteer": "^24.28.0"
   },
   "devDependencies": {
     "@types/node-fetch": "^2.5.12",

--- a/src/util/Puppeteer.js
+++ b/src/util/Puppeteer.js
@@ -9,8 +9,11 @@
 async function exposeFunction(page, name, fn) {
     try {
         await page.removeExposedFunction(name);
-    } catch {
-        // Function doesn't exist yet, ignore
+    } catch (error) {
+        // Only ignore if function doesn't exist, rethrow other errors
+        if (!error?.message?.includes('No function with name')) {
+            throw error;
+        }
     }
     await page.exposeFunction(name, fn);
 }

--- a/src/util/Puppeteer.js
+++ b/src/util/Puppeteer.js
@@ -1,23 +1,18 @@
 /**
- * Expose a function to the page if it does not exist
+ * Expose a function to the page, replacing it if it already exists.
+ * Uses page.removeExposedFunction (available since Puppeteer 20.6) to upsert.
  *
- * NOTE:
- * Rewrite it to 'upsertFunction' after updating Puppeteer to 20.6 or higher
- * using page.removeExposedFunction
- * https://pptr.dev/api/puppeteer.page.removeExposedFunction
- *
- * @param {import(puppeteer).Page} page
+ * @param {import('puppeteer').Page} page
  * @param {string} name
  * @param {Function} fn
  */
-async function exposeFunctionIfAbsent(page, name, fn) {
-    const exist = await page.evaluate((name) => {
-        return !!window[name];
-    }, name);
-    if (exist) {
-        return;
+async function exposeFunction(page, name, fn) {
+    try {
+        await page.removeExposedFunction(name);
+    } catch {
+        // Function doesn't exist yet, ignore
     }
     await page.exposeFunction(name, fn);
 }
 
-module.exports = {exposeFunctionIfAbsent};
+module.exports = { exposeFunction };


### PR DESCRIPTION


# PR Details
upgraded Puppeteer from ^18.2.1 to ^24.28.0. 



## Description
1. package.json
Updated puppeteer dependency from ^18.2.1 to ^24.28.0
2. Puppeteer.js
Refactored exposeFunctionIfAbsent to exposeFunction
Now uses page.removeExposedFunction() API (available since Puppeteer 20.6) instead of the workaround that evaluated window[name] existence
Cleaner implementation that properly upserts exposed functions
3. Client.js
Updated import from exposeFunctionIfAbsent to exposeFunction
All 21 function calls updated to use the new function name

## Related Issue(s)


## Motivation and Context

To make the library more robust with latest version

## How Has This Been Tested

<!-- Please describe in detail how you tested your changes. -->

### Environment

<!-- Include details of your testing environment: -->
- Machine OS: <!-- The operation system of a machine you tested the PR on. (Mac | Windows | Linux | Docker + Ubuntu | other (provide the type)) -->
- Phone OS: <!-- The operation system of a phone you used to check the the PR functionality on. -->
- Library Version: <!-- The whatsapp-web.js version you used to test the PR. -->
- WhatsApp Web Version: <!-- Run `await client.getWWebVersion()` to see the WWeb version you used to test the PR. -->
- Puppeteer Version:
- Browser Type and Version: <!-- Chromium XX | Google Chrome XX | other (provide the type and version) -->
- Node Version: <!-- Run `npm -v` in your terminal to see the version of Node.js being used. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [x] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).
- [x] I have updated the usage example accordingly (example.js)