### PR TITLE
feat(client): add `sendReaction` method to the Client

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -172,6 +172,9 @@ declare namespace WAWebJS {
         /** Send a message to a specific chatId */
         sendMessage(chatId: string, content: MessageContent, options?: MessageSendOptions): Promise<Message>
 
+        /** Send a reaction to a specific messageId */
+        sendReaction(messageId: string, reaction: string): Promise<void>
+
         /** Sends a channel admin invitation to a user, allowing them to become an admin of the channel */
         sendChannelAdminInvite(chatId: string, channelId: string, options?: { comment?: string }): Promise<boolean>
         

--- a/src/Client.js
+++ b/src/Client.js
@@ -905,6 +905,25 @@ class Client extends EventEmitter {
         }, chatId);
     }
 
+
+    /**
+     * React to a message with an emoji
+     * @param {string} messageId - Id of the message to add the reaction.
+     * @param {string} reaction  - Emoji to react with. Send an empty string to remove the reaction.
+     * @return {Promise}
+     */
+    async sendReaction(messageId, reaction){
+        await this.pupPage.evaluate(async (messageId, reaction) => {
+            if (!messageId) return null;
+            const msg =
+                window.Store.Msg.get(messageId) || (await window.Store.Msg.getMessagesById([messageId]))?.messages?.[0];
+            if(!msg) return null;
+
+            await window.Store.sendReactionToMsg(msg, reaction);
+        }, messageId, reaction);
+    }
+
+
     /**
      * An object representing mentions of groups
      * @typedef {Object} GroupMention

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -407,13 +407,7 @@ class Message extends Base {
      * @return {Promise}
      */
     async react(reaction){
-        await this.client.pupPage.evaluate(async (messageId, reaction) => {
-            if (!messageId) return null;
-            const msg =
-                window.Store.Msg.get(messageId) || (await window.Store.Msg.getMessagesById([messageId]))?.messages?.[0];
-            if(!msg) return null;
-            await window.Store.sendReactionToMsg(msg, reaction);
-        }, this.id._serialized, reaction);
+        return this.client.sendReaction(this.id._serialized, reaction)
     }
 
     /**


### PR DESCRIPTION
# PR Details

Add `sendReaction` method to the `Client`. 

## Description

The new method created from `Message.react`, and the original method now calls the new one. 

## Motivation and Context

With this method it is possible to send reactions to any message, not only to the just received message, or fetched by "load/fetch messages"

## How Has This Been Tested

Basically, the code were just moved, so I called both: 

- msg.react
- client.sendReaction

and both worked in private/group messages.

### Environment

I've tested with `whatsapp-web.js@1.34.2` inside a `node:24.11.0-alpine3.22` (linux) docker image.

webVersion: "2.3000.1030417076"

## Types of changes

- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)