### PR TITLE
Fix: getIsMyContact is not a function

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -644,7 +644,7 @@ exports.LoadUtils = () => {
         res.isGroup = window.Store.ContactMethods.getIsGroup(contact);
         res.isWAContact = window.Store.ContactMethods.getIsWAContact(contact);
         //res.isMyContact = window.Store.ContactMethods.getIsMyContact(contact);
-        res.isMyContact = window.Store.ContactMethods.getIsWAContac(contact);
+        res.isMyContact = window.Store.ContactMethods.getIsWAContact(contact);
         res.isBlocked = contact.isContactBlocked;
         res.userid = window.Store.ContactMethods.getUserid(contact);
         res.isEnterprise = window.Store.ContactMethods.getIsEnterprise(contact);

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -643,7 +643,8 @@ exports.LoadUtils = () => {
         res.isUser = window.Store.ContactMethods.getIsUser(contact);
         res.isGroup = window.Store.ContactMethods.getIsGroup(contact);
         res.isWAContact = window.Store.ContactMethods.getIsWAContact(contact);
-        res.isMyContact = window.Store.ContactMethods.getIsMyContact(contact);
+        //res.isMyContact = window.Store.ContactMethods.getIsMyContact(contact);
+        res.isMyContact = window.Store.ContactMethods.getIsWAContac(contact);
         res.isBlocked = contact.isContactBlocked;
         res.userid = window.Store.ContactMethods.getUserid(contact);
         res.isEnterprise = window.Store.ContactMethods.getIsEnterprise(contact);


### PR DESCRIPTION
The method `getIsMyContact` no longer exists in the latest WhatsApp Web API,
which caused a runtime error in `Utils.js`.

This PR replaces:
- getIsMyContact(contact)
with:
- getIsWAContact(contact)

This resolves the error and restores compatibility with the latest ContactMethods.