### PR TITLE
fix: memory leak, input validation, and deprecation docs

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -850,6 +850,12 @@ class Client extends EventEmitter {
      * Closes the client
      */
     async destroy() {
+        // Remove all Puppeteer page event listeners to prevent memory leaks
+        if (this.pupPage) {
+            this.pupPage.removeAllListeners('framenavigated');
+            this.pupPage.removeAllListeners('request');
+            this.pupPage.removeAllListeners('response');
+        }
         await this.pupBrowser.close();
         await this.authStrategy.destroy();
     }
@@ -951,6 +957,12 @@ class Client extends EventEmitter {
      * @returns {Promise<Message>} Message that was just sent
      */
     async sendMessage(chatId, content, options = {}) {
+        if (!chatId || typeof chatId !== 'string') {
+            throw new Error('chatId is required and must be a string');
+        }
+        if (content === undefined || content === null) {
+            throw new Error('content is required');
+        }
         const isChannel = /@\w*newsletter\b/.test(chatId);
 
         if (isChannel && [
@@ -1143,6 +1155,9 @@ class Client extends EventEmitter {
      * @returns {Promise<Chat|Channel>}
      */
     async getChatById(chatId) {
+        if (!chatId || typeof chatId !== 'string') {
+            throw new Error('chatId is required and must be a string');
+        }
         const chat = await this.pupPage.evaluate(async chatId => {
             return await window.WWebJS.getChat(chatId);
         }, chatId);
@@ -1191,6 +1206,9 @@ class Client extends EventEmitter {
      * @returns {Promise<Contact>}
      */
     async getContactById(contactId) {
+        if (!contactId || typeof contactId !== 'string') {
+            throw new Error('contactId is required and must be a string');
+        }
         let contact = await this.pupPage.evaluate(contactId => {
             return window.WWebJS.getContact(contactId);
         }, contactId);
@@ -1199,6 +1217,9 @@ class Client extends EventEmitter {
     }
     
     async getMessageById(messageId) {
+        if (!messageId || typeof messageId !== 'string') {
+            throw new Error('messageId is required and must be a string');
+        }
         const msg = await this.pupPage.evaluate(async messageId => {
             let msg = window.Store.Msg.get(messageId);
             if(msg) return window.WWebJS.getMessageModel(msg);
@@ -1661,8 +1682,11 @@ class Client extends EventEmitter {
      * @returns {Promise<CreateGroupResult|string>} Object with resulting data or an error message as a string
      */
     async createGroup(title, participants = [], options = {}) {
+        if (!title || typeof title !== 'string') {
+            throw new Error('title is required and must be a string');
+        }
         !Array.isArray(participants) && (participants = [participants]);
-        participants.map(p => (p instanceof Contact) ? p.id._serialized : p);
+        participants = participants.map(p => (p instanceof Contact) ? p.id._serialized : p);
 
         return await this.pupPage.evaluate(async (title, participants, options) => {
             const {

--- a/src/Client.js
+++ b/src/Client.js
@@ -356,6 +356,7 @@ class Client extends EventEmitter {
                 }
                 await this.inject();
             } catch (err) {
+                console.error('Error during framenavigated handler:', err);
                 this.emit(Events.DISCONNECTED, 'NAVIGATION');
             }
         });
@@ -1332,7 +1333,7 @@ class Client extends EventEmitter {
      */
     async acceptGroupV4Invite(inviteInfo) {
         if (!inviteInfo.inviteCode) throw new Error('Invalid invite code, try passing the message.inviteV4 object');
-        if (inviteInfo.inviteCodeExp == 0) throw new Error('Expired invite code');
+        if (inviteInfo.inviteCodeExp === 0) throw new Error('Expired invite code');
         return this.pupPage.evaluate(async inviteInfo => {
             let { groupId, fromId, inviteCode, inviteCodeExp } = inviteInfo;
             let userWid = window.Store.WidFactory.createWid(fromId);
@@ -2429,7 +2430,7 @@ class Client extends EventEmitter {
     async getPollVotes(messageId) {
         const msg = await this.getMessageById(messageId);
         if (!msg) return [];
-        if (msg.type != MessageTypes.POLL_CREATION) throw new Error('Invalid usage! Can only be used with a pollCreation message');
+        if (msg.type !== MessageTypes.POLL_CREATION) throw new Error('Invalid usage! Can only be used with a pollCreation message');
 
         const pollVotes = await this.pupPage.evaluate( async (msg) => {
             const msgKey = window.Store.MsgKey.fromString(msg.id._serialized);

--- a/src/Client.js
+++ b/src/Client.js
@@ -857,7 +857,10 @@ class Client extends EventEmitter {
             this.pupPage.removeAllListeners('request');
             this.pupPage.removeAllListeners('response');
         }
-        await this.pupBrowser.close();
+        // Only close browser if still connected to avoid hanging
+        if (this.pupBrowser?.isConnected()) {
+            await this.pupBrowser.close();
+        }
         await this.authStrategy.destroy();
     }
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -2453,7 +2453,7 @@ class Client extends EventEmitter {
     async getPollVotes(messageId) {
         const msg = await this.getMessageById(messageId);
         if (!msg) return [];
-        if (msg.type != MessageTypes.POLL_CREATION) throw new Error('Invalid usage! Can only be used with a pollCreation message');
+        if (msg.type !== MessageTypes.POLL_CREATION) throw new Error('Invalid usage! Can only be used with a pollCreation message');
 
         const pollVotes = await this.pupPage.evaluate( async (msg) => {
             const msgKey = window.Store.MsgKey.fromString(msg.id._serialized);

--- a/src/structures/Buttons.js
+++ b/src/structures/Buttons.js
@@ -58,7 +58,7 @@ class Buttons {
          * @type {FormattedButtonSpec[]}
          */
         this.buttons = this._format(buttons);
-        if(!this.buttons.length){ throw '[BT01] No buttons';}
+        if(!this.buttons.length){ throw new Error('[BT01] No buttons');}
                 
     }
 

--- a/src/structures/Buttons.js
+++ b/src/structures/Buttons.js
@@ -19,6 +19,7 @@ const Util = require('../util/Util');
 
 /**
  * Message type buttons
+ * @deprecated Buttons are no longer supported by WhatsApp. See https://faq.whatsapp.com/1026418498719742
  */
 class Buttons {
     /**

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -310,7 +310,7 @@ class Channel extends Base {
                 
                 if (msgs.length > searchOptions.limit) {
                     msgs.sort((a, b) => (a.t > b.t) ? 1 : -1);
-                    msgs = msgs.splice(msgs.length - searchOptions.limit);
+                    msgs = msgs.slice(-searchOptions.limit);
                 }
             }
 

--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -213,7 +213,7 @@ class Chat extends Base {
                 
                 if (msgs.length > searchOptions.limit) {
                     msgs.sort((a, b) => (a.t > b.t) ? 1 : -1);
-                    msgs = msgs.splice(msgs.length - searchOptions.limit);
+                    msgs = msgs.slice(-searchOptions.limit);
                 }
             }
 

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -110,12 +110,12 @@ class GroupChat extends Chat {
                 return errorCodes.iAmNotAdmin;
             }
 
-            groupParticipants.map(({ id }) => {
+            groupParticipants = groupParticipants.map(({ id }) => {
                 return id.server === 'lid' ? window.Store.LidUtils.getPhoneNumber(id) : id;
             });
 
             const _getSleepTime = (sleep) => {
-                if (!Array.isArray(sleep) || sleep.length === 2 && sleep[0] === sleep[1]) {
+                if (!Array.isArray(sleep) || (sleep.length === 2 && sleep[0] === sleep[1])) {
                     return sleep;
                 }
                 if (sleep.length === 1) {

--- a/src/structures/Label.js
+++ b/src/structures/Label.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const Base = require('./Base');
-// eslint-disable-next-line no-unused-vars
-const Chat = require('./Chat');
 
 /**
  * WhatsApp Business Label information

--- a/src/structures/List.js
+++ b/src/structures/List.js
@@ -4,6 +4,7 @@ const Util = require('../util/Util');
 
 /**
  * Message type List
+ * @deprecated Lists are no longer supported by WhatsApp. See https://faq.whatsapp.com/1026418498719742
  */
 class List {
     /**

--- a/src/structures/List.js
+++ b/src/structures/List.js
@@ -56,14 +56,14 @@ class List {
      * Returns: [{'title':'sectionTitle','rows':[{'rowId':'customId','title':'ListItem1','description':'desc'},{'rowId':'oGSRoD','title':'ListItem2','description':''}]}]
      */
     _format(sections){
-        if(!sections.length){throw '[LT02] List without sections';}
-        if(sections.length > 1 && sections.filter(s => typeof s.title == 'undefined').length > 1){throw '[LT05] You can\'t have more than one empty title.';}
+        if(!sections.length){throw new Error('[LT02] List without sections');}
+        if(sections.length > 1 && sections.filter(s => typeof s.title == 'undefined').length > 1){throw new Error('[LT05] You can\'t have more than one empty title.');}
         return sections.map( (section) =>{
-            if(!section.rows.length){throw '[LT03] Section without rows';}
+            if(!section.rows.length){throw new Error('[LT03] Section without rows');}
             return {
                 title: section.title ? section.title : undefined,
                 rows: section.rows.map( (row) => {
-                    if(!row.title){throw '[LT04] Row without title';}
+                    if(!row.title){throw new Error('[LT04] Row without title');}
                     return {
                         rowId: row.id ? row.id : Util.generateHash(6),
                         title: row.title,

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -755,7 +755,7 @@ class Message extends Base {
      * @returns {Promise}
      */
     async vote(selectedOptions) {
-        if (this.type != MessageTypes.POLL_CREATION) throw new Error('Invalid usage! Can only be used with a pollCreation message');
+        if (this.type !== MessageTypes.POLL_CREATION) throw new Error('Invalid usage! Can only be used with a pollCreation message');
 
         await this.client.pupPage.evaluate(async (messageId, votes) => {
             if (!messageId) return null;

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -7,7 +7,6 @@ const Order = require('./Order');
 const Payment = require('./Payment');
 const Reaction = require('./Reaction');
 const Contact = require('./Contact');
-const ScheduledEvent = require('./ScheduledEvent'); // eslint-disable-line no-unused-vars
 const { MessageTypes } = require('../util/Constants');
 
 /**
@@ -756,7 +755,7 @@ class Message extends Base {
      * @returns {Promise}
      */
     async vote(selectedOptions) {
-        if (this.type != MessageTypes.POLL_CREATION) throw 'Invalid usage! Can only be used with a pollCreation message';
+        if (this.type != MessageTypes.POLL_CREATION) throw new Error('Invalid usage! Can only be used with a pollCreation message');
 
         await this.client.pupPage.evaluate(async (messageId, votes) => {
             if (!messageId) return null;

--- a/src/util/Injected/AuthStore/LegacyAuthStore.js
+++ b/src/util/Injected/AuthStore/LegacyAuthStore.js
@@ -3,8 +3,8 @@
 //TODO: To be removed by version 2.3000.x hard release
 
 exports.ExposeLegacyAuthStore = (moduleRaidStr) => {
-    eval('var moduleRaid = ' + moduleRaidStr);
-    // eslint-disable-next-line no-undef
+    // Use Function constructor instead of eval for safer code execution
+    const moduleRaid = new Function('return ' + moduleRaidStr)();
     window.mR = moduleRaid();
     window.AuthStore = {};
     window.AuthStore.AppState = window.mR.findModule('Socket')[0].Socket;

--- a/src/util/Injected/AuthStore/LegacyAuthStore.js
+++ b/src/util/Injected/AuthStore/LegacyAuthStore.js
@@ -3,7 +3,7 @@
 //TODO: To be removed by version 2.3000.x hard release
 
 exports.ExposeLegacyAuthStore = (moduleRaidStr) => {
-    // Use Function constructor instead of eval for safer code execution
+    // Use Function constructor instead of eval (isolated scope, passes linters)
     const moduleRaid = new Function('return ' + moduleRaidStr)();
     window.mR = moduleRaid();
     window.AuthStore = {};

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1067,10 +1067,11 @@ exports.LoadUtils = () => {
                         ? response.value.membershipRequestsActionApprove
                         : response.value.membershipRequestsActionReject;
                     if (value?.participant) {
-                        const [_] = value.participant.map(p => {
-                            const error = toApprove
-                                ? value.participant[0].membershipRequestsActionAcceptParticipantMixins?.value.error
-                                : value.participant[0].membershipRequestsActionRejectParticipantMixins?.value.error;
+                        const participantResults = value.participant.map(p => {
+                            const mixins = toApprove
+                                ? p.membershipRequestsActionAcceptParticipantMixins
+                                : p.membershipRequestsActionRejectParticipantMixins;
+                            const error = mixins?.value?.error;
                             return {
                                 requesterId: window.Store.WidFactory.createWid(p.jid)._serialized,
                                 ...(error
@@ -1078,7 +1079,7 @@ exports.LoadUtils = () => {
                                     : { message: `${toApprove ? 'Approved' : 'Rejected'} successfully` })
                             };
                         });
-                        _ && result.push(_);
+                        result.push(...participantResults);
                     }
                 } else {
                     result.push({

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -793,7 +793,7 @@ exports.LoadUtils = () => {
             await window.Store.ChatState.sendChatStatePaused(chatId);
             break;
         default:
-            throw 'Invalid chatstate';
+            throw new Error('Invalid chatstate');
         }
 
         return true;

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -99,8 +99,7 @@ class Util {
                     '-vcodec',
                     'libwebp',
                     '-vf',
-                    // eslint-disable-next-line no-useless-escape
-                    'scale=\'iw*min(300/iw\,300/ih)\':\'ih*min(300/iw\,300/ih)\',format=rgba,pad=300:300:\'(300-iw)/2\':\'(300-ih)/2\':\'#00000000\',setsar=1,fps=10',
+                    'scale=\'iw*min(300/iw,300/ih)\':\'ih*min(300/iw,300/ih)\',format=rgba,pad=300:300:\'(300-iw)/2\':\'(300-ih)/2\':\'#00000000\',setsar=1,fps=10',
                     '-loop',
                     '0',
                     '-ss',

--- a/tests/test-fixes-online.js
+++ b/tests/test-fixes-online.js
@@ -1,0 +1,79 @@
+'use strict';
+
+/**
+ * Online test script for fix/critical-issues branch
+ * Requires a real WhatsApp account to test
+ *
+ * Run: node tests/test-fixes-online.js
+ */
+
+const { Client } = require('../index.js');
+const qrcode = require('qrcode-terminal');
+
+const client = new Client();
+
+console.log('=== Online Tests for fix/critical-issues ===\n');
+console.log('This test requires a real WhatsApp account.');
+console.log('Please scan the QR code when prompted.\n');
+
+client.on('qr', qr => {
+    console.log('Scan this QR code to login:');
+    qrcode.generate(qr, { small: true });
+});
+
+client.on('authenticated', () => {
+    console.log('✅ PASS: Authentication successful');
+    console.log('   (LegacyAuthStore new Function() works correctly)');
+});
+
+client.on('ready', async () => {
+    console.log('✅ PASS: Client ready');
+
+    // Test 1: acceptGroupV4Invite error handling
+    console.log('\n--- Testing acceptGroupV4Invite error handling ---');
+    try {
+        await client.acceptGroupV4Invite({});
+        console.log('❌ FAIL: Should have thrown an error');
+    } catch (e) {
+        if (e instanceof Error && e.stack) {
+            console.log('✅ PASS: acceptGroupV4Invite throws Error object with stack trace');
+        } else {
+            console.log('❌ FAIL: Expected Error object with stack trace');
+        }
+    }
+
+    // Test 2: getPollVotes error handling
+    console.log('\n--- Testing getPollVotes error handling ---');
+    try {
+        // This will fail because the message doesn't exist, but that's expected
+        await client.getPollVotes('fake_message_id');
+    } catch (e) {
+        // We expect either an Error or an empty result
+        console.log('✅ PASS: getPollVotes handled gracefully');
+    }
+
+    // Test 3: deleteChannel (only if you have a channel)
+    console.log('\n--- Testing deleteChannel ---');
+    console.log('   Skipped: Requires an existing channel ID');
+    console.log('   To test manually:');
+    console.log('   const result = await client.deleteChannel("your_channel_id@newsletter");');
+
+    console.log('\n=== Online Tests Complete ===');
+    console.log('Disconnecting...');
+
+    await client.destroy();
+    process.exit(0);
+});
+
+client.on('disconnected', (reason) => {
+    console.log(`\nClient disconnected: ${reason}`);
+    console.log('✅ PASS: framenavigated try-catch working (no crash on disconnect)');
+});
+
+client.on('auth_failure', (msg) => {
+    console.log('❌ FAIL: Authentication failed:', msg);
+    process.exit(1);
+});
+
+console.log('Initializing client...');
+client.initialize();

--- a/tests/test-fixes.js
+++ b/tests/test-fixes.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * Test script for fix/critical-issues branch
+ * Tests the error handling improvements (throw string → throw Error)
+ *
+ * Run: node tests/test-fixes.js
+ */
+
+const { Buttons, List } = require('../index.js');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try {
+        fn();
+        console.log(`✅ PASS: ${name}`);
+        passed++;
+    } catch (e) {
+        console.log(`❌ FAIL: ${name}`);
+        console.log(`   Error: ${e.message}`);
+        failed++;
+    }
+}
+
+function expectError(fn, expectedMessage) {
+    try {
+        fn();
+        throw new Error('Expected an error to be thrown');
+    } catch (e) {
+        if (!(e instanceof Error)) {
+            throw new Error(`Expected Error object, got ${typeof e}`);
+        }
+        if (!e.stack) {
+            throw new Error('Error should have stack trace');
+        }
+        if (expectedMessage && !e.message.includes(expectedMessage)) {
+            throw new Error(`Expected message containing "${expectedMessage}", got "${e.message}"`);
+        }
+    }
+}
+
+console.log('=== Testing Error Handling Improvements ===\n');
+
+// Test Buttons
+test('Buttons: throws Error object (not string) when empty', () => {
+    expectError(() => new Buttons('body', [], 'title', 'footer'), '[BT01]');
+});
+
+// Test List - empty sections
+test('List: throws Error for empty sections', () => {
+    expectError(() => new List('body', 'button', [], 'title', 'footer'), '[LT02]');
+});
+
+// Test List - section without rows
+test('List: throws Error for section without rows', () => {
+    expectError(
+        () => new List('body', 'button', [{ title: 'Section', rows: [] }], 'title', 'footer'),
+        '[LT03]'
+    );
+});
+
+// Test List - row without title
+test('List: throws Error for row without title', () => {
+    expectError(
+        () => new List('body', 'button', [{ title: 'Section', rows: [{ id: '1' }] }], 'title', 'footer'),
+        '[LT04]'
+    );
+});
+
+// Test List - multiple empty titles
+test('List: throws Error for multiple empty titles', () => {
+    expectError(
+        () => new List('body', 'button', [
+            { rows: [{ title: 'Row1' }] },
+            { rows: [{ title: 'Row2' }] }
+        ], 'title', 'footer'),
+        '[LT05]'
+    );
+});
+
+console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
+
+if (failed > 0) {
+    process.exit(1);
+}
+
+console.log('\n✅ All offline tests passed!');
+console.log('\nNote: The following fixes require a real WhatsApp account to test:');
+console.log('  - deleteChannel() reference fix');
+console.log('  - LegacyAuthStore eval() → new Function()');
+console.log('  - framenavigated try-catch error handling');
+console.log('\nSee tests/test-fixes-online.js for online testing.');

--- a/tests/test-fixes.js
+++ b/tests/test-fixes.js
@@ -1,13 +1,13 @@
 'use strict';
 
 /**
- * Test script for fix/critical-issues branch
- * Tests the error handling improvements (throw string → throw Error)
+ * Test script for fix/critical-issues and fix/additional-issues branches
+ * Tests error handling improvements and input validation
  *
  * Run: node tests/test-fixes.js
  */
 
-const { Buttons, List } = require('../index.js');
+const { Buttons, List, Client } = require('../index.js');
 
 let passed = 0;
 let failed = 0;
@@ -15,6 +15,18 @@ let failed = 0;
 function test(name, fn) {
     try {
         fn();
+        console.log(`✅ PASS: ${name}`);
+        passed++;
+    } catch (e) {
+        console.log(`❌ FAIL: ${name}`);
+        console.log(`   Error: ${e.message}`);
+        failed++;
+    }
+}
+
+async function testAsync(name, fn) {
+    try {
+        await fn();
         console.log(`✅ PASS: ${name}`);
         passed++;
     } catch (e) {
@@ -41,54 +53,117 @@ function expectError(fn, expectedMessage) {
     }
 }
 
-console.log('=== Testing Error Handling Improvements ===\n');
-
-// Test Buttons
-test('Buttons: throws Error object (not string) when empty', () => {
-    expectError(() => new Buttons('body', [], 'title', 'footer'), '[BT01]');
-});
-
-// Test List - empty sections
-test('List: throws Error for empty sections', () => {
-    expectError(() => new List('body', 'button', [], 'title', 'footer'), '[LT02]');
-});
-
-// Test List - section without rows
-test('List: throws Error for section without rows', () => {
-    expectError(
-        () => new List('body', 'button', [{ title: 'Section', rows: [] }], 'title', 'footer'),
-        '[LT03]'
-    );
-});
-
-// Test List - row without title
-test('List: throws Error for row without title', () => {
-    expectError(
-        () => new List('body', 'button', [{ title: 'Section', rows: [{ id: '1' }] }], 'title', 'footer'),
-        '[LT04]'
-    );
-});
-
-// Test List - multiple empty titles
-test('List: throws Error for multiple empty titles', () => {
-    expectError(
-        () => new List('body', 'button', [
-            { rows: [{ title: 'Row1' }] },
-            { rows: [{ title: 'Row2' }] }
-        ], 'title', 'footer'),
-        '[LT05]'
-    );
-});
-
-console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
-
-if (failed > 0) {
-    process.exit(1);
+async function expectErrorAsync(fn, expectedMessage) {
+    try {
+        await fn();
+        throw new Error('Expected an error to be thrown');
+    } catch (e) {
+        if (!(e instanceof Error)) {
+            throw new Error(`Expected Error object, got ${typeof e}`);
+        }
+        if (!e.stack) {
+            throw new Error('Error should have stack trace');
+        }
+        if (expectedMessage && !e.message.includes(expectedMessage)) {
+            throw new Error(`Expected message containing "${expectedMessage}", got "${e.message}"`);
+        }
+    }
 }
 
-console.log('\n✅ All offline tests passed!');
-console.log('\nNote: The following fixes require a real WhatsApp account to test:');
-console.log('  - deleteChannel() reference fix');
-console.log('  - LegacyAuthStore eval() → new Function()');
-console.log('  - framenavigated try-catch error handling');
-console.log('\nSee tests/test-fixes-online.js for online testing.');
+async function runTests() {
+    console.log('=== Testing Error Handling Improvements ===\n');
+
+    // Test Buttons
+    test('Buttons: throws Error object (not string) when empty', () => {
+        expectError(() => new Buttons('body', [], 'title', 'footer'), '[BT01]');
+    });
+
+    // Test List - empty sections
+    test('List: throws Error for empty sections', () => {
+        expectError(() => new List('body', 'button', [], 'title', 'footer'), '[LT02]');
+    });
+
+    // Test List - section without rows
+    test('List: throws Error for section without rows', () => {
+        expectError(
+            () => new List('body', 'button', [{ title: 'Section', rows: [] }], 'title', 'footer'),
+            '[LT03]'
+        );
+    });
+
+    // Test List - row without title
+    test('List: throws Error for row without title', () => {
+        expectError(
+            () => new List('body', 'button', [{ title: 'Section', rows: [{ id: '1' }] }], 'title', 'footer'),
+            '[LT04]'
+        );
+    });
+
+    // Test List - multiple empty titles
+    test('List: throws Error for multiple empty titles', () => {
+        expectError(
+            () => new List('body', 'button', [
+                { rows: [{ title: 'Row1' }] },
+                { rows: [{ title: 'Row2' }] }
+            ], 'title', 'footer'),
+            '[LT05]'
+        );
+    });
+
+    // Test input validation
+    console.log('\n=== Testing Input Validation ===\n');
+
+    // Mock client for testing validation (without initializing browser)
+    const mockClient = Object.create(Client.prototype);
+
+    await testAsync('sendMessage: throws Error for missing chatId', async () => {
+        await expectErrorAsync(() => mockClient.sendMessage(null, 'test'), 'chatId is required');
+    });
+
+    await testAsync('sendMessage: throws Error for non-string chatId', async () => {
+        await expectErrorAsync(() => mockClient.sendMessage(123, 'test'), 'chatId is required');
+    });
+
+    await testAsync('sendMessage: throws Error for missing content', async () => {
+        await expectErrorAsync(() => mockClient.sendMessage('123@c.us', null), 'content is required');
+    });
+
+    await testAsync('getChatById: throws Error for missing chatId', async () => {
+        await expectErrorAsync(() => mockClient.getChatById(null), 'chatId is required');
+    });
+
+    await testAsync('getContactById: throws Error for missing contactId', async () => {
+        await expectErrorAsync(() => mockClient.getContactById(null), 'contactId is required');
+    });
+
+    await testAsync('getMessageById: throws Error for missing messageId', async () => {
+        await expectErrorAsync(() => mockClient.getMessageById(null), 'messageId is required');
+    });
+
+    await testAsync('createGroup: throws Error for missing title', async () => {
+        await expectErrorAsync(() => mockClient.createGroup(null), 'title is required');
+    });
+
+    await testAsync('createGroup: throws Error for non-string title', async () => {
+        await expectErrorAsync(() => mockClient.createGroup(123), 'title is required');
+    });
+
+    console.log(`\n=== Final Results: ${passed} passed, ${failed} failed ===`);
+
+    if (failed > 0) {
+        process.exit(1);
+    }
+
+    console.log('\n✅ All offline tests passed!');
+    console.log('\nNote: The following fixes require a real WhatsApp account to test:');
+    console.log('  - deleteChannel() reference fix');
+    console.log('  - LegacyAuthStore eval() → new Function()');
+    console.log('  - framenavigated try-catch error handling');
+    console.log('  - destroy() event listener cleanup');
+    console.log('\nSee tests/test-fixes-online.js for online testing.');
+}
+
+runTests().catch(e => {
+    console.error('Test runner error:', e);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **Memory leak fix**: Clean up Puppeteer event listeners in `destroy()` method before closing browser
- **Input validation**: Add parameter validation to `sendMessage()`, `getChatById()`, `getContactById()`, `getMessageById()`, and `createGroup()`
- **Bug fix**: Fix `createGroup()` where `participants.map()` result was not being assigned
- **Deprecation docs**: Add `@deprecated` JSDoc annotations to `Buttons` and `List` classes with WhatsApp FAQ link

## Changes

### Memory Leak Prevention
```javascript
async destroy() {
    if (this.pupPage) {
        this.pupPage.removeAllListeners('framenavigated');
        this.pupPage.removeAllListeners('request');
        this.pupPage.removeAllListeners('response');
    }
    await this.pupBrowser.close();
    await this.authStrategy.destroy();
}
```

### Input Validation
- `sendMessage(chatId, content)` - validates chatId is string, content is not null/undefined
- `getChatById(chatId)` - validates chatId exists and is string
- `getContactById(contactId)` - validates contactId exists and is string
- `getMessageById(messageId)` - validates messageId exists and is string
- `createGroup(title, participants)` - validates title is string

### Bug Fix in createGroup
Fixed issue where `participants.map()` result was not assigned back to variable.

## Test Plan

- [x] Added test cases in `tests/test-fixes.js`
- [x] All 13 validation tests pass
- [x] Existing functionality unchanged

## Related

This PR builds on #3978 and addresses additional code quality issues.