### PR TITLE
fix: correct array method usage and logic errors

### DIFF
--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -310,7 +310,7 @@ class Channel extends Base {
                 
                 if (msgs.length > searchOptions.limit) {
                     msgs.sort((a, b) => (a.t > b.t) ? 1 : -1);
-                    msgs = msgs.splice(msgs.length - searchOptions.limit);
+                    msgs = msgs.slice(-searchOptions.limit);
                 }
             }
 

--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -213,7 +213,7 @@ class Chat extends Base {
                 
                 if (msgs.length > searchOptions.limit) {
                     msgs.sort((a, b) => (a.t > b.t) ? 1 : -1);
-                    msgs = msgs.splice(msgs.length - searchOptions.limit);
+                    msgs = msgs.slice(-searchOptions.limit);
                 }
             }
 

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -110,12 +110,12 @@ class GroupChat extends Chat {
                 return errorCodes.iAmNotAdmin;
             }
 
-            groupParticipants.map(({ id }) => {
+            groupParticipants = groupParticipants.map(({ id }) => {
                 return id.server === 'lid' ? window.Store.LidUtils.getPhoneNumber(id) : id;
             });
 
             const _getSleepTime = (sleep) => {
-                if (!Array.isArray(sleep) || sleep.length === 2 && sleep[0] === sleep[1]) {
+                if (!Array.isArray(sleep) || (sleep.length === 2 && sleep[0] === sleep[1])) {
                     return sleep;
                 }
                 if (sleep.length === 1) {

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1067,10 +1067,11 @@ exports.LoadUtils = () => {
                         ? response.value.membershipRequestsActionApprove
                         : response.value.membershipRequestsActionReject;
                     if (value?.participant) {
-                        const [_] = value.participant.map(p => {
-                            const error = toApprove
-                                ? value.participant[0].membershipRequestsActionAcceptParticipantMixins?.value.error
-                                : value.participant[0].membershipRequestsActionRejectParticipantMixins?.value.error;
+                        const participantResults = value.participant.map(p => {
+                            const mixins = toApprove
+                                ? p.membershipRequestsActionAcceptParticipantMixins
+                                : p.membershipRequestsActionRejectParticipantMixins;
+                            const error = mixins?.value?.error;
                             return {
                                 requesterId: window.Store.WidFactory.createWid(p.jid)._serialized,
                                 ...(error
@@ -1078,7 +1079,7 @@ exports.LoadUtils = () => {
                                     : { message: `${toApprove ? 'Approved' : 'Rejected'} successfully` })
                             };
                         });
-                        _ && result.push(_);
+                        result.push(...participantResults);
                     }
                 } else {
                     result.push({


### PR DESCRIPTION
## Summary

This PR fixes five functional bugs related to incorrect JavaScript array method usage and logic errors.

## Bug Details

### 1. `splice()` should be `slice()` in Chat.js

**File:** `src/structures/Chat.js:216`

```javascript
// Before (incorrect)
msgs = msgs.splice(msgs.length - searchOptions.limit);

// After (correct)
msgs = msgs.slice(-searchOptions.limit);
```

**Problem:** `Array.splice()` mutates the original array in-place and returns the removed elements. The intent was to get the last N messages, but `splice()` causes unintended side effects.

---

### 2. Same `splice()` bug in Channel.js

**File:** `src/structures/Channel.js:313`

Identical fix as Chat.js.

---

### 3. Unused `.map()` result in GroupChat.js

**File:** `src/structures/GroupChat.js:113-115`

```javascript
// Before (incorrect) - result discarded
groupParticipants.map(({ id }) => {
    return id.server === 'lid' ? window.Store.LidUtils.getPhoneNumber(id) : id;
});

// After (correct) - result assigned
groupParticipants = groupParticipants.map(({ id }) => {
    return id.server === 'lid' ? window.Store.LidUtils.getPhoneNumber(id) : id;
});
```

**Impact:** Group participant operations may fail for accounts using LID format.

---

### 4. Operator precedence bug in GroupChat.js

**File:** `src/structures/GroupChat.js:118`

```javascript
// Before (ambiguous)
if (!Array.isArray(sleep) || sleep.length === 2 && sleep[0] === sleep[1]) {

// After (explicit)
if (!Array.isArray(sleep) || (sleep.length === 2 && sleep[0] === sleep[1])) {
```

**Problem:** `&&` has higher precedence than `||`. Added parentheses for clarity.

---

### 5. Only first participant processed in Utils.js

**File:** `src/util/Injected/Utils.js:1070-1081`

```javascript
// Before (incorrect) - only first element used
const [_] = value.participant.map(p => {
    const error = value.participant[0].membershipRequestsAction...  // Always [0]!
    ...
});
_ && result.push(_);

// After (correct) - all participants processed
const participantResults = value.participant.map(p => {
    const mixins = p.membershipRequestsAction...  // Uses current participant
    ...
});
result.push(...participantResults);
```

**Impact:** When approving/rejecting multiple group join requests, only the first one was processed.

---

## Test Plan

- [x] Code review for correctness
- [ ] Manual testing with WhatsApp Web (requires live account)

## References

- MDN: [Array.prototype.splice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice)
- MDN: [Array.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice)
- MDN: [Array.prototype.map()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map)