### PR TITLE
fix: prevent destroy() from hanging when browser disconnected

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -846,7 +846,9 @@ class Client extends EventEmitter {
      * Closes the client
      */
     async destroy() {
-        await this.pupBrowser.close();
+        if (this.pupBrowser?.isConnected()) {
+            await this.pupBrowser.close();
+        }
         await this.authStrategy.destroy();
     }
 


### PR DESCRIPTION
## Summary

When the browser process has already been terminated or disconnected (e.g., crashed, killed externally, or connection lost), calling `destroy()` would hang indefinitely because `pupBrowser.close()` never resolves.

This fix adds a check using `isConnected()` before attempting to close the browser, preventing the hang.

## Changes

- Added `isConnected()` check in `destroy()` method before calling `close()`

## Issue

Fixes #3846

## Test

The fix prevents `destroy()` from hanging when:
1. Browser process was killed externally
2. Browser crashed
3. Connection to browser was lost

Before fix:
```javascript
await client.destroy(); // Hangs indefinitely if browser disconnected
```

After fix:
```javascript
await client.destroy(); // Returns immediately if browser not connected
```