### PR TITLE
fix(LocalAuth): handle EBUSY and ENOTEMPTY errors with retry delay

### DIFF
--- a/src/authStrategies/LocalAuth.js
+++ b/src/authStrategies/LocalAuth.js
@@ -55,12 +55,12 @@ class LocalAuth extends BaseAuthStrategy {
                     // Handle EBUSY (resource busy) and ENOTEMPTY (directory not empty) errors
                     // These commonly occur on Windows when Chrome hasn't fully released file locks
                     if ((e.code === 'EBUSY' || e.code === 'ENOTEMPTY') && retries < this.rmMaxRetries - 1) {
-                        retries++;
-                        // Wait before retrying, with exponential backoff
+                        // Wait before retrying, with exponential backoff (100ms, 200ms, 400ms, 800ms)
                         await new Promise(resolve => setTimeout(resolve, 100 * Math.pow(2, retries)));
+                        retries++;
                         continue;
                     }
-                    throw new Error(e);
+                    throw e;
                 }
             }
         }


### PR DESCRIPTION
# PR Details

Fix LocalAuth logout() throwing unhandled errors when session directory cannot be deleted immediately.

## Description

The `logout()` method now properly handles `EBUSY` (resource busy) and `ENOTEMPTY` (directory not empty) errors by implementing a retry mechanism with exponential backoff delay.

### Changes:
- Add retry loop with configurable max retries (uses existing `rmMaxRetries` option)
- Add exponential backoff delay (100ms, 200ms, 400ms, 800ms) between retries
- Only retry on EBUSY/ENOTEMPTY errors, other errors are thrown immediately

## Related Issue(s)

closes #3903
closes #3904
closes #3976

## Motivation and Context

On Windows, Chrome/Chromium doesn't immediately release file locks when the browser closes. This causes `fs.promises.rm()` to fail with EBUSY or ENOTEMPTY errors, crashing the Node.js process.

The previous implementation used `maxRetries` option of `fs.promises.rm()`, but this option doesn't add delay between retries, making it ineffective for file lock issues.

## How Has This Been Tested

Code review and static analysis.

### Environment

- Machine OS: Mac
- Phone OS: N/A
- Library Version: latest
- WhatsApp Web Version: N/A
- Puppeteer Version: latest
- Browser Type and Version: Chromium
- Node Version: 20

## Types of changes

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)