### PR TITLE
fix(getContact): handle LID colon format and undefined phoneNumber

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -658,9 +658,13 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.getContact = async contactId => {
+        // Handle LID format with colon (e.g., "123456:21@lid" -> "123456@lid")
+        if (contactId.includes(':') && contactId.endsWith('@lid')) {
+            contactId = contactId.replace(/:\d+@lid$/, '@lid');
+        }
         const wid = window.Store.WidFactory.createWid(contactId);
         let contact = await window.Store.Contact.find(wid);
-        if (contact.id._serialized.endsWith('@lid')) {
+        if (contact.id?._serialized?.endsWith('@lid') && contact.phoneNumber) {
             contact.id = contact.phoneNumber;
         }
         const bizProfile = await window.Store.BusinessProfile.fetchBizProfile(wid);

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -664,6 +664,9 @@ exports.LoadUtils = () => {
         }
         const wid = window.Store.WidFactory.createWid(contactId);
         let contact = await window.Store.Contact.find(wid);
+        if (!contact) {
+            throw new Error(`Contact not found for ID: ${contactId}`);
+        }
         if (contact.id?._serialized?.endsWith('@lid') && contact.phoneNumber) {
             contact.id = contact.phoneNumber;
         }

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -658,7 +658,11 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.getContact = async contactId => {
+        if (!contactId || typeof contactId !== 'string') {
+            throw new Error('contactId must be a non-empty string');
+        }
         // Handle LID format with colon (e.g., "123456:21@lid" -> "123456@lid")
+        // Pre-checks avoid regex execution on non-matching strings for performance
         if (contactId.includes(':') && contactId.endsWith('@lid')) {
             contactId = contactId.replace(/:\d+@lid$/, '@lid');
         }


### PR DESCRIPTION
# PR Details

Fix `getContact()` and `msg.getContact()` throwing "Data passed to getter must include an id property" error.

## Description

### Changes:
1. **Handle LID colon format**: Some `msg.author` values contain format like `123456:21@lid` (with colon and extra digits). This is now sanitized to `123456@lid` before processing.

2. **Guard against undefined phoneNumber**: Added optional chaining and null check before replacing `contact.id` with `contact.phoneNumber` to prevent errors when `phoneNumber` is undefined.

## Related Issue(s)

closes #4000

## Motivation and Context

In group chats, some message events have `author` field with abnormal LID format containing a colon (e.g., `154864650254076:21@lid`). This causes `getContact()` to fail because:
1. `createWid()` may not handle this format correctly
2. When `contact.phoneNumber` is undefined, setting `contact.id = contact.phoneNumber` causes `getIsMe()` to throw an error

## How Has This Been Tested

Code review and static analysis based on user-reported stack traces.

### Environment

- Machine OS: Mac
- Phone OS: N/A
- Library Version: latest
- WhatsApp Web Version: N/A
- Puppeteer Version: latest
- Browser Type and Version: Chromium
- Node Version: 20

## Types of changes

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)