### PR TITLE
fix: use markSeen instead of sendSeen to fix markedUnread error

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -13,7 +13,7 @@ exports.LoadUtils = () => {
         const chat = await window.WWebJS.getChat(chatId, { getAsModel: false });
         if (chat) {
             window.Store.WAWebStreamModel.Stream.markAvailable();
-            await window.Store.SendSeen.sendSeen(chat);
+            await window.Store.SendSeen.markSeen(chat);
             window.Store.WAWebStreamModel.Stream.markUnavailable();
             return true;
         }


### PR DESCRIPTION
## Summary

Fixes `TypeError: Cannot read properties of undefined (reading 'markedUnread')` that occurs in newer WhatsApp Web versions.

**Closes #5718**

## Changes

Replaces `window.Store.SendSeen.sendSeen(chat)` with `window.Store.SendSeen.markSeen(chat)` in the `sendSeen` utility function.

## Root Cause

The `sendSeen` method in WhatsApp Web's internal API was changed/removed in recent updates. The method now throws an error when trying to access `chat.markedUnread` which may be undefined.

## Solution

Use `markSeen` instead of `sendSeen` - this method is still available and works correctly with the current WhatsApp Web version.

## Credits

This fix was discovered through community collaboration in #5718:

- @cp1797 - First identified the version pinning workaround
- @eltonnicolau - Discovered the `sendSeen: false` option workaround  
- @telmedola - Found that replacing `sendSeen` with `markSeen` works
- @qw271862028 - Provided detailed root cause analysis
- @duola8789 - Contributed comprehensive alternative implementation

Thank you all for your contributions! 🙏