### PR TITLE
AppState.hasSynced may already be true when listeners are registered, especially in fast session restores (Docker/headless).

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -285,8 +285,16 @@ class Client extends EventEmitter {
             await this.pupPage.waitForNavigation({waitUntil: 'load', timeout: 5000}).catch((_) => _);
         });
         await this.pupPage.evaluate(() => {
-            window.AuthStore.AppState.on('change:state', (_AppState, state) => { window.onAuthAppStateChangedEvent(state); });
-            window.AuthStore.AppState.on('change:hasSynced', () => { window.onAppStateHasSyncedEvent(); });
+            const appState = window.AuthStore.AppState;
+            if (appState.hasSynced) {
+                window.onAppStateHasSyncedEvent();
+            }
+            appState.on('change:hasSynced', (_AppState, hasSynced) => {
+                if (hasSynced) {
+                    window.onAppStateHasSyncedEvent();
+                }
+            });
+            appState.on('change:state', (_AppState, state) => { window.onAuthAppStateChangedEvent(state); });
             window.AuthStore.Cmd.on('offline_progress_update', () => {
                 window.onOfflineProgressUpdateEvent(window.AuthStore.OfflineMessageHandler.getOfflineDeliveryProgress()); 
             });


### PR DESCRIPTION
# PR Details

AppState.hasSynced may already be true when listeners are registered, especially in fast session restores (Docker/headless).
In that case, change:hasSynced is never emitted and onAppStateHasSyncedEvent is never called.

## Description

This race condition can prevent firing the 'authenticated' an 'ready' events.

## Related Issue(s)
closes #5685 closes #5758

## Motivation and Context

I want this change because when I restart my service using whatsapp-web.js, sometimes the session is not recovering, no errors, just not firing the authenticated event. When that happens, usually I delete my session and scan the QR again to recover the session.

I read the Clients.js code and notice a race condition event, when I fix it, the session was recovered and the event authenticated was fired again.

## How Has This Been Tested

I've tested the issue with the following configuration:

``` javascript
const whatsClient = new Client({
                    puppeteer: {
                        args: [
                            '--no-sandbox',
                            '--disable-setuid-sandbox',
                            '--disable-dev-shm-usage',
                            '--disable-accelerated-2d-canvas',
                            '--no-first-run',
                            '--no-zygote',
                            '--single-process',
                            '--disable-gpu',
                            '--disable-popup-blocking'
                        ],
                        headless: true,
                    },
                    headless: true,
                    authStrategy: new LocalAuth(),
                    webVersionCache = {
                              type: 'remote' ,
                              remotePath: 'https://raw.githubusercontent.com/wppconnect-team/wa-version/fd3e915c152e48950fb2be9adc196ebb3bf96d71/html/2.3000.1031980585-alpha.html',
                     };
});
```

Before the changes the authenticated method is never firing and after the changes the authenticated event is firing on every restart.

### Environment

<!-- Include details of your testing environment: -->
- Machine OS: Socker node:18.6.0-alpine3.16 over an Debian GNU/Linux 12 (bookworm) host.
- Phone OS: Android 16
- Library Version: 1.34.2
- WhatsApp Web Version: 2.3000.1031980585
- Puppeteer Version: 18.2.1
- Browser Type and Version: HeadlessChrome/102.0.5005.182
- Node Version: 8.13.2

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)