### PR TITLE
fix: ready event from not firing after extended operation, error on getChats/getChatByID

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1998,7 +1998,7 @@ class Client extends EventEmitter {
             const channel = await window.WWebJS.getChat(channelId, { getAsModel: false });
             const newOwner = window.Store.Contact.get(newOwnerId) || (await window.Store.Contact.find(newOwnerId));
             if (!channel.newsletterMetadata) {
-                await window.Store.NewsletterMetadataCollection.update(channel.id);
+                await window.Store.NewsletterMetadataCollection?.update(channel.id);
             }
 
             try {

--- a/src/Client.js
+++ b/src/Client.js
@@ -1494,7 +1494,8 @@ class Client extends EventEmitter {
      */
     async setDisplayName(displayName) {
         const couldSet = await this.pupPage.evaluate(async displayName => {
-            if(!window.Store.Conn.canSetMyPushname()) return false;
+            if(!window.Store.Conn?.canSetMyPushname()) return false;
+            if(typeof window.Store.Settings?.setPushname !== 'function') return false;
             await window.Store.Settings.setPushname(displayName);
             return true;
         }, displayName);
@@ -1508,7 +1509,7 @@ class Client extends EventEmitter {
      */
     async getState() {
         return await this.pupPage.evaluate(() => {
-            if(!window.Store) return null;
+            if(!window.Store || !window.Store.AppState) return null;
             return window.Store.AppState.state;
         });
     }
@@ -2258,7 +2259,7 @@ class Client extends EventEmitter {
     async addOrRemoveLabels(labelIds, chatIds) {
 
         return this.pupPage.evaluate(async (labelIds, chatIds) => {
-            if (['smba', 'smbi'].indexOf(window.Store.Conn.platform) === -1) {
+            if (['smba', 'smbi'].indexOf(window.Store.Conn?.platform) === -1) {
                 throw '[LT01] Only Whatsapp business';
             }
             const labels = window.WWebJS.getLabels().filter(e => labelIds.find(l => l == e.id) !== undefined);

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -274,7 +274,7 @@ class GroupChat extends Chat {
     async setDescription(description) {
         const success = await this.client.pupPage.evaluate(async (chatId, description) => {
             const chatWid = window.Store.WidFactory.createWid(chatId);
-            let descId = window.Store.GroupMetadata.get(chatWid).descId;
+            let descId = window.Store.GroupMetadata?.get(chatWid)?.descId;
             let newId = await window.Store.MsgKey.newId();
             try {
                 await window.Store.GroupUtils.setGroupDescription(chatWid, description, newId, descId);

--- a/src/util/Injected/Store.js
+++ b/src/util/Injected/Store.js
@@ -207,6 +207,16 @@ exports.ExposeStore = () => {
         ...window.require('WAWebStatusGatingUtils')
     };
 
+    // GroupMetadata moved to WAWebGroupMetadataCollection in WWeb 2.3000.x
+    if (!window.Store.GroupMetadata) {
+        try {
+            const mod = window.require('WAWebGroupMetadataCollection');
+            window.Store.GroupMetadata = mod?.GroupMetadata ?? mod?.default;
+        } catch {
+            // Module doesn't exist in older versions
+        }
+    }
+
     if (!window.Store.Chat._find || !window.Store.Chat.findImpl) {
         window.Store.Chat._find = e => {
             const target = window.Store.Chat.get(e);

--- a/src/util/Injected/Store.js
+++ b/src/util/Injected/Store.js
@@ -44,9 +44,25 @@ exports.ExposeStore = () => {
     };
 
     window.Store = Object.assign({}, window.require('WAWebCollections'));
-    window.Store.AppState = window.require('WAWebSocketModel').Socket;
+
+    // AppState - critical for connection state events (disconnected, etc.)
+    // May have moved or changed structure in WWeb 2.3000.x
+    try {
+        const socketModel = window.require('WAWebSocketModel');
+        window.Store.AppState = socketModel?.Socket ?? socketModel?.AppState ?? socketModel?.default?.Socket;
+    } catch {
+        // Module doesn't exist or structure changed
+    }
+
     window.Store.BlockContact = window.require('WAWebBlockContactAction');
-    window.Store.Conn = window.require('WAWebConnModel').Conn;
+
+    // Conn - for connection/battery events
+    try {
+        const connModel = window.require('WAWebConnModel');
+        window.Store.Conn = connModel?.Conn ?? connModel?.default?.Conn ?? connModel?.default;
+    } catch {
+        // Module doesn't exist or structure changed
+    }
     window.Store.Cmd = window.require('WAWebCmd').Cmd;
     window.Store.DownloadManager = window.require('WAWebDownloadManager').downloadManager;
     window.Store.GroupQueryAndUpdate = window.require('WAWebGroupQueryJob').queryAndUpdateGroupMetadataById;
@@ -207,7 +223,12 @@ exports.ExposeStore = () => {
         ...window.require('WAWebStatusGatingUtils')
     };
 
-    // GroupMetadata moved to WAWebGroupMetadataCollection in WWeb 2.3000.x
+    // =====================================================
+    // Fallback loading for modules that may have moved in WWeb 2.3000.x
+    // These modules might no longer be in WAWebCollections
+    // =====================================================
+
+    // GroupMetadata moved to WAWebGroupMetadataCollection
     if (!window.Store.GroupMetadata) {
         try {
             const mod = window.require('WAWebGroupMetadataCollection');
@@ -217,7 +238,64 @@ exports.ExposeStore = () => {
         }
     }
 
-    if (!window.Store.Chat._find || !window.Store.Chat.findImpl) {
+    // Msg collection - critical for message events
+    if (!window.Store.Msg) {
+        try {
+            const mod = window.require('WAWebMsgCollection');
+            window.Store.Msg = mod?.Msg ?? mod?.MsgCollection ?? mod?.default;
+        } catch {
+            // Try alternative module name
+            try {
+                const mod = window.require('WAWebMessageCollection');
+                window.Store.Msg = mod?.Msg ?? mod?.default;
+            } catch {
+                // Module doesn't exist
+            }
+        }
+    }
+
+    // Chat collection - critical for chat events
+    if (!window.Store.Chat) {
+        try {
+            const mod = window.require('WAWebChatCollection');
+            window.Store.Chat = mod?.Chat ?? mod?.ChatCollection ?? mod?.default;
+        } catch {
+            // Module doesn't exist
+        }
+    }
+
+    // Call collection - for incoming call events
+    if (!window.Store.Call) {
+        try {
+            const mod = window.require('WAWebCallCollection');
+            window.Store.Call = mod?.Call ?? mod?.CallCollection ?? mod?.default;
+        } catch {
+            // Module doesn't exist
+        }
+    }
+
+    // AppState fallback - critical for disconnected event
+    if (!window.Store.AppState) {
+        try {
+            // Try alternative module names
+            const mod = window.require('WAWebAppStateModel') ?? window.require('WAWebSocketAppState');
+            window.Store.AppState = mod?.Socket ?? mod?.AppState ?? mod?.default;
+        } catch {
+            // Module doesn't exist
+        }
+    }
+
+    // Conn fallback - for battery/connection events
+    if (!window.Store.Conn) {
+        try {
+            const mod = window.require('WAWebConnCollection');
+            window.Store.Conn = mod?.Conn ?? mod?.default;
+        } catch {
+            // Module doesn't exist
+        }
+    }
+
+    if (window.Store.Chat && (!window.Store.Chat._find || !window.Store.Chat.findImpl)) {
         window.Store.Chat._find = e => {
             const target = window.Store.Chat.get(e);
             return target ? Promise.resolve(target) : Promise.resolve({

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -13,7 +13,13 @@ exports.LoadUtils = () => {
         const chat = await window.WWebJS.getChat(chatId, { getAsModel: false });
         if (chat) {
             window.Store.WAWebStreamModel.Stream.markAvailable();
-            await window.Store.SendSeen.markSeen(chat);
+            try {
+                // New signature for WWeb 2.3000+ (PR #5729)
+                await window.Store.SendSeen.sendSeen({ chat: chat, threadId: undefined });
+            } catch {
+                // Fallback to old signature for older versions
+                await window.Store.SendSeen.sendSeen(chat);
+            }
             window.Store.WAWebStreamModel.Stream.markUnavailable();
             return true;
         }

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -639,7 +639,7 @@ exports.LoadUtils = () => {
         if (chat.groupMetadata) {
             model.isGroup = true;
             const chatWid = window.Store.WidFactory.createWid(chat.id._serialized);
-            await window.Store.GroupMetadata.update(chatWid);
+            await window.Store.GroupMetadata?.update(chatWid);
             chat.groupMetadata.participants._models
                 .filter(x => x.id?._serialized?.endsWith('@lid'))
                 .forEach(x => x.contact?.phoneNumber && (x.id = x.contact.phoneNumber));
@@ -648,7 +648,7 @@ exports.LoadUtils = () => {
         }
 
         if (chat.newsletterMetadata) {
-            await window.Store.NewsletterMetadataCollection.update(chat.id);
+            await window.Store.NewsletterMetadataCollection?.update(chat.id);
             model.channelMetadata = chat.newsletterMetadata.serialize();
             model.channelMetadata.createdAtTs = chat.newsletterMetadata.creationTime;
         }

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -212,7 +212,7 @@ exports.LoadUtils = () => {
 
         let listOptions = {};
         if (options.list) {
-            if (window.Store.Conn.platform === 'smba' || window.Store.Conn.platform === 'smbi') {
+            if (window.Store.Conn?.platform === 'smba' || window.Store.Conn?.platform === 'smbi') {
                 throw '[LT01] Whatsapp business can\'t send this yet';
             }
             listOptions = {

--- a/src/util/Puppeteer.js
+++ b/src/util/Puppeteer.js
@@ -1,23 +1,41 @@
 /**
- * Expose a function to the page if it does not exist
- *
- * NOTE:
- * Rewrite it to 'upsertFunction' after updating Puppeteer to 20.6 or higher
- * using page.removeExposedFunction
- * https://pptr.dev/api/puppeteer.page.removeexposedfunction
+ * Expose a function to the page, handling the case where the CDP binding
+ * already exists (e.g., after page navigation where the page context is
+ * cleared but the CDP binding persists).
  *
  * @param {object} page - Puppeteer Page instance
  * @param {string} name
  * @param {Function} fn
  */
 async function exposeFunctionIfAbsent(page, name, fn) {
-    const exist = await page.evaluate((name) => {
+    // Check if the function exists in the page context
+    const existsInPage = await page.evaluate((name) => {
         return !!window[name];
     }, name);
-    if (exist) {
+
+    if (existsInPage) {
         return;
     }
-    await page.exposeFunction(name, fn);
+
+    // Try to expose the function, handling the case where the CDP binding
+    // already exists (can happen after page navigation)
+    try {
+        await page.exposeFunction(name, fn);
+    } catch (err) {
+        if (err.message && err.message.includes('already exists')) {
+            // CDP binding exists but page context was cleared (after navigation)
+            // Remove the old binding and re-add it with the new function
+            try {
+                await page.removeExposedFunction(name);
+                await page.exposeFunction(name, fn);
+            } catch (removeErr) {
+                // If removal fails, the binding is still usable from the previous expose
+                // This can happen in older Puppeteer versions
+            }
+        } else {
+            throw err;
+        }
+    }
 }
 
 module.exports = {exposeFunctionIfAbsent};


### PR DESCRIPTION
# PR Details                                                                                                                                                                              
                                                                                                                                                                                            
  ## Description                                                                                                                                                                            
                                                                                                                                                                                            
  Fixes multiple root causes that prevent the ready event from firing after extended operation or in certain WhatsApp Web versions:                                                         
                                                                                                                                                                                            
  1. **Race condition fix**: Check if `hasSynced` is already true before registering the change listener, as fast session restores may complete before the listener is attached             
  2. **Page navigation detection**: Track listener registration state in both client-side (`_authEventListenersInjected`) and page context (`window._authListenersRegistered`) to           
  re-register after navigation                                                                                                                                                              
  3. **Error handling**: Wrap `onAppStateHasSyncedEvent` in try-catch to emit `AUTHENTICATION_FAILURE` instead of silently failing                                                          
  4. **Duplicate event prevention**: Add `_readyEmitted` flag to prevent multiple READY events if hasSynced toggles                                                                         
  5. **Store property guards**: Add null checks for all Store properties (Msg, AppState, Conn, Call, Chat, etc.) in `attachEventListeners` to handle WhatsApp A/B testing variations where  
  some modules may not be available                                                                                                                                                         
  6. **IndexedDB persistence**: Request storage persistence and add delay in `destroy()` to allow pending writes to flush, preventing session corruption especially for Business WhatsApp   
  accounts                                                                                                                                                                                  
                                                                                                                                                                                            
  ## Related Issue(s)                                                                                                                                                                       
                                                                                                                                                                                            
  closes #5717 closes #5685 closes #3971                                                                                                                                                    
                                                                                                                                                                                            
  ## Motivation and Context                                                                                                                                                                 
                                                                                                                                                                                            
  Users reported that after several days of operation, the client stops emitting the ready event despite successful authentication. The root causes include race conditions with            
  `hasSynced`, page navigation losing event listeners, and WhatsApp A/B testing making certain Store modules unavailable. This PR addresses all identified causes comprehensively.          
                                                                                                                                                                                            
  ## How Has This Been Tested                                                                                                                                                               
                                                                                                                                                                                            
  Tested by verifying the client initializes correctly and emits ready events. The guards prevent crashes when Store properties are undefined.                                              
                                                                                                                                                                                            
  ### Environment                                                                                                                                                                           
                                                                                                                                                                                            
  - Machine OS: <!-- Fill in -->                                                                                                                                                            
  - Phone OS: <!-- Fill in -->                                                                                                                                                              
  - Library Version: 1.34.5-alpha.3                                                                                                                                                         
  - WhatsApp Web Version: <!-- Run await client.getWWebVersion() -->                                                                                                                        
  - Puppeteer Version: <!-- Fill in -->                                                                                                                                                     
  - Browser Type and Version: Chromium                                                                                                                                                      
  - Node Version: <!-- Fill in -->                                                                                                                                                          
                                                                                                                                                                                            
  ## Types of changes                                                                                                                                                                       
                                                                                                                                                                                            
  - [ ] Dependency change                                                                                                                                                                   
  - [X] Bug fix (non-breaking change which fixes an issue)                                                                                                                                  
  - [ ] New feature (non-breaking change which adds functionality)                                                                                                                          
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)                                                                                                  
                                                                                                                                                                                            
  ## Checklist                                                                                                                                                                              
                                                                                                                                                                                            
  - [X] My code follows the code style of this project.                                                                                                                                     
  - [ ] I have updated the documentation accordingly (index.d.ts).                                                                                                                          
  - [ ] I have updated the usage example accordingly (example.js)