### PR TITLE
fix(events): restore ready & message delivery after WA Web changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whatsapp-web.js",
-  "version": "1.34.5-alpha.3",
+  "version": "1.34.5-alpha.3-douglas.1",
   "description": "Library for interacting with the WhatsApp Web API ",
   "main": "./index.js",
   "typings": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whatsapp-web.js",
-  "version": "1.34.5-alpha.3-douglas.1",
+  "version": "1.34.5-alpha.3-douglas.2",
   "description": "Library for interacting with the WhatsApp Web API ",
   "main": "./index.js",
   "typings": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whatsapp-web.js",
-  "version": "1.34.5-alpha.3-douglas.2",
+  "version": "1.34.5-alpha.3-fix.1",
   "description": "Library for interacting with the WhatsApp Web API ",
   "main": "./index.js",
   "typings": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whatsapp-web.js",
-  "version": "1.34.5-alpha.3-fix.1",
+  "version": "1.34.5-alpha.3-events-fix.1",
   "description": "Library for interacting with the WhatsApp Web API ",
   "main": "./index.js",
   "typings": "./index.d.ts",

--- a/src/Client.js
+++ b/src/Client.js
@@ -1007,10 +1007,14 @@ class Client extends EventEmitter {
             const toModel = (msg) => {
                 try {
                     if (window.WWebJS?.getMessageModel) return window.WWebJS.getMessageModel(msg);
-                } catch (_) {}
+                } catch (_) {
+                    // Ignore and fall back to other serialization paths.
+                }
                 try {
                     if (msg?.serialize) return msg.serialize();
-                } catch (_) {}
+                } catch (_) {
+                    // Ignore serialization errors and fall back to raw message.
+                }
                 return msg;
             };
             const emitIfNew = (msg) => {


### PR DESCRIPTION
## Summary
- Add AppState sync fallback to ensure `ready` is emitted even when `hasSynced` no longer fires reliably.
- Improve message event reliability with safe serialization, dedupe, and polling fallback.
- Guard group metadata updates to avoid `undefined.update` runtime errors.

## Details
- AppState: emit sync on initial `hasSynced`, on `CONNECTED`, and via timeout fallback.
- Messages: safe `toModel()` resolution and dedupe; polling recent messages when `Store.Msg.on('add')` fails.
- Groups: best-effort metadata update using available WA Web stores.

## Tests
- `npx eslint src/Client.js src/util/Injected/Utils.js`
- Manual: connect session, verify `ready`, verify `message` events (including ciphertext -> resolved).