### PR TITLE
fix: update call handling for recent WhatsApp Web changes

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -756,7 +756,6 @@ class Client extends EventEmitter {
             window.Store.Msg.on('change:body change:caption', (msg, newBody, prevBody) => { window.onEditMessageEvent(window.WWebJS.getMessageModel(msg), newBody, prevBody); });
             window.Store.AppState.on('change:state', (_AppState, state) => { window.onAppStateChangedEvent(state); });
             window.Store.Conn.on('change:battery', (state) => { window.onBatteryStateChangedEvent(state); });
-            // WhatsApp Web renomeou Store.Call para WAWebCallCollection em versões recentes
             const callCollection = (window.Store && window.Store.Call) || (window.Store && window.Store.WAWebCallCollection);
             if (callCollection && typeof callCollection.on === 'function') {
                 callCollection.on('add', (call) => { window.onIncomingCall(call); });

--- a/src/Client.js
+++ b/src/Client.js
@@ -756,7 +756,11 @@ class Client extends EventEmitter {
             window.Store.Msg.on('change:body change:caption', (msg, newBody, prevBody) => { window.onEditMessageEvent(window.WWebJS.getMessageModel(msg), newBody, prevBody); });
             window.Store.AppState.on('change:state', (_AppState, state) => { window.onAppStateChangedEvent(state); });
             window.Store.Conn.on('change:battery', (state) => { window.onBatteryStateChangedEvent(state); });
-            window.Store.Call.on('add', (call) => { window.onIncomingCall(call); });
+            // WhatsApp Web renomeou Store.Call para WAWebCallCollection em versões recentes
+            const callCollection = (window.Store && window.Store.Call) || (window.Store && window.Store.WAWebCallCollection);
+            if (callCollection && typeof callCollection.on === 'function') {
+                callCollection.on('add', (call) => { window.onIncomingCall(call); });
+            }
             window.Store.Chat.on('remove', async (chat) => { window.onRemoveChatEvent(await window.WWebJS.getChatModel(chat)); });
             window.Store.Chat.on('change:archive', async (chat, currState, prevState) => { window.onArchiveChatEvent(await window.WWebJS.getChatModel(chat), currState, prevState); });
             window.Store.Msg.on('add', (msg) => { 


### PR DESCRIPTION
Updated the call handling logic to accommodate the renaming of Store.Call to WAWebCallCollection in recent WhatsApp Web versions. This ensures that incoming calls are properly managed without breaking functionality.

# PR Details

<!-- Provide here a general summary of your changes. -->

## Description

Updated the call handling logic to accommodate the renaming of Store.Call to WAWebCallCollection in recent WhatsApp Web versions. This ensures that incoming calls are properly managed without breaking functionality.

When Store.Call is undefined, the previous code threw "Cannot read properties of undefined (reading 'on')", which prevented the rest of attachEventListeners from running (including Store.Msg.on('add', ...)), so the client stopped receiving messages. The fallback fixes both call handling and message reception.

## Related Issue(s)

<!-- Optional --->
<!-- If there is an issue related to the PR, link it here using a 'closes' keyword, for example: -->
<!-- closes #XXXX (where the XXXX is an issue number) -->
<!-- If there are multiple issues, link them as follows: -->
<!-- closes #XXXX closes #YYYY closes #ZZZZ -->
<!-- See more here: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Motivation and Context

In recent WhatsApp Web builds, Store.Call was renamed to WAWebCallCollection. The code assumed Store.Call always existed and called Store.Call.on('add', ...), which threw when Store.Call was undefined. That exception aborted the entire page.evaluate(), so Store.Msg.on('add', ...) was never registered and the client never received messages. This change uses Store.Call when present, otherwise WAWebCallCollection, and only registers if the collection exists and has an .on method.

## How Has This Been Tested

Manual testing: ran the client with the fix, linked via QR, confirmed READY fires and message_create events are received (e.g. !ping responds). Verified in browser DevTools that window.Store has WAWebCallCollection and no longer has Call.

### Environment

Machine OS: WSL2 (Linux)
Phone OS: (e.g. Android)
Library Version: (github:pedroslopez/whatsapp-web.js#auto-wa-web-update/patch)
WhatsApp Web Version: '2.3000.1032614117'
Puppeteer Version: 24.36.1 (puppeteer-core)
Browser Type and Version: Chromium (Puppeteer)
Node Version: v20.19.0

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)