### PR TITLE
Added support for getting the current user's display name

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -202,6 +202,11 @@ declare namespace WAWebJS {
          */
         setStatus(status: string): Promise<void>
 
+        /**
+         * Gets the current user's display name
+         */
+        getDisplayName(): Promise<string>
+
         /** 
          * Sets the current user's display name
          * @param displayName New display name

--- a/src/Client.js
+++ b/src/Client.js
@@ -1397,6 +1397,16 @@ class Client extends EventEmitter {
     }
 
     /**
+     * Gets the current display name for the client
+     * @returns {Promise<string|null>} Current display name
+     */
+    async getDisplayName() {
+        return this.pupPage.evaluate(() => {
+            return window.Store.Conn.pushname;
+        });
+    }
+
+    /**
      * Sets the current user's display name. 
      * This is the name shown to WhatsApp users that have not added you as a contact beside your number in groups and in your profile.
      * @param {string} displayName New display name


### PR DESCRIPTION
# PR Details

Added a way to get the display name of the current user.

## Description

Added a method to the client class to get the display name of the current user.

## Related Issue(s)

## Motivation and Context

I wanted to create a program that works with chat exports. They use the displayname of the user that created the export as the author for those messages. This change makes it much easier to work with those exports, as you can get the displayname directly from the client rather than through messages.

## How Has This Been Tested

Linked the updated package to my source code, and was able to get the username properly.

### Environment

- Machine OS: Debian 12
- Phone OS: -
- Library Version: 1.34.6
- WhatsApp Web Version: 2.3000.1032721183
- Puppeteer Version: 24.36.1
- Browser Type and Version: -
- Node Version: v22.18.0

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)