### PR TITLE
fixed error i.getLastMsgKeyForAction

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -981,7 +981,7 @@ class Client extends EventEmitter {
      * @returns {Promise<Message>} Message that was just sent
      */
     async sendMessage(chatId, content, options = {}) {
-        const isChannel = /@\w*newsletter\b/.test(chatId);
+        const isChannel = /@newsletter\b/.test(chatId);
         const isStatus = /@\w*broadcast\b/.test(chatId);
 
         if (isChannel && [
@@ -1033,7 +1033,7 @@ class Client extends EventEmitter {
             extraOptions: options.extra
         };
 
-        const sendSeen = options.sendSeen !== false;
+        const sendSeen = (options.sendSeen !== false) && !isChannel;
 
         if (content instanceof MessageMedia) {
             internalOptions.media = content;

--- a/src/Client.js
+++ b/src/Client.js
@@ -981,7 +981,7 @@ class Client extends EventEmitter {
      * @returns {Promise<Message>} Message that was just sent
      */
     async sendMessage(chatId, content, options = {}) {
-        const isChannel = /@newsletter\b/.test(chatId);
+        const isChannel = /@\w*newsletter\b/.test(chatId);
         const isStatus = /@\w*broadcast\b/.test(chatId);
 
         if (isChannel && [

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -12,6 +12,10 @@ exports.LoadUtils = () => {
     window.WWebJS.sendSeen = async (chatId) => {
         const chat = await window.WWebJS.getChat(chatId, { getAsModel: false });
         if (chat) {
+            const isChannel = window.Store.ChatGetters.getIsNewsletter(chat);
+            if (isChannel) {
+                return true; // Skip sendSeen for channels
+            }
             window.Store.WAWebStreamModel.Stream.markAvailable();
             await window.Store.SendSeen.sendSeen({
                 chat: chat,


### PR DESCRIPTION
# WhatsApp Web.js Newsletter Fix

## The Problem

I was getting this error when trying to send messages to WhatsApp Newsletters: `TypeError: i.getLastMsgKeyForAction is not a function`.

## What Was Happening

The library was trying to mark newsletter chats as "read" after sending messages (that's the sendSeen feature), but newsletter chats don't have that `getLastMsgKeyForAction` method that regular chats have. So it would crash every time.

## My Fix

I modified the `sendMessage` function in `Client.js` to automatically skip the sendSeen feature for newsletter chats. Now it detects if the chat ID ends with `@newsletter` and disables sendSeen just for those chats.

## Code Changes

In `src/Client.js`:
```javascript
// Before
const sendSeen = options.sendSeen !== false;

// After  
const sendSeen = (options.sendSeen !== false) && !isChannel;
```

Where `isChannel` checks if the chat ID contains `@newsletter`.

I also added a safety check in the `sendSeen` function itself in case someone calls it directly on a newsletter chat.

## Result

- ✅ Newsletter messages now work without crashing
- ✅ Regular chats still work normally
- ✅ No breaking changes to existing code

That's the main fix I implemented for the newsletter messaging issue.</content>