### PR TITLE
Fix setDescription to use updated group metadata

### DIFF
--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -274,7 +274,8 @@ class GroupChat extends Chat {
     async setDescription(description) {
         const success = await this.client.pupPage.evaluate(async (chatId, description) => {
             const chatWid = window.Store.WidFactory.createWid(chatId);
-            let descId = window.Store.GroupMetadata.get(chatWid).descId;
+            const chat = await window.WWebJS.getChat(chatId, { getAsModel: false });
+            let descId = chat.groupMetadata.descId;
             let newId = await window.Store.MsgKey.newId();
             try {
                 await window.Store.GroupUtils.setGroupDescription(chatWid, description, newId, descId);


### PR DESCRIPTION
# PR Details

<!-- Provide here a general summary of your changes. -->

## Description

<!-- Describe here your changes in detail. -->

## Related Issue(s)

<!-- Optional --->
<!-- If there is an issue related to the PR, link it here using a 'closes' keyword, for example: -->
<!-- closes #XXXX (where the XXXX is an issue number) -->
<!-- If there are multiple issues, link them as follows: -->
<!-- closes #XXXX closes #YYYY closes #ZZZZ -->
<!-- See more here: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Motivation and Context

<!-- Optional --->
<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!-- Please describe in detail how you tested your changes. -->

### Environment

<!-- Include details of your testing environment: -->
- Machine OS: <!-- The operation system of a machine you tested the PR on. (Mac | Windows | Linux | Docker + Ubuntu | other (provide the type)) -->
- Phone OS: <!-- The operation system of a phone you used to check the the PR functionality on. -->
- Library Version: <!-- The whatsapp-web.js version you used to test the PR. -->
- WhatsApp Web Version: <!-- Run `await client.getWWebVersion()` to see the WWeb version you used to test the PR. -->
- Puppeteer Version:
- Browser Type and Version: <!-- Chromium XX | Google Chrome XX | other (provide the type and version) -->
- Node Version: <!-- Run `npm -v` in your terminal to see the version of Node.js being used. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)