### PR TITLE
Fix getFormattedNumber

### DIFF
--- a/src/util/Injected/Store.js
+++ b/src/util/Injected/Store.js
@@ -121,7 +121,8 @@ exports.ExposeStore = () => {
     };
     window.Store.NumberInfo = {
         ...window.require('WAPhoneUtils'),
-        ...window.require('WAPhoneFindCC')
+        ...window.require('WAPhoneFindCC'),
+        ...window.require('WAWebPhoneUtils')
     };
     window.Store.ForwardUtils = {
         ...window.require('WAWebChatForwardMessage')


### PR DESCRIPTION
# PR Details

This PR fixes the method getFormattedNumber.

## Description

This PR fixes the method getFormattedNumber.

## Related Issues

Closes https://github.com/pedroslopez/whatsapp-web.js/issues/5812
Closes https://github.com/pedroslopez/whatsapp-web.js/issues/5814

## How Has This Been Tested

```
// client initialization...

client.on('ready', async () => {
     const numberFormatted = client.getFormattedNumber('xxxxxx@c.us');
     console.log(numberFormatted);
});
```

## You can try the fix by running one of the following commands:

- NPM
`npm install github:BenyFilho/whatsapp-web.js#fix_getFormattedNumber`

- YARN
`yarn add github:BenyFilho/whatsapp-web.js#fix_getFormattedNumber`

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)