### PR TITLE
fix: disconnected event is not being fired

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -293,6 +293,9 @@ class Client extends EventEmitter {
             window.AuthStore.Cmd.on('logout', async () => {
                 await window.onLogoutEvent();
             });
+            window.AuthStore.Cmd.on('logout_from_bridge', async () => {
+                await window.onLogoutEvent();
+            });
         });
     }
 


### PR DESCRIPTION
# PR Details

Fixes https://github.com/pedroslopez/whatsapp-web.js/issues/5802

## Description

Listen to `logout_from_bridge` AuthStore CMD event and executes `onLogoutEvent`

## Related Issue(s)

https://github.com/pedroslopez/whatsapp-web.js/issues/5802

## Motivation and Context

<!-- Optional --->
<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Manual testing, logging out from my mobile and seeing that the `disconnected` event is being fired with this change

### Environment

<!-- Include details of your testing environment: -->
- Machine OS: Mac OS M3 PRO
- Phone OS: Android
- Library Version: 1.34.6
- WhatsApp Web Version: 2.3000.1032900857
- Browser Type and Version: Chrome
- Node Version: 22

## Types of changes

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)