### PR TITLE
feat: add cancelPairingCode() and requestPairingCode() on QR clients

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -197,6 +197,9 @@ declare namespace WAWebJS {
             intervalMs?: number,
         ): Promise<string>;
 
+        /** Cancels an active pairing code session and returns to QR code mode */
+        cancelPairingCode(): Promise<void>
+
         /** Force reset of connection state for the client */
         resetState(): Promise<void>;
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -269,6 +269,7 @@ class Client extends EventEmitter {
                         advSecretKey +
                         ',' +
                         platform;
+                    window.getQR = getQR;
 
                     window.onQRChangedEvent(getQR(window.AuthStore.Conn.ref)); // initial qr
                     window.AuthStore.Conn.on('change:ref', (_, ref) => {
@@ -516,6 +517,14 @@ class Client extends EventEmitter {
         showNotification = true,
         intervalMs = 180000,
     ) {
+        await exposeFunctionIfAbsent(
+            this.pupPage,
+            'onCodeReceivedEvent',
+            async (code) => {
+                this.emit(Events.CODE_RECEIVED, code);
+                return code;
+            },
+        );
         return await this.pupPage.evaluate(
             async (phoneNumber, showNotification, intervalMs) => {
                 const getCode = async () => {
@@ -551,6 +560,20 @@ class Client extends EventEmitter {
             showNotification,
             intervalMs,
         );
+    }
+
+    /**
+     * Cancels an active pairing code session and returns to QR code mode
+     */
+    async cancelPairingCode() {
+        await this.pupPage.evaluate(() => {
+            if (window.codeInterval) {
+                clearInterval(window.codeInterval);
+                window.codeInterval = undefined;
+            }
+            window.AuthStore.PairingCodeLinkUtils.initializeQRLinking();
+            window.onQRChangedEvent(window.getQR(window.AuthStore.Conn.ref));
+        });
     }
 
     /**

--- a/src/Client.js
+++ b/src/Client.js
@@ -255,8 +255,6 @@ class Client extends EventEmitter {
                         window.AuthStore.Base64Tools.encodeB64(
                             registrationInfo.identityKeyPair.pubKey,
                         );
-                    const advSecretKey =
-                        await window.AuthStore.RegistrationUtils.getADVSecretKey();
                     const platform =
                         window.AuthStore.RegistrationUtils.DEVICE_PLATFORM;
                     const getQR = (ref) =>
@@ -266,11 +264,11 @@ class Client extends EventEmitter {
                         ',' +
                         identityKeyB64 +
                         ',' +
-                        advSecretKey +
+                        window
+                            .require('WAWebUserPrefsMultiDevice')
+                            .getADVSecretKey() +
                         ',' +
                         platform;
-                    window.getQR = getQR;
-
                     window.onQRChangedEvent(getQR(window.AuthStore.Conn.ref)); // initial qr
                     window.AuthStore.Conn.on('change:ref', (_, ref) => {
                         window.onQRChangedEvent(getQR(ref));
@@ -566,13 +564,15 @@ class Client extends EventEmitter {
      * Cancels an active pairing code session and returns to QR code mode
      */
     async cancelPairingCode() {
-        await this.pupPage.evaluate(() => {
+        await this.pupPage.evaluate(async () => {
             if (window.codeInterval) {
                 clearInterval(window.codeInterval);
                 window.codeInterval = undefined;
             }
-            window.AuthStore.PairingCodeLinkUtils.initializeQRLinking();
-            window.onQRChangedEvent(window.getQR(window.AuthStore.Conn.ref));
+            window.require('WAWebLaunchSocketUtils').refreshQR();
+            await window
+                .require('WAWebAltDeviceLinkingApi')
+                .initializeQRLinking();
         });
     }
 


### PR DESCRIPTION
## Summary

Add `cancelPairingCode()` method and allow `requestPairingCode()` to work on QR-initialized clients (not just clients initialized with `pairWithPhoneNumber` option).

## Changes

### `requestPairingCode()` - allow on QR-initialized clients
When called on a client that was initialized in QR mode, `onCodeReceivedEvent` may not be exposed yet (it is only set up in `initialize()` when `pairWithPhoneNumber` is configured). Added `exposeFunctionIfAbsent` call at the beginning of `requestPairingCode()` to ensure the callback is available regardless of initialization mode.

### `cancelPairingCode()` - new method
Cancels an active pairing code session and returns to QR code mode:
1. Clears the `window.codeInterval` refresh timer
2. Calls `PairingCodeLinkUtils.initializeQRLinking()` to switch WhatsApp Web back to QR mode
3. Re-emits the current QR code via `onQRChangedEvent` using the cached `getQR` helper

### `window.getQR` - cached QR builder
The `getQR` function (which builds the full QR string from registration keys) is now saved on `window` during `initialize()`. This is necessary because:
- `Store.Cmd.refreshQR()` is no longer available in current WhatsApp Web versions
- `getADVSecretKey()` returns null after `setPairingType("ALT_DEVICE_LINKING")` is called
- The `change:ref` listener registered in `initialize()` already uses this closure, so caching it on `window` allows `cancelPairingCode()` to reuse the same keys

### TypeScript definition
Added `cancelPairingCode(): Promise<void>` to `index.d.ts`.

## Use case

Allows switching between QR code and pairing code authentication **without destroying and recreating the client**. This enables UIs where users can toggle between QR scanning and phone number pairing on the same screen.

```js
const client = new Client({ /* QR mode (default) */ });
client.initialize();

// User wants to switch to pairing code
client.on("qr", () => { /* show QR */ });
const code = await client.requestPairingCode("1234567890");
// show pairing code to user

// User wants to switch back to QR
await client.cancelPairingCode();
// qr event fires again with fresh QR
```

## Testing

Tested full round-trip flow via E2E tests:
1. QR displayed -> switch to pairing code (received valid code)
2. Cancel pairing -> QR returns with valid scannable code
3. Switch to pairing again -> new code received
4. Cancel again -> QR returns

All transitions work without destroying the client.

Closes #22390