### PR TITLE
Remove old module

### DIFF
--- a/docs/util_Injected_Store.js.html
+++ b/docs/util_Injected_Store.js.html
@@ -151,8 +151,8 @@ exports.ExposeStore &#x3D; () &#x3D;&gt; {
         setPushname: window.require(&#x27;WAWebSetPushnameConnAction&#x27;).setPushname
     };
     window.Store.NumberInfo &#x3D; {
+        ...window.require(&#x27;WAPhoneUtils&#x27;),
         ...window.require(&#x27;WAPhoneFindCC&#x27;)
-        ...window.require(&#x27;WAWebPhoneUtils&#x27;),
     };
     window.Store.ForwardUtils &#x3D; {
         ...window.require(&#x27;WAWebChatForwardMessage&#x27;)

--- a/docs/util_Injected_Store.js.html
+++ b/docs/util_Injected_Store.js.html
@@ -151,8 +151,8 @@ exports.ExposeStore &#x3D; () &#x3D;&gt; {
         setPushname: window.require(&#x27;WAWebSetPushnameConnAction&#x27;).setPushname
     };
     window.Store.NumberInfo &#x3D; {
-        ...window.require(&#x27;WAPhoneUtils&#x27;),
         ...window.require(&#x27;WAPhoneFindCC&#x27;)
+        ...window.require(&#x27;WAWebPhoneUtils&#x27;),
     };
     window.Store.ForwardUtils &#x3D; {
         ...window.require(&#x27;WAWebChatForwardMessage&#x27;)

--- a/src/util/Injected/Store.js
+++ b/src/util/Injected/Store.js
@@ -120,7 +120,6 @@ exports.ExposeStore = () => {
         setPushname: window.require('WAWebSetPushnameConnAction').setPushname
     };
     window.Store.NumberInfo = {
-        ...window.require('WAPhoneUtils'),
         ...window.require('WAPhoneFindCC'),
         ...window.require('WAWebPhoneUtils')
     };


### PR DESCRIPTION
# PR Details

New WhatsApp update changed the name of this module to the one concerted in https://github.com/pedroslopez/whatsapp-web.js/pull/5806

## Description

Remove an invisible error given every time it boots.

## How Has This Been Tested

Removing an old module does not require any testing, I still checked to make sure the number options were still working.

### Environment

- Machine OS: Windows 11
- Phone OS:  Android
- Library Version: latest
- WhatsApp Web Version: latest
- Puppeteer Version:
- Browser Type and Version:  Google Chrome and microsoft edge
- Node Version:  Node: v24.13.0 npm: 11.8.0

## Types of changes


- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)