### PR TITLE
fix: add requestPairingCode() guard clause and improve pairing code documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,62 @@ client.initialize();
 Take a look at [example.js][examples] for another examples with additional use cases.  
 For further details on saving and restoring sessions, explore the provided [Authentication Strategies][auth-strategies].
 
+## Authentication
+
+The library supports two authentication methods: **QR Code** (default) and **Pairing Code**.
+
+### QR Code (default)
+
+The default authentication method. A QR code is generated that must be scanned with your phone:
+
+```js
+const { Client } = require('whatsapp-web.js');
+
+const client = new Client();
+
+client.on('qr', (qr) => {
+    // Use a library like qrcode-terminal to render in terminal
+    console.log('QR RECEIVED', qr);
+});
+
+client.initialize();
+```
+
+### Pairing Code
+
+Instead of scanning a QR code, you can authenticate by entering an 8-character code on your phone. This is ideal for terminal applications or environments without a display to scan QR codes.
+
+The phone number **must** be passed via `pairWithPhoneNumber` in the Client constructor:
+
+```js
+const { Client, LocalAuth } = require('whatsapp-web.js');
+
+const client = new Client({
+    authStrategy: new LocalAuth(),
+    pairWithPhoneNumber: {
+        phoneNumber: '5511999999999',  // Country code + number, no symbols
+        showNotification: true,        // Show notification on phone
+        intervalMs: 180000             // Renew code every 3 minutes
+    }
+});
+
+client.on('code', (code) => {
+    console.log('Pairing code:', code);
+    // On your phone: Settings → Linked Devices → Link a Device
+    //                → Link with phone number
+});
+
+client.on('ready', () => {
+    console.log('Client is ready!');
+});
+
+client.initialize();
+```
+
+> [!WARNING]
+> **Do NOT call `requestPairingCode()` manually** (e.g., from the `qr` event). The phone number must be set in the constructor via `pairWithPhoneNumber` so that the internal event handler is registered correctly. Calling `requestPairingCode()` without this will result in an error.
+
+
 
 ## Supported features
 

--- a/example.js
+++ b/example.js
@@ -18,10 +18,25 @@ const client = new Client({
         // args: ['--proxy-server=proxy-server-that-requires-authentication.example.com'],
         headless: false,
     },
+    /**
+     * AUTHENTICATION VIA PAIRING CODE
+     * ================================
+     * To authenticate via pairing code instead of QR code,
+     * uncomment the pairWithPhoneNumber block below.
+     * 
+     * The 'code' event will fire with an 8-character code (e.g. "ABCDEFGH").
+     * Enter it on your phone:
+     *   Settings → Linked Devices → Link a Device → Link with phone number
+     * 
+     * ⚠️  WARNING: Do NOT call client.requestPairingCode() manually from the
+     *     'qr' event. The internal handler (onCodeReceivedEvent) is only
+     *     registered when pairWithPhoneNumber is set here in the constructor.
+     *     Calling requestPairingCode() without it will throw an error.
+     */
     // pairWithPhoneNumber: {
-    //     phoneNumber: '96170100100' // Pair with phone number (format: <COUNTRY_CODE><PHONE_NUMBER>)
-    //     showNotification: true,
-    //     intervalMs: 180000 // Time to renew pairing code in milliseconds, defaults to 3 minutes
+    //     phoneNumber: '5511999999999', // Format: <COUNTRY_CODE><PHONE_NUMBER>, no symbols
+    //     showNotification: true,       // Show notification on phone
+    //     intervalMs: 180000            // Time to renew pairing code (default: 3 minutes)
     // }
 });
 
@@ -37,8 +52,12 @@ client.on('qr', async (qr) => {
     console.log('QR RECEIVED', qr);
 });
 
+/**
+ * Emitted when a pairing code is received.
+ * Only fires when pairWithPhoneNumber is set in the Client constructor.
+ */
 client.on('code', (code) => {
-    console.log('Pairing code:',code);
+    console.log('Pairing code:', code);
 });
 
 client.on('authenticated', () => {


### PR DESCRIPTION
# Summary

Improve documentation and developer experience for the Pairing Code authentication flow. Add a guard clause to `requestPairingCode()` so it throws a clear, actionable error instead of the confusing `"window.onCodeReceivedEvent is not a function"` when called incorrectly.

## Changes

### `requestPairingCode()` — guard clause and improved JSDoc

When called on a client that was initialized without `pairWithPhoneNumber` in the constructor, the internal callback `onCodeReceivedEvent` is not registered (it is only set up in `inject()` when `pairWithPhoneNumber.phoneNumber` is provided). Previously, this produced a cryptic Puppeteer error: `"window.onCodeReceivedEvent is not a function"`.

Added a guard clause that checks for the handler before proceeding and throws a descriptive `Error` explaining:
- That `pairWithPhoneNumber` must be set in the constructor
- That calling `requestPairingCode()` manually from the `qr` event will not work
- A reference to the correct usage pattern

Also expanded the JSDoc with:
- `@throws` documenting the new error
- `@see` cross-referencing the constructor option and the `code` event
- `@example` showing correct vs incorrect usage

### Constructor JSDoc — document `pairWithPhoneNumber` option

The `pairWithPhoneNumber` constructor option was not documented in the JSDoc `@param` tags, meaning it did not appear in the generated API docs. Added:
- `@param {object} options.pairWithPhoneNumber` — main description with usage instructions
- `@param {string} options.pairWithPhoneNumber.phoneNumber` — format requirements
- `@param {boolean} options.pairWithPhoneNumber.showNotification` — with default value
- `@param {number} options.pairWithPhoneNumber.intervalMs` — with default value
- `@fires Client#code` — was missing from the fires list

### `code` event — expanded documentation

The `code` event JSDoc only had `"Emitted when a pairing code is received"` with no further context. Expanded with:
- Description of when it fires and what the code format is
- Instructions for where to enter the code on the phone
- `@see` linking back to the constructor option
- Full `@example` with working code

### `README.md` — new Authentication section

The README only showed QR Code authentication. Added a new **Authentication** section between "Example usage" and "Supported features" containing:
- **QR Code (default)** — existing flow with example
- **Pairing Code** — complete example with `pairWithPhoneNumber` and `code` event
- Warning box about the `requestPairingCode()` pitfall

### `example.js` — improved pairing code comments

The existing `pairWithPhoneNumber` block was commented out with minimal context. Improved with:
- Multi-line JSDoc block explaining the feature
- Instructions for entering the code on the phone
- Warning about not calling `requestPairingCode()` manually
- Better formatted property comments with defaults
- JSDoc on the `code` event listener

## Use case

Developers who want to authenticate via pairing code instead of QR code currently have no clear guidance in the documentation. The only hint is a 4-line commented block in `example.js`. This leads to:

1. **Discovery problem** — developers don't know the feature exists (README doesn't mention it)
2. **Usage trap** — the most intuitive approach (calling `requestPairingCode()` from the `qr` event) fails silently with a confusing error
3. **No API docs** — the `pairWithPhoneNumber` option doesn't appear in the generated JSDoc

```js
// Before: confusing error
const client = new Client();
client.on('qr', async () => {
    await client.requestPairingCode('5511999999999');
    // ❌ "window.onCodeReceivedEvent is not a function"
});

// After: clear error message
// ❌ Error: requestPairingCode() requires "pairWithPhoneNumber" to be
// configured in the Client constructor options...

// ✅ Correct usage is now well-documented:
const client = new Client({
    pairWithPhoneNumber: {
        phoneNumber: '5511999999999',
        showNotification: true,
        intervalMs: 180000
    }
});
client.on('code', (code) => {
    console.log('Pairing code:', code);
});
client.initialize();
```

## Testing

- Verified `requestPairingCode()` guard clause throws the correct error when `pairWithPhoneNumber` is not configured
- Verified pairing code flow works end-to-end when `pairWithPhoneNumber` is properly set in the constructor
- Confirmed `code` event fires with a valid 8-character pairing code
- Confirmed `authenticated` and `ready` events fire after successful pairing

**Closes:** #3316 
