### PR TITLE
fix: prevent stale change:ref listener from triggering false QR disconnect

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -220,6 +220,11 @@ class Client extends EventEmitter {
                 );
             } else {
                 let qrRetries = 0;
+
+                this.on(Events.LOADING_SCREEN, () => {
+                    qrRetries = 0;
+                });
+
                 await exposeFunctionIfAbsent(
                     this.pupPage,
                     'onQRChangedEvent',
@@ -270,10 +275,18 @@ class Client extends EventEmitter {
                         ',' +
                         platform;
 
-                    window.onQRChangedEvent(getQR(window.AuthStore.Conn.ref)); // initial qr
-                    window.AuthStore.Conn.on('change:ref', (_, ref) => {
+                    const onRefChange = (_, ref) => {
+                        if (ref == null) return;
                         window.onQRChangedEvent(getQR(ref));
-                    }); // future QR changes
+                    };
+
+                    window.onQRChangedEvent(getQR(window.AuthStore.Conn.ref)); // initial qr
+                    window.AuthStore.Conn.on('change:ref', onRefChange); // future QR changes
+
+                    // Remove QR listener once authentication succeeds
+                    window.AuthStore.AppState.on('change:hasSynced', () => {
+                        window.AuthStore.Conn.off('change:ref', onRefChange);
+                    });
                 });
             }
         }


### PR DESCRIPTION
Fixes #127089

## Problem

Two related bugs in the QR handling code:

1. The `change:ref` listener on `AuthStore.Conn` is never removed after a successful QR scan. When WhatsApp Web clears the ref during/after authentication (setting it to null/undefined), the listener fires `onQRChangedEvent` with an invalid ref, incrementing `qrRetries` past `qrMaxRetries` and triggering a spurious `"Max qrcode retries reached"` disconnect while authentication is already in progress.

2. The `qrRetries` counter never resets. Pre-scan QR refreshes consume retry attempts, so any post-scan QR event (even legitimate) immediately hits the limit. If linking fails and WA Web falls back to QR mode, the user gets zero retry attempts.

## Changes

Three layered fixes in `src/Client.js`, each addressing a different aspect:

1. **Reset `qrRetries` on `loading_screen`**: When the loading screen fires (QR was successfully scanned and authentication begins), reset the counter to 0. If the linking fails and WA Web falls back to QR, the user gets a fresh set of retry attempts.

2. **Null guard on `change:ref`**: Skip `onQRChangedEvent` when ref is null/undefined. Prevents malformed QR strings (starting with `"undefined,"`) from being emitted and counted as retry attempts.

3. **Listener cleanup on `change:hasSynced`**: Remove the `change:ref` listener when authentication completes (`change:hasSynced` on `AuthStore.AppState`, which is the same object as `WAWebSocketModel.Socket`). Prevents any stale QR events from firing after the client is fully connected.

## How it was found

Production logs showed a client reaching loading 95-99% after a successful QR scan, then disconnecting 3 minutes later. The final QR event had `qrLength=146` (vs normal `239`), confirming the ref was the literal string `"undefined"`. The `qrRetries` counter (already at 4 from normal pre-scan QR refreshes) was pushed to 5, exceeding `qrMaxRetries=4`.