### PR TITLE
fix(RemoteAuth): pass session name to store.save instead of full path

### DIFF
--- a/src/authStrategies/RemoteAuth.js
+++ b/src/authStrategies/RemoteAuth.js
@@ -139,7 +139,7 @@ class RemoteAuth extends BaseAuthStrategy {
         try {
             compressedSessionPath = await this.compressSession();
             await this.store.save({
-                session: path.join(this.dataPath, this.sessionName),
+                session: this.sessionName,
             });
             if (options && options.emit)
                 this.client.emit(Events.REMOTE_SESSION_SAVED);


### PR DESCRIPTION
`store.save()` in `storeRemoteSession` is passing `path.join(this.dataPath, this.sessionName)` as the session identifier, but every other store call in the file (`sessionExists`, `extract`, `delete`) passes just `this.sessionName`. Because of this mismatch, the session gets saved under the full local filesystem path as the remote key, so on the next startup `sessionExists` can't find it and the session is lost.

This is what people end up seeing in S3 (or any other remote store):

```
sessions/home/user/project/.wwebjs_session/default-customer/RemoteAuth-default-customer.zip
```

instead of:

```
sessions/RemoteAuth-default-customer.zip
```

The `path.join(this.dataPath, ...)` part makes sense for the actual zip file on disk, and `compressSession` already handles that correctly. The `session:` parameter is just the remote key, it has nothing to do with where the zip lives locally.

Fix is a one-liner: pass `this.sessionName` to `store.save()`, same as the other three store calls.

Regression introduced in e6fd112. Working on 1.36.2, broken on 1.36.4.