### PR TITLE
fix: use WA's own LID resolution for block/unblock

### DIFF
--- a/src/structures/Contact.js
+++ b/src/structures/Contact.js
@@ -155,10 +155,18 @@ class Contact extends Base {
         if (this.isGroup) return false;
 
         await this.client.pupPage.evaluate(async (contactId) => {
-            const chat = await window.WWebJS.getChat(contactId);
+            const contact = await window
+                .require('WAWebCollections')
+                .Contact.find(contactId);
+            const resolved = window
+                .require('WAWebBlockContactUtils')
+                .getContactToBlockOnlyUseIfNoAssociatedChat(
+                    contact,
+                    'ChatListBlock',
+                );
             await window
                 .require('WAWebBlockContactAction')
-                .blockContact({ contact: chat });
+                .blockContact({ contact: resolved });
         }, this.id._serialized);
 
         this.isBlocked = true;
@@ -173,12 +181,18 @@ class Contact extends Base {
         if (this.isGroup) return false;
 
         await this.client.pupPage.evaluate(async (contactId) => {
-            const contact = window
+            const contact = await window
                 .require('WAWebCollections')
-                .Contact.get(contactId);
+                .Contact.find(contactId);
+            const resolved = window
+                .require('WAWebBlockContactUtils')
+                .getContactToBlockOnlyUseIfNoAssociatedChat(
+                    contact,
+                    'ChatListBlock',
+                );
             await window
                 .require('WAWebBlockContactAction')
-                .unblockContact(contact);
+                .unblockContact(resolved);
         }, this.id._serialized);
 
         this.isBlocked = false;

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1015,6 +1015,20 @@ exports.LoadUtils = () => {
         }
 
         res.isBlocked = contact.isContactBlocked;
+        if (!res.isBlocked) {
+            const alt = window
+                .require('WAWebApiContact')
+                .getAlternateUserWid(
+                    window
+                        .require('WAWebWidFactory')
+                        .asUserWidOrThrow(contact.id),
+                );
+            if (alt) {
+                res.isBlocked = !!window
+                    .require('WAWebCollections')
+                    .Blocklist.get(alt);
+            }
+        }
 
         const ContactMethods = window.require('WAWebContactGetters');
         res.isMe = ContactMethods.getIsMe(contact);


### PR DESCRIPTION
## Summary

block() and unblock() have two issues:

- **block()** passes a Chat object to `blockContact()`, which expects a Contact model. It works by accident because both have `.id`, but it's the wrong type. The `getChat()` call also creates an unnecessary chat as a side effect via `findOrCreateLatestChat`.
- **unblock()** uses the synchronous `Contact.get()` which returns `undefined` when the contact isn't in the local cache yet.

With blocklist migration enabled (`isBlocklistMigrated() === true`), `blockContact()` internally calls `S()` which needs either a LID or an existing chat with `accountLid` to resolve the target. The old `getChat()` workaround created a chat to satisfy this, but the proper way is to resolve the contact's LID directly.

This PR uses `WAWebBlockContactUtils.getContactToBlockOnlyUseIfNoAssociatedChat()`, which is WA's own utility for this exact scenario. It calls `getCurrentLidContact()` to convert PN contacts to their LID equivalent without creating unnecessary chats.

Tested in WhatsApp Web DevTools: block + unblock cycle works correctly for contacts with and without existing chats.

## Test plan
- [ ] Block a contact you have an existing chat with
- [ ] Block a contact you have never interacted with before
- [ ] Unblock both contacts
- [ ] Verify no unnecessary chats are created