### PR TITLE
feat: support external browser + page in puppeteer options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -197,6 +197,9 @@ declare namespace WAWebJS {
             intervalMs?: number,
         ): Promise<string>;
 
+        /** Cancels an active pairing code session and returns to QR code mode */
+        cancelPairingCode(): Promise<void>
+
         /** Force reset of connection state for the client */
         resetState(): Promise<void>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -996,6 +996,7 @@ declare namespace WAWebJS {
         CHAT_ARCHIVED = 'chat_archived',
         MESSAGE_RECEIVED = 'message',
         MESSAGE_CIPHERTEXT = 'message_ciphertext',
+        MESSAGE_CIPHERTEXT_FAILED = 'message_ciphertext_failed',
         MESSAGE_CREATE = 'message_create',
         MESSAGE_REVOKED_EVERYONE = 'message_revoke_everyone',
         MESSAGE_REVOKED_ME = 'message_revoke_me',

--- a/src/Client.js
+++ b/src/Client.js
@@ -1498,11 +1498,19 @@ class Client extends EventEmitter {
         });
 
         // [L7] Verify Store.Msg listener registration succeeded
+        // NOTE: Backbone's .listeners() may not exist in newer WAWeb versions.
+        //       Fall back to checking _events directly.
         const listenerCount = await this.pupPage.evaluate(() => {
             const Msg = window.require('WAWebCollections').Msg;
-            const addListeners = Msg.listeners?.('add')?.length ?? -1;
-            const changeTypeListeners = Msg.listeners?.('change:type')?.length ?? -1;
-            return { add: addListeners, changeType: changeTypeListeners };
+            var addCount = -1, changeTypeCount = -1;
+            if (typeof Msg.listeners === 'function') {
+                addCount = Msg.listeners('add')?.length ?? -1;
+                changeTypeCount = Msg.listeners('change:type')?.length ?? -1;
+            } else if (Msg._events) {
+                addCount = Msg._events['add'] ? (Array.isArray(Msg._events['add']) ? Msg._events['add'].length : 1) : 0;
+                changeTypeCount = Msg._events['change:type'] ? (Array.isArray(Msg._events['change:type']) ? Msg._events['change:type'].length : 1) : 0;
+            }
+            return { add: addCount, changeType: changeTypeCount };
         });
         this.emit('diag', 'info', 'Store.Msg listener count', JSON.stringify(listenerCount));
     }

--- a/src/Client.js
+++ b/src/Client.js
@@ -269,6 +269,7 @@ class Client extends EventEmitter {
                         advSecretKey +
                         ',' +
                         platform;
+                    window.getQR = getQR;
 
                     window.onQRChangedEvent(getQR(window.AuthStore.Conn.ref)); // initial qr
                     window.AuthStore.Conn.on('change:ref', (_, ref) => {
@@ -516,6 +517,14 @@ class Client extends EventEmitter {
         showNotification = true,
         intervalMs = 180000,
     ) {
+        await exposeFunctionIfAbsent(
+            this.pupPage,
+            'onCodeReceivedEvent',
+            async (code) => {
+                this.emit(Events.CODE_RECEIVED, code);
+                return code;
+            },
+        );
         return await this.pupPage.evaluate(
             async (phoneNumber, showNotification, intervalMs) => {
                 const getCode = async () => {
@@ -551,6 +560,20 @@ class Client extends EventEmitter {
             showNotification,
             intervalMs,
         );
+    }
+
+    /**
+     * Cancels an active pairing code session and returns to QR code mode
+     */
+    async cancelPairingCode() {
+        await this.pupPage.evaluate(() => {
+            if (window.codeInterval) {
+                clearInterval(window.codeInterval);
+                window.codeInterval = undefined;
+            }
+            window.AuthStore.PairingCodeLinkUtils.initializeQRLinking();
+            window.onQRChangedEvent(window.getQR(window.AuthStore.Conn.ref));
+        });
     }
 
     /**

--- a/src/Client.js
+++ b/src/Client.js
@@ -1498,7 +1498,7 @@ class Client extends EventEmitter {
                 ) {
                     window.__diag?.safeDiagLog('debug', 'change:type', {
                         ...window.__wwjsDiag.diagTrace(msg),
-                        prevType: msg?.previousAttributes?.type,
+                        prevType: args[2],
                         newType: msg?.type,
                         argCount: args.length,
                         args: args.map((a) => window.__diag?.safeStr(a)),

--- a/src/Client.js
+++ b/src/Client.js
@@ -1054,35 +1054,85 @@ class Client extends EventEmitter {
             },
         );
 
-        let last_message;
-
         await exposeFunctionIfAbsent(
             this.pupPage,
             'onChangeMessageTypeEvent',
             (msg) => {
-                if (msg.type === 'revoked') {
-                    const message = new Message(this, msg);
-                    let revoked_msg;
-                    if (last_message && msg.id.id === last_message.id.id) {
-                        revoked_msg = new Message(this, last_message);
+                const originalKey = msg.protocolMessageKey;
+                const K2 = msg.id?._serialized || msg.id?.id;
+                const K1 = originalKey?._serialized || originalKey?.id;
+                const secret = msg.messageSecret || msg.messageSecretV2 || null;
+                const secretHex = secret
+                    ? Buffer.from(Object.values(secret)).toString('hex')
+                    : null;
 
-                        if (message.protocolMessageKey)
-                            revoked_msg.id = { ...message.protocolMessageKey };
-                    }
+                console.log('[wwjs-revoke] node:received', {
+                    K2,
+                    K1,
+                    hasProtocolMessageKey: !!originalKey,
+                    idsAreDifferent: K1 !== K2,
+                    type: msg.type,
+                    K2_remote: msg.id?.remote,
+                    K2_fromMe: msg.id?.fromMe,
+                    K2_id: msg.id?.id,
+                    K2_participant: msg.id?.participant,
+                    K1_remote: originalKey?.remote,
+                    K1_fromMe: originalKey?.fromMe,
+                    K1_id: originalKey?.id,
+                    K1_participant: originalKey?.participant,
+                    remoteMatch: msg.id?.remote === originalKey?.remote,
+                    timestamp: msg.t || msg.timestamp,
+                    hasMessageSecret: !!secret,
+                    messageSecretHex: secretHex,
+                    subtype: msg.subtype,
+                    revokeTimestamp: msg.revokeTimestamp,
+                    isOverwrittenByRevoke: msg.isOverwrittenByRevoke,
+                    body:
+                        msg.body === undefined ? 'undefined' : typeof msg.body,
+                });
 
-                    /**
-                     * Emitted when a message is deleted for everyone in the chat.
-                     * @event Client#message_revoke_everyone
-                     * @param {Message} message The message that was revoked, in its current state. It will not contain the original message's data.
-                     * @param {?Message} revoked_msg The message that was revoked, before it was revoked. It will contain the message's original data.
-                     * Note that due to the way this data is captured, it may be possible that this param will be undefined.
-                     */
-                    this.emit(
-                        Events.MESSAGE_REVOKED_EVERYONE,
-                        message,
-                        revoked_msg,
-                    );
-                }
+                const message = new Message(this, { ...msg, id: originalKey });
+                const revoked_msg = originalKey
+                    ? new Message(this, { id: originalKey })
+                    : undefined;
+
+                // Log exactly what createStableKeys will compute
+                const stableRemote = message.id?.remote;
+                const stableTs = message.timestamp;
+                const stableSecretHex = secretHex;
+                const stablePrimary =
+                    stableRemote && stableSecretHex && stableTs
+                        ? `${stableRemote}_${stableSecretHex}_${stableTs}`
+                        : null;
+                const stableFallback =
+                    stableRemote && stableTs
+                        ? `${stableRemote}_${stableTs}`
+                        : null;
+
+                console.log('[wwjs-revoke] node:emitting', {
+                    messageId: message.id?._serialized || message.id?.id,
+                    messageRemote: stableRemote,
+                    messageTimestamp: stableTs,
+                    messageSecretHex: stableSecretHex,
+                    stableKey_primary: stablePrimary,
+                    stableKey_fallback: stableFallback,
+                    hasRevokedMsg: !!revoked_msg,
+                    revokedMsgId:
+                        revoked_msg?.id?._serialized || revoked_msg?.id?.id,
+                });
+
+                /**
+                 * Emitted when a message is deleted for everyone in the chat.
+                 * @event Client#message_revoke_everyone
+                 * @param {Message} message The message that was revoked, in its current state. It will not contain the original message's data.
+                 * @param {?Message} revoked_msg The message that was revoked, before it was revoked. It will contain the message's original data.
+                 * Note that due to the way this data is captured, it may be possible that this param will be undefined.
+                 */
+                this.emit(
+                    Events.MESSAGE_REVOKED_EVERYONE,
+                    message,
+                    revoked_msg,
+                );
             },
         );
 
@@ -1090,10 +1140,6 @@ class Client extends EventEmitter {
             this.pupPage,
             'onChangeMessageEvent',
             (msg) => {
-                if (msg.type !== 'revoked') {
-                    last_message = msg;
-                }
-
                 /**
                  * The event notification that is received when one of
                  * the group participants changes their phone number.
@@ -1504,6 +1550,56 @@ class Client extends EventEmitter {
                         args: args.map((a) => window.__diag?.safeStr(a)),
                     });
                 }
+                if (msg.type !== 'revoked') return;
+
+                var pk = msg.protocolMessageKey;
+                var serialized = null;
+                try {
+                    serialized = msg.serialize();
+                } catch (serializeErr) {
+                    window.__diag?.safeDiagLog(
+                        'error',
+                        'revoke:serialize-failed',
+                        {
+                            error: String(serializeErr),
+                        },
+                    );
+                }
+
+                window.__diag?.safeDiagLog('info', 'revoke:browser', {
+                    currentId: msg.id?._serialized?.toString(),
+                    protocolMessageKey: pk?._serialized?.toString(),
+                    hasProtocolMessageKey: !!pk,
+                    idsAreDifferent:
+                        pk?._serialized?.toString() !==
+                        msg.id?._serialized?.toString(),
+                    K2_remote: msg.id?.remote?.toString(),
+                    K2_fromMe: msg.id?.fromMe,
+                    K2_id: msg.id?.id,
+                    K2_participant: msg.id?.participant?.toString(),
+                    K1_remote: pk?.remote?.toString(),
+                    K1_fromMe: pk?.fromMe,
+                    K1_id: pk?.id,
+                    K1_participant: pk?.participant?.toString(),
+                    remoteMatch:
+                        msg.id?.remote?.toString() === pk?.remote?.toString(),
+                    type: msg.type,
+                    timestamp: msg.t,
+                    hasMessageSecret: !!msg.messageSecret,
+                    messageSecretType: msg.messageSecret
+                        ? typeof msg.messageSecret
+                        : 'absent',
+                    subtype: msg.subtype,
+                    revokeTimestamp: msg.revokeTimestamp,
+                    isOverwrittenByRevoke: msg.isOverwrittenByRevoke,
+                    body: msg.body === undefined ? 'cleared' : typeof msg.body,
+                    serializeHasProtocolMessageKey:
+                        !!serialized?.protocolMessageKey,
+                    serializeIdRemoteType: typeof serialized?.id?.remote,
+                    serializePkRemoteType:
+                        typeof serialized?.protocolMessageKey?.remote,
+                });
+
                 window.onChangeMessageTypeEvent(
                     window.WWebJS.getMessageModel(msg),
                 );

--- a/src/Client.js
+++ b/src/Client.js
@@ -1669,6 +1669,39 @@ class Client extends EventEmitter {
             const __handledByAdd = new Set();
             const __HANDLED_SET_CAP = 5000;
 
+            const pendingResend = new Set();
+            let resendFlush = null;
+
+            function requestResend(msg) {
+                pendingResend.add(msg);
+                if (resendFlush) return;
+                resendFlush = setTimeout(() => {
+                    resendFlush = null;
+                    const msgs = [...pendingResend];
+                    pendingResend.clear();
+                    if (msgs.length === 0) return;
+                    window.onDiagLog?.(
+                        'info',
+                        'CIPHERTEXT_BATCH_FLUSH',
+                        JSON.stringify({
+                            count: msgs.length,
+                            ids: msgs
+                                .slice(0, 5)
+                                .map((m) => m.id?._serialized || ''),
+                        }),
+                    );
+                    try {
+                        window
+                            .require(
+                                'WAWebNonMessageDataRequestPlaceholderMessageResendUtils',
+                            )
+                            .handlePlaceholderMsgsSeen(msgs, true);
+                    } catch (_) {
+                        // module may not be available
+                    }
+                }, 5000);
+            }
+
             Msg.on('add', (msg) => {
                 if (msg.isNewMsg) {
                     const _id = msg.id?._serialized;
@@ -1684,53 +1717,71 @@ class Client extends EventEmitter {
                                 __handledByAdd.add(v);
                         }
                     }
-                    if (msg.type === 'ciphertext') {
-                        // defer message event until ciphertext is resolved (type changed)
-                        const resendTimer = setTimeout(() => {
-                            try {
-                                const { sendPeerDataOperationRequest } =
-                                    window.require(
-                                        'WAWebSendNonMessageDataRequest',
-                                    );
-                                sendPeerDataOperationRequest(4, {
-                                    msgKeys: [msg.id],
-                                }).catch(() => {});
-                            } catch (_) {
-                                // module may not be available
-                            }
-                        }, 5000);
-                        const failTimer = setTimeout(() => {
-                            window.onCiphertextFailedEvent(
-                                window.WWebJS.getMessageModel(msg),
-                            );
-                        }, 15000);
-                        msg.once('change:type', (_msg) => {
-                            clearTimeout(resendTimer);
-                            clearTimeout(failTimer);
-                            window.onDiagLog?.(
-                                'debug',
-                                'CIPHERTEXT_DEFERRED_RESOLVED',
-                                JSON.stringify({
-                                    traceId: _msg.id?._serialized || '',
-                                    resolvedType: _msg.type,
-                                    from: _msg.from?._serialized || '',
-                                    hasDirectPath: !!_msg.directPath,
-                                    hasMediaKey: !!_msg.mediaKey,
-                                }),
-                            );
-                            if (_msg.type === 'revoked') return;
-                            window.onAddMessageEvent(
-                                window.WWebJS.getMessageModel(_msg),
-                            );
-                        });
-                        window.onAddMessageCiphertextEvent(
-                            window.WWebJS.getMessageModel(msg),
-                        );
-                    } else {
+
+                    if (msg.type !== 'ciphertext') {
                         window.onAddMessageEvent(
                             window.WWebJS.getMessageModel(msg),
                         );
+                        return;
                     }
+
+                    window.onDiagLog?.(
+                        'debug',
+                        'CIPHERTEXT_BUFFERED',
+                        JSON.stringify({
+                            traceId: _id || '',
+                            from: msg.from?._serialized || '',
+                            subtype: msg.subtype || null,
+                            pendingCount: pendingResend.size + 1,
+                            flushScheduled: !!resendFlush,
+                        }),
+                    );
+
+                    requestResend(msg);
+                    const _arrivalTs = Date.now();
+
+                    const failTimer = setTimeout(() => {
+                        if (msg.type !== 'ciphertext') {
+                            window.onDiagLog?.(
+                                'debug',
+                                'CIPHERTEXT_FAIL_SKIPPED',
+                                JSON.stringify({
+                                    traceId: _id || '',
+                                    currentType: msg.type,
+                                }),
+                            );
+                            return;
+                        }
+                        window.onCiphertextFailedEvent(
+                            window.WWebJS.getMessageModel(msg),
+                        );
+                    }, 15000);
+
+                    msg.once('change:type', (_msg) => {
+                        clearTimeout(failTimer);
+                        const wasPending = pendingResend.delete(_msg);
+                        window.onDiagLog?.(
+                            'debug',
+                            'CIPHERTEXT_DEFERRED_RESOLVED',
+                            JSON.stringify({
+                                traceId: _msg.id?._serialized || '',
+                                resolvedType: _msg.type,
+                                from: _msg.from?._serialized || '',
+                                hasDirectPath: !!_msg.directPath,
+                                hasMediaKey: !!_msg.mediaKey,
+                                removedFromBuffer: wasPending,
+                                elapsed: Date.now() - _arrivalTs,
+                            }),
+                        );
+                        if (_msg.type === 'revoked') return;
+                        window.onAddMessageEvent(
+                            window.WWebJS.getMessageModel(_msg),
+                        );
+                    });
+
+                    window.onAddMessageCiphertextEvent(
+                        window.WWebJS.getMessageModel(msg),
+                    );
                 }
             });
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -14,6 +14,8 @@ const {
 } = require('./util/Constants');
 const { ExposeAuthStore } = require('./util/Injected/AuthStore/AuthStore');
 const { LoadUtils } = require('./util/Injected/Utils');
+const { InjectDiagCommon, shouldSkipMsg: _shouldSkipDiagMsg } = require('./util/Injected/DiagCommon');
+const { InjectDiagHooks } = require('./util/Injected/DiagHooks');
 const ChatFactory = require('./factories/ChatFactory');
 const ContactFactory = require('./factories/ContactFactory');
 const WebCacheFactory = require('./webCache/WebCacheFactory');
@@ -116,6 +118,12 @@ class Client extends EventEmitter {
         this._injectInProgress = true;
 
         try {
+            const _injectStart = Date.now();
+            let _injectUrl = '';
+            try { _injectUrl = this.pupPage?.url?.() || ''; } catch (_) { /* page may be closed */ }
+            console.log('[wwjs-diag] inject:start', JSON.stringify({ ts: _injectStart, url: _injectUrl.slice(0, 120) }));
+            this._hasSyncedTriggered = false;
+
             const authTimeout = this.options.authTimeoutMs || 30000;
             await this.pupPage
                 .waitForFunction('window.Debug?.VERSION != undefined', {
@@ -148,11 +156,18 @@ class Client extends EventEmitter {
                     return {
                         need: state === 'UNPAIRED' || state === 'UNPAIRED_IDLE',
                         state,
+                        hasSynced: window.require?.('WAWebSocketModel')?.Socket?.hasSynced,
                     };
                 },
                 { timeout: authTimeout },
             );
             const needAuthentication = await needAuthHandle.jsonValue();
+            console.log('[wwjs-diag] inject:authCheck', JSON.stringify({
+                ts: Date.now(),
+                needAuthentication: needAuthentication.need,
+                appState: needAuthentication.state,
+                hasSynced: needAuthentication.hasSynced
+            }));
 
             if (needAuthentication.need) {
                 const { failed, failureEventPayload, restart } =
@@ -283,6 +298,7 @@ class Client extends EventEmitter {
                 this.pupPage,
                 'onAuthAppStateChangedEvent',
                 async (state) => {
+                    console.log('[wwjs-diag] onAuthAppStateChangedEvent', JSON.stringify({ state, ts: Date.now() }));
                     if (
                         state == 'UNPAIRED_IDLE' &&
                         !pairWithPhoneNumber.phoneNumber
@@ -297,80 +313,94 @@ class Client extends EventEmitter {
                 this.pupPage,
                 'onAppStateHasSyncedEvent',
                 async () => {
-                    const authEventPayload =
-                        await this.authStrategy.getAuthEventPayload();
-                    /**
-                     * Emitted when authentication is successful
-                     * @event Client#authenticated
-                     */
-                    this.emit(Events.AUTHENTICATED, authEventPayload);
-
-                    const injected = await this.pupPage.evaluate(async () => {
-                        return typeof window.WWebJS !== 'undefined';
-                    });
-
-                    if (!injected) {
-                        if (
-                            this.options.webVersionCache.type === 'local' &&
-                            this.currentIndexHtml
-                        ) {
-                            const { type: webCacheType, ...webCacheOptions } =
-                                this.options.webVersionCache;
-                            const webCache = WebCacheFactory.createWebCache(
-                                webCacheType,
-                                webCacheOptions,
-                            );
-
-                            await webCache.persist(
-                                this.currentIndexHtml,
-                                version,
-                            );
-                        }
-
-                        //Load util functions (serializers, helper functions)
-                        await this.pupPage.evaluate(LoadUtils);
-
-                        await this.pupPage
-                            .waitForFunction(
-                                'typeof window.WWebJS !== "undefined"',
-                                { timeout: 30000 },
-                            )
-                            .catch(() => {
-                                throw 'ready timeout';
-                            });
-
-                        /**
-                         * Current connection information
-                         * @type {ClientInfo}
-                         */
-                        this.info = new ClientInfo(
-                            this,
-                            await this.pupPage.evaluate(() => {
-                                return {
-                                    ...window
-                                        .require('WAWebConnModel')
-                                        .Conn.serialize(),
-                                    wid:
-                                        window
-                                            .require('WAWebUserPrefsMeUser')
-                                            .getMaybeMePnUser() ||
-                                        window
-                                            .require('WAWebUserPrefsMeUser')
-                                            .getMaybeMeLidUser(),
-                                };
-                            }),
-                        );
-
-                        this.interface = new InterfaceController(this);
-
-                        await this.attachEventListeners();
+                    if (this._hasSyncedTriggered) {
+                        console.warn('[wwjs-diag] onAppStateHasSyncedEvent SKIPPED (already handled)');
+                        return;
                     }
-                    /**
-                     * Emitted when the client has initialized and is ready to receive messages.
-                     * @event Client#ready
-                     */
-                    this.emit(Events.READY);
-                    this.authStrategy.afterAuthReady();
+                    this._hasSyncedTriggered = true;
+                    console.log('[wwjs-diag] onAppStateHasSyncedEvent CALLED', JSON.stringify({ ts: Date.now() }));
+                    try {
+                        const authEventPayload =
+                            await this.authStrategy.getAuthEventPayload();
+                        this.emit(Events.AUTHENTICATED, authEventPayload);
+                        console.log('[wwjs-diag] onAppStateHasSyncedEvent AUTHENTICATED emitted');
+
+                        const injected = await this.pupPage.evaluate(async () => {
+                            return typeof window.WWebJS !== 'undefined';
+                        });
+                        console.log('[wwjs-diag] onAppStateHasSyncedEvent storeCheck', JSON.stringify({ injected, ts: Date.now() }));
+
+                        if (!injected) {
+                            if (
+                                this.options.webVersionCache.type === 'local' &&
+                                this.currentIndexHtml
+                            ) {
+                                const { type: webCacheType, ...webCacheOptions } =
+                                    this.options.webVersionCache;
+                                const webCache = WebCacheFactory.createWebCache(
+                                    webCacheType,
+                                    webCacheOptions,
+                                );
+
+                                await webCache.persist(
+                                    this.currentIndexHtml,
+                                    version,
+                                );
+                            }
+
+                            // Inject diagnostic common helpers before LoadUtils
+                            await this.pupPage.evaluate(InjectDiagCommon);
+
+                            //Load util functions (serializers, helper functions)
+                            await this.pupPage.evaluate(LoadUtils);
+
+                            // Inject diagnostic hooks (media download, signal/crypto, receipts, etc.)
+                            await this.pupPage.evaluate(InjectDiagHooks);
+                            console.log('[wwjs-diag] onAppStateHasSyncedEvent Store exposed, waiting for readiness...');
+
+                            await this.pupPage
+                                .waitForFunction(
+                                    'typeof window.WWebJS !== "undefined"',
+                                    { timeout: 30000 },
+                                )
+                                .catch(() => {
+                                    console.warn('[wwjs-diag] onAppStateHasSyncedEvent READY TIMEOUT after 30s');
+                                    throw 'ready timeout';
+                                });
+                            console.log('[wwjs-diag] onAppStateHasSyncedEvent Store ready');
+
+                            this.info = new ClientInfo(
+                                this,
+                                await this.pupPage.evaluate(() => {
+                                    return {
+                                        ...window
+                                            .require('WAWebConnModel')
+                                            .Conn.serialize(),
+                                        wid:
+                                            window
+                                                .require('WAWebUserPrefsMeUser')
+                                                .getMaybeMePnUser() ||
+                                            window
+                                                .require('WAWebUserPrefsMeUser')
+                                                .getMaybeMeLidUser(),
+                                    };
+                                }),
+                            );
+
+                            this.interface = new InterfaceController(this);
+
+                            await this.attachEventListeners();
+                        }
+                        this.emit(Events.READY);
+                        console.log('[wwjs-diag] onAppStateHasSyncedEvent READY emitted');
+                        this.authStrategy.afterAuthReady();
+                    } catch (err) {
+                        console.warn('[wwjs-diag] onAppStateHasSyncedEvent ERROR', JSON.stringify({
+                            error: String(err?.message || err),
+                            ts: Date.now()
+                        }));
+                        throw err;
+                    }
                 },
             );
             let lastPercent = null;
@@ -388,6 +418,7 @@ class Client extends EventEmitter {
                 this.pupPage,
                 'onLogoutEvent',
                 async () => {
+                    console.warn('[wwjs-diag] onLogoutEvent CALLED', JSON.stringify({ ts: Date.now() }));
                     this.lastLoggedOut = true;
                     await this.pupPage
                         .waitForNavigation({ waitUntil: 'load', timeout: 5000 })
@@ -398,11 +429,21 @@ class Client extends EventEmitter {
                 const Socket = window.require('WAWebSocketModel').Socket;
                 const Cmd = window.require('WAWebCmd').Cmd;
 
+                // [diag] Log state BEFORE registering listeners
+                const _diagState = {
+                    hasSynced: Socket.hasSynced,
+                    state: Socket.state,
+                    ts: Date.now()
+                };
+                console.error('[wwjs-diag] listeners:registering ' + JSON.stringify(_diagState));
+                window._wwjsDiagAppState = Socket;
+
                 const listeners = [
                     [
                         Socket,
                         'change:state',
                         (_AppState, state) => {
+                            console.error('[wwjs-diag] change:state FIRED ' + JSON.stringify({ state, ts: Date.now() }));
                             window.onAuthAppStateChangedEvent(state);
                         },
                     ],
@@ -410,6 +451,12 @@ class Client extends EventEmitter {
                         Socket,
                         'change:hasSynced',
                         () => {
+                            console.error('[wwjs-diag] change:hasSynced FIRED ' + JSON.stringify({
+                                hasSynced: Socket.hasSynced,
+                                state: Socket.state,
+                                sameAppState: Socket === window._wwjsDiagAppState,
+                                ts: Date.now()
+                            }));
                             window.onAppStateHasSyncedEvent();
                         },
                     ],
@@ -426,6 +473,7 @@ class Client extends EventEmitter {
                         Cmd,
                         'logout',
                         async () => {
+                            console.error('[wwjs-diag] Cmd:logout FIRED ' + JSON.stringify({ ts: Date.now() }));
                             await window.onLogoutEvent();
                         },
                     ],
@@ -433,6 +481,7 @@ class Client extends EventEmitter {
                         Cmd,
                         'logout_from_bridge',
                         async () => {
+                            console.error('[wwjs-diag] Cmd:logout_from_bridge FIRED ' + JSON.stringify({ ts: Date.now() }));
                             await window.onLogoutEvent();
                         },
                     ],
@@ -455,13 +504,22 @@ class Client extends EventEmitter {
                 window._wwjsListeners = listeners;
 
                 // Atomic hasSynced check in the same synchronous block as listener registration.
-                // If hasSynced is already true, Backbone won't fire change:hasSynced (no transition).
-                // If hasSynced is false, the listener above will catch the future transition.
                 const storeInjected = typeof window.WWebJS !== 'undefined';
+                console.error('[wwjs-diag] inject:hasSyncedCheck ' + JSON.stringify({
+                    hasSynced: Socket.hasSynced,
+                    state: Socket.state,
+                    storeInjected,
+                    sameAppState: Socket === window._wwjsDiagAppState,
+                    ts: Date.now()
+                }));
                 if (Socket.hasSynced === true && !storeInjected) {
+                    console.error('[wwjs-diag] inject:hasSyncedFix TRIGGERING manual onAppStateHasSyncedEvent');
                     window.onAppStateHasSyncedEvent();
                 }
+                console.error('[wwjs-diag] listeners:registered ' + JSON.stringify({ ts: Date.now() }));
             });
+
+            console.log('[wwjs-diag] inject:end', JSON.stringify({ ts: Date.now(), durationMs: Date.now() - _injectStart }));
         } finally {
             this._injectInProgress = false;
         }
@@ -534,13 +592,73 @@ class Client extends EventEmitter {
             referer: 'https://whatsapp.com/',
         });
 
+        console.log('[wwjs-diag] initialize:inject START (first call)');
         await this.inject();
+        console.log('[wwjs-diag] initialize:inject END (first call)');
+
+        // [diag:promise-collected] Monitor execution context lifecycle via CDP
+        try {
+            const cdpSession = await this.pupPage.target().createCDPSession();
+            await cdpSession.send('Runtime.enable');
+            cdpSession.on('Runtime.executionContextDestroyed', (event) => {
+                this.emit('diag', 'warn', 'CDP_CONTEXT_DESTROYED', JSON.stringify({
+                    executionContextId: event.executionContextId,
+                    ts: Date.now()
+                }));
+            });
+            cdpSession.on('Runtime.executionContextsCleared', () => {
+                this.emit('diag', 'warn', 'CDP_CONTEXTS_CLEARED', JSON.stringify({ ts: Date.now() }));
+            });
+            this._diagCdpSession = cdpSession;
+        } catch (e) {
+            this.emit('diag', 'error', 'CDP_MONITOR_SETUP_FAILED', JSON.stringify({ error: String(e?.message || e) }));
+        }
+
+        // [diag:promise-collected] Track concurrent evaluate calls to detect CDP congestion
+        this._diagEvalInflight = 0;
+        const origEvaluate = this.pupPage.evaluate.bind(this.pupPage);
+        const self = this;
+        this.pupPage.evaluate = async function (...args) {
+            self._diagEvalInflight++;
+            const inflight = self._diagEvalInflight;
+            if (inflight > 20) {
+                self.emit('diag', 'warn', 'HIGH_EVAL_CONCURRENCY', JSON.stringify({ inflight, ts: Date.now() }));
+            }
+            try {
+                return await origEvaluate(...args);
+            } catch (err) {
+                const isPromiseCollected = err.message?.includes('Promise was collected');
+                const isContextDestroyed = err.message?.includes('Execution context was destroyed');
+                if (isPromiseCollected || isContextDestroyed) {
+                    self.emit('diag', 'error', 'EVALUATE_CDP_ERROR', JSON.stringify({
+                        inflight: self._diagEvalInflight,
+                        error: err.message,
+                        isPromiseCollected,
+                        isContextDestroyed,
+                        ts: Date.now()
+                    }));
+                }
+                throw err;
+            } finally {
+                self._diagEvalInflight--;
+            }
+        };
 
         this.pupPage.on('framenavigated', async (frame) => {
             if (frame.parentFrame() !== null) return;
 
+            const frameUrl = frame.url();
+            const isMainFrame = frame === this.pupPage.mainFrame();
             const isLogout =
-                frame.url().includes('post_logout=1') || this.lastLoggedOut;
+                frameUrl.includes('post_logout=1') || this.lastLoggedOut;
+
+            console.log('[wwjs-diag] framenavigated', JSON.stringify({
+                ts: Date.now(),
+                url: frameUrl.slice(0, 150),
+                isMainFrame,
+                isLogout,
+                lastLoggedOut: this.lastLoggedOut
+            }));
 
             if (isLogout) {
                 this.emit(Events.DISCONNECTED, 'LOGOUT');
@@ -561,10 +679,12 @@ class Client extends EventEmitter {
 
             if (!isLogout && storeAvailable) return;
 
+            console.log('[wwjs-diag] framenavigated:inject START', JSON.stringify({ ts: Date.now(), url: frameUrl.slice(0, 150), storeAvailable }));
             try {
                 await this.inject();
+                console.log('[wwjs-diag] framenavigated:inject END (success)');
             } catch (err) {
-                // inject() may fail if page is still loading after navigation
+                console.warn('[wwjs-diag] framenavigated:inject END (error)', String(err?.message || err));
             }
         });
     }
@@ -646,10 +766,29 @@ class Client extends EventEmitter {
      * @property {boolean} reinject is this a reinject?
      */
     async attachEventListeners() {
+        // [diag] Expose diagnostic logging bridge from browser to Node.js
+        await exposeFunctionIfAbsent(this.pupPage, 'onDiagLog', (level, tag, data) => {
+            this.emit('diag', level, tag, data);
+        });
+
         await exposeFunctionIfAbsent(
             this.pupPage,
             'onAddMessageEvent',
             (msg) => {
+                // [L4] Diagnostic: log non-skipped messages
+                const _skipDiag = msg.type === 'gp2' || _shouldSkipDiagMsg(msg);
+                if (!_skipDiag) {
+                    this.emit('diag', 'debug', 'onAddMessageEvent', JSON.stringify({
+                        traceId: msg.id?._serialized || msg.id?.id,
+                        type: msg.type,
+                        from: typeof msg.from === 'object' ? msg.from?._serialized : msg.from,
+                        to: typeof msg.to === 'object' ? msg.to?._serialized : msg.to,
+                        hasMedia: !!msg.directPath,
+                        isStatusV3: msg.isStatusV3 || false,
+                        idRemote: msg.id?.remote || null
+                    }));
+                }
+
                 if (msg.type === 'gp2') {
                     const notification = new GroupNotification(this, msg);
                     if (
@@ -716,6 +855,14 @@ class Client extends EventEmitter {
                  * @param {Message} message The message that was created
                  */
                 this.emit(Events.MESSAGE_CREATE, message);
+
+                // [L5] Log fromMe gate decision
+                if (!_skipDiag) {
+                    this.emit('diag', 'debug', 'fromMe gate', JSON.stringify({
+                        traceId: msg.id?._serialized || msg.id?.id,
+                        fromMe: msg.id.fromMe
+                    }));
+                }
 
                 if (msg.id.fromMe) return;
 
@@ -1084,6 +1231,32 @@ class Client extends EventEmitter {
         );
 
         await this.pupPage.evaluate(() => {
+            // Helper namespace for diagnostic functions
+            window.__wwjsDiag = window.__wwjsDiag || {};
+            window.__wwjsDiag.resolvePhone = (wid) => {
+                try {
+                    const serialized = wid?._serialized || String(wid || '');
+                    if (!serialized) return '';
+                    if (!serialized.endsWith('@lid')) return serialized;
+                    const contact = window.require('WAWebCollections').Contact?.get(wid);
+                    const phone = contact?.phoneNumber?._serialized;
+                    return phone || serialized;
+                } catch (e) {
+                    return wid?._serialized || String(wid || '');
+                }
+            };
+            window.__wwjsDiag.diagTrace = (msg) => {
+                try {
+                    const traceId = msg.id?._serialized || '';
+                    const senderWid = msg.author || msg.from;
+                    const from = window.__wwjsDiag.resolvePhone(senderWid);
+                    const to = window.__wwjsDiag.resolvePhone(msg.to);
+                    return { traceId, from, to };
+                } catch (e) {
+                    return { traceId: msg.id?._serialized || '', from: msg.from?._serialized || '', to: msg.to?._serialized || '' };
+                }
+            };
+
             const { Msg, Chat, WAWebCallCollection } =
                 window.require('WAWebCollections');
             const AppState = window.require('WAWebSocketModel').Socket;
@@ -1099,10 +1272,18 @@ class Client extends EventEmitter {
             Msg.on('change', (msg) => {
                 window.onChangeMessageEvent(window.WWebJS.getMessageModel(msg));
             });
-            Msg.on('change:type', (msg) => {
-                window.onChangeMessageTypeEvent(
-                    window.WWebJS.getMessageModel(msg),
-                );
+            Msg.on('change:type', (...args) => {
+                var [msg] = args;
+                if (!window.__diag?.isStatusOrGroup(msg?.from) && !window.__diag?.isStatusOrGroup(msg?.to) && !window.__diag?.isStatusOrGroup(msg?.id?.remote) && !msg?.isStatusV3) {
+                    window.__diag?.safeDiagLog('debug', 'change:type', {
+                        ...window.__wwjsDiag.diagTrace(msg),
+                        prevType: msg?.previousAttributes?.type,
+                        newType: msg?.type,
+                        argCount: args.length,
+                        args: args.map(a => window.__diag?.safeStr(a))
+                    });
+                }
+                window.onChangeMessageTypeEvent(window.WWebJS.getMessageModel(msg));
             });
             Msg.on('change:ack', (msg, ack) => {
                 window.onMessageAckEvent(
@@ -1157,8 +1338,24 @@ class Client extends EventEmitter {
                     prevState,
                 );
             });
+            // Track message IDs handled by the normal 'add' path for silent-loss detection
+            const __handledByAdd = new Set();
+            const __HANDLED_SET_CAP = 5000;
+
             Msg.on('add', (msg) => {
                 if (msg.isNewMsg) {
+                    const _id = msg.id?._serialized;
+                    if (_id) {
+                        __handledByAdd.add(_id);
+                        if (__handledByAdd.size > __HANDLED_SET_CAP) {
+                            const iter = __handledByAdd.values();
+                            for (let i = 0; i < 1000; i++) iter.next();
+                            const remaining = [];
+                            for (const v of __handledByAdd) remaining.push(v);
+                            __handledByAdd.clear();
+                            for (const v of remaining.slice(1000)) __handledByAdd.add(v);
+                        }
+                    }
                     if (msg.type === 'ciphertext') {
                         // defer message event until ciphertext is resolved (type changed)
                         const resendTimer = setTimeout(() => {
@@ -1182,6 +1379,14 @@ class Client extends EventEmitter {
                         msg.once('change:type', (_msg) => {
                             clearTimeout(resendTimer);
                             clearTimeout(failTimer);
+                            window.onDiagLog?.('debug', 'CIPHERTEXT_DEFERRED_RESOLVED', JSON.stringify({
+                                traceId: _msg.id?._serialized || '',
+                                resolvedType: _msg.type,
+                                from: _msg.from?._serialized || '',
+                                hasDirectPath: !!_msg.directPath,
+                                hasMediaKey: !!_msg.mediaKey,
+                            }));
+                            if (_msg.type === 'revoked') return;
                             window.onAddMessageEvent(
                                 window.WWebJS.getMessageModel(_msg),
                             );
@@ -1196,6 +1401,26 @@ class Client extends EventEmitter {
                     }
                 }
             });
+
+            // [SILENT_LOSS_FIX] Fallback: catch messages added to Msg without triggering 'add'
+            Msg.on('change:type', (msg) => {
+                try {
+                    const id = msg.id?._serialized;
+                    if (!id || __handledByAdd.has(id)) return;
+                    if (!msg.isNewMsg) return;
+                    if (msg.type === 'ciphertext') return;
+                    __handledByAdd.add(id);
+                    window.onDiagLog?.('warn', 'ADD_BYPASS_RECOVERED', JSON.stringify({
+                        traceId: id,
+                        type: msg.type,
+                        from: msg.from?._serialized || '',
+                    }));
+                    window.onAddMessageEvent(window.WWebJS.getMessageModel(msg));
+                } catch (e) {
+                    // Fallback must never break the main flow
+                }
+            });
+
             Chat.on('change:unreadCount', (chat) => {
                 window.onChatUnreadCountEvent(chat);
             });
@@ -1270,6 +1495,15 @@ class Client extends EventEmitter {
                 },
             );
         });
+
+        // [L7] Verify Store.Msg listener registration succeeded
+        const listenerCount = await this.pupPage.evaluate(() => {
+            const Msg = window.require('WAWebCollections').Msg;
+            const addListeners = Msg.listeners?.('add')?.length ?? -1;
+            const changeTypeListeners = Msg.listeners?.('change:type')?.length ?? -1;
+            return { add: addListeners, changeType: changeTypeListeners };
+        });
+        this.emit('diag', 'info', 'Store.Msg listener count', JSON.stringify(listenerCount));
     }
 
     async initWebVersionCache() {
@@ -1744,9 +1978,25 @@ class Client extends EventEmitter {
      * @returns {Promise<Contact>}
      */
     async getContactById(contactId) {
-        let contact = await this.pupPage.evaluate((contactId) => {
-            return window.WWebJS.getContact(contactId);
-        }, contactId);
+        const start = Date.now();
+        let contact;
+        try {
+            contact = await this.pupPage.evaluate((contactId) => {
+                return window.WWebJS.getContact(contactId);
+            }, contactId);
+        } catch (err) {
+            const took = Date.now() - start;
+            this.emit('diag', 'error', 'getContactById:failed', JSON.stringify({
+                contactId: contactId?.substring?.(0, 30),
+                took,
+                inflight: this._diagEvalInflight || -1,
+                isPromiseCollected: err.message?.includes('Promise was collected'),
+                isContextDestroyed: err.message?.includes('Execution context was destroyed'),
+                isLid: contactId?.endsWith?.('@lid'),
+                error: String(err.message || err).substring(0, 200)
+            }));
+            throw err;
+        }
 
         return ContactFactory.create(this, contact);
     }

--- a/src/Client.js
+++ b/src/Client.js
@@ -117,7 +117,12 @@ class Client extends EventEmitter {
      * Private function
      */
     async inject() {
-        if (this._injectInProgress) return;
+        if (this._injectInProgress) {
+            console.warn('[wwjs-diag] inject:SKIPPED (already in progress)', {
+                ts: Date.now(),
+            });
+            return;
+        }
         this._injectInProgress = true;
 
         try {
@@ -128,13 +133,10 @@ class Client extends EventEmitter {
             } catch (_) {
                 /* page may be closed */
             }
-            console.log(
-                '[wwjs-diag] inject:start',
-                JSON.stringify({
-                    ts: _injectStart,
-                    url: _injectUrl.slice(0, 120),
-                }),
-            );
+            console.log('[wwjs-diag] inject:start', {
+                ts: _injectStart,
+                url: _injectUrl.slice(0, 120),
+            });
             this._hasSyncedTriggered = false;
 
             const authTimeout = this.options.authTimeoutMs || 30000;
@@ -177,19 +179,28 @@ class Client extends EventEmitter {
                 { timeout: authTimeout },
             );
             const needAuthentication = await needAuthHandle.jsonValue();
-            console.log(
-                '[wwjs-diag] inject:authCheck',
-                JSON.stringify({
-                    ts: Date.now(),
-                    needAuthentication: needAuthentication.need,
-                    appState: needAuthentication.state,
-                    hasSynced: needAuthentication.hasSynced,
-                }),
-            );
+            console.log('[wwjs-diag] inject:authCheck', {
+                ts: Date.now(),
+                needAuthentication: needAuthentication.need,
+                appState: needAuthentication.state,
+                hasSynced: needAuthentication.hasSynced,
+            });
 
             if (needAuthentication.need) {
                 const { failed, failureEventPayload, restart } =
                     await this.authStrategy.onAuthenticationNeeded();
+
+                console.log(
+                    '[wwjs-diag] inject:onAuthenticationNeeded result',
+                    {
+                        failed,
+                        restart,
+                        failureEventPayload: String(
+                            failureEventPayload || '',
+                        ).substring(0, 100),
+                        ts: Date.now(),
+                    },
+                );
 
                 if (failed) {
                     /**
@@ -249,7 +260,17 @@ class Client extends EventEmitter {
                             this.emit(Events.QR_RECEIVED, qr);
                             if (this.options.qrMaxRetries > 0) {
                                 qrRetries++;
+                                console.log('[wwjs-diag] onQRChangedEvent', {
+                                    qrRetries,
+                                    qrMaxRetries: this.options.qrMaxRetries,
+                                    willDisconnect:
+                                        qrRetries > this.options.qrMaxRetries,
+                                    ts: Date.now(),
+                                });
                                 if (qrRetries > this.options.qrMaxRetries) {
+                                    console.warn(
+                                        '[wwjs-diag] onQRChangedEvent DISCONNECTED max retries reached',
+                                    );
                                     this.emit(
                                         Events.DISCONNECTED,
                                         'Max qrcode retries reached',
@@ -316,15 +337,18 @@ class Client extends EventEmitter {
                 this.pupPage,
                 'onAuthAppStateChangedEvent',
                 async (state) => {
-                    console.log(
-                        '[wwjs-diag] onAuthAppStateChangedEvent',
-                        JSON.stringify({ state, ts: Date.now() }),
-                    );
+                    console.log('[wwjs-diag] onAuthAppStateChangedEvent', {
+                        state,
+                        ts: Date.now(),
+                    });
                     if (
                         state == 'UNPAIRED_IDLE' &&
                         !pairWithPhoneNumber.phoneNumber
                     ) {
-                        // refresh qr code
+                        console.log(
+                            '[wwjs-diag] onAuthAppStateChangedEvent refreshQR triggered',
+                        );
+                        // refresh qr code - must run in browser context, not Node.js
                         await this.pupPage.evaluate(() => {
                             window.require('WAWebCmd').Cmd.refreshQR();
                         });
@@ -343,10 +367,9 @@ class Client extends EventEmitter {
                         return;
                     }
                     this._hasSyncedTriggered = true;
-                    console.log(
-                        '[wwjs-diag] onAppStateHasSyncedEvent CALLED',
-                        JSON.stringify({ ts: Date.now() }),
-                    );
+                    console.log('[wwjs-diag] onAppStateHasSyncedEvent CALLED', {
+                        ts: Date.now(),
+                    });
                     try {
                         const authEventPayload =
                             await this.authStrategy.getAuthEventPayload();
@@ -362,7 +385,7 @@ class Client extends EventEmitter {
                         );
                         console.log(
                             '[wwjs-diag] onAppStateHasSyncedEvent storeCheck',
-                            JSON.stringify({ injected, ts: Date.now() }),
+                            { injected, ts: Date.now() },
                         );
 
                         if (!injected) {
@@ -411,9 +434,7 @@ class Client extends EventEmitter {
                                 });
                             console.log(
                                 '[wwjs-diag] onAppStateHasSyncedEvent Store ready',
-                                JSON.stringify({
-                                    durationMs: Date.now() - _readyStart,
-                                }),
+                                { durationMs: Date.now() - _readyStart },
                             );
 
                             this.info = new ClientInfo(
@@ -436,7 +457,15 @@ class Client extends EventEmitter {
 
                             this.interface = new InterfaceController(this);
 
+                            console.log(
+                                '[wwjs-diag] onAppStateHasSyncedEvent calling attachEventListeners',
+                                { ts: Date.now() },
+                            );
                             await this.attachEventListeners();
+                            console.log(
+                                '[wwjs-diag] onAppStateHasSyncedEvent attachEventListeners done',
+                                { ts: Date.now() },
+                            );
                         }
                         this.emit(Events.READY);
                         console.log(
@@ -446,10 +475,10 @@ class Client extends EventEmitter {
                     } catch (err) {
                         console.warn(
                             '[wwjs-diag] onAppStateHasSyncedEvent ERROR',
-                            JSON.stringify({
+                            {
                                 error: String(err?.message || err),
                                 ts: Date.now(),
-                            }),
+                            },
                         );
                         throw err;
                     }
@@ -470,10 +499,9 @@ class Client extends EventEmitter {
                 this.pupPage,
                 'onLogoutEvent',
                 async () => {
-                    console.warn(
-                        '[wwjs-diag] onLogoutEvent CALLED',
-                        JSON.stringify({ ts: Date.now() }),
-                    );
+                    console.warn('[wwjs-diag] onLogoutEvent CALLED', {
+                        ts: Date.now(),
+                    });
                     this.lastLoggedOut = true;
                     await this.pupPage
                         .waitForNavigation({ waitUntil: 'load', timeout: 5000 })
@@ -490,7 +518,7 @@ class Client extends EventEmitter {
                     state: Socket.state,
                     ts: Date.now(),
                 };
-                console.error(
+                console.warn(
                     '[wwjs-diag] listeners:registering ' +
                         JSON.stringify(_diagState),
                 );
@@ -501,7 +529,7 @@ class Client extends EventEmitter {
                         Socket,
                         'change:state',
                         (_AppState, state) => {
-                            console.error(
+                            console.warn(
                                 '[wwjs-diag] change:state FIRED ' +
                                     JSON.stringify({ state, ts: Date.now() }),
                             );
@@ -512,7 +540,7 @@ class Client extends EventEmitter {
                         Socket,
                         'change:hasSynced',
                         () => {
-                            console.error(
+                            console.warn(
                                 '[wwjs-diag] change:hasSynced FIRED ' +
                                     JSON.stringify({
                                         hasSynced: Socket.hasSynced,
@@ -538,7 +566,7 @@ class Client extends EventEmitter {
                         Cmd,
                         'logout',
                         async () => {
-                            console.error(
+                            console.warn(
                                 '[wwjs-diag] Cmd:logout FIRED ' +
                                     JSON.stringify({ ts: Date.now() }),
                             );
@@ -549,7 +577,7 @@ class Client extends EventEmitter {
                         Cmd,
                         'logout_from_bridge',
                         async () => {
-                            console.error(
+                            console.warn(
                                 '[wwjs-diag] Cmd:logout_from_bridge FIRED ' +
                                     JSON.stringify({ ts: Date.now() }),
                             );
@@ -560,6 +588,12 @@ class Client extends EventEmitter {
 
                 // Clean up old listeners to prevent accumulation on re-inject
                 if (window._wwjsListeners) {
+                    console.warn(
+                        '[wwjs-diag] inject:cleanupListeners removing ' +
+                            window._wwjsListeners.length +
+                            ' old listeners ts=' +
+                            Date.now(),
+                    );
                     for (const [obj, event, handler] of window._wwjsListeners) {
                         try {
                             obj.off(event, handler);
@@ -567,6 +601,11 @@ class Client extends EventEmitter {
                             /* listeners may already be gone */
                         }
                     }
+                } else {
+                    console.warn(
+                        '[wwjs-diag] inject:cleanupListeners no previous listeners ts=' +
+                            Date.now(),
+                    );
                 }
 
                 for (const [obj, event, handler] of listeners) {
@@ -576,7 +615,7 @@ class Client extends EventEmitter {
 
                 // Atomic hasSynced check in the same synchronous block as listener registration.
                 const storeInjected = typeof window.WWebJS !== 'undefined';
-                console.error(
+                console.warn(
                     '[wwjs-diag] inject:hasSyncedCheck ' +
                         JSON.stringify({
                             hasSynced: Socket.hasSynced,
@@ -587,24 +626,21 @@ class Client extends EventEmitter {
                         }),
                 );
                 if (Socket.hasSynced === true && !storeInjected) {
-                    console.error(
+                    console.warn(
                         '[wwjs-diag] inject:hasSyncedFix TRIGGERING manual onAppStateHasSyncedEvent',
                     );
                     window.onAppStateHasSyncedEvent();
                 }
-                console.error(
+                console.warn(
                     '[wwjs-diag] listeners:registered ' +
                         JSON.stringify({ ts: Date.now() }),
                 );
             });
 
-            console.log(
-                '[wwjs-diag] inject:end',
-                JSON.stringify({
-                    ts: Date.now(),
-                    durationMs: Date.now() - _injectStart,
-                }),
-            );
+            console.log('[wwjs-diag] inject:end', {
+                ts: Date.now(),
+                durationMs: Date.now() - _injectStart,
+            });
         } finally {
             this._injectInProgress = false;
         }
@@ -766,16 +802,13 @@ class Client extends EventEmitter {
             const isLogout =
                 frameUrl.includes('post_logout=1') || this.lastLoggedOut;
 
-            console.log(
-                '[wwjs-diag] framenavigated',
-                JSON.stringify({
-                    ts: Date.now(),
-                    url: frameUrl.slice(0, 150),
-                    isMainFrame,
-                    isLogout,
-                    lastLoggedOut: this.lastLoggedOut,
-                }),
-            );
+            console.log('[wwjs-diag] framenavigated', {
+                ts: Date.now(),
+                url: frameUrl.slice(0, 150),
+                isMainFrame,
+                isLogout,
+                lastLoggedOut: this.lastLoggedOut,
+            });
 
             if (isLogout) {
                 this.emit(Events.DISCONNECTED, 'LOGOUT');
@@ -796,22 +829,18 @@ class Client extends EventEmitter {
 
             if (!isLogout && storeAvailable) return;
 
-            console.log(
-                '[wwjs-diag] framenavigated:inject START',
-                JSON.stringify({
-                    ts: Date.now(),
-                    url: frameUrl.slice(0, 150),
-                    storeAvailable,
-                }),
-            );
+            console.log('[wwjs-diag] framenavigated:inject START', {
+                ts: Date.now(),
+                url: frameUrl.slice(0, 150),
+                storeAvailable,
+            });
             try {
                 await this.inject();
                 console.log('[wwjs-diag] framenavigated:inject END (success)');
             } catch (err) {
-                console.warn(
-                    '[wwjs-diag] framenavigated:inject END (error)',
-                    String(err?.message || err),
-                );
+                console.warn('[wwjs-diag] framenavigated:inject END (error)', {
+                    error: String(err?.message || err),
+                });
             }
         });
     }
@@ -893,6 +922,9 @@ class Client extends EventEmitter {
      * @property {boolean} reinject is this a reinject?
      */
     async attachEventListeners() {
+        console.log('[wwjs-diag] attachEventListeners:start', {
+            ts: Date.now(),
+        });
         // [diag] Expose diagnostic logging bridge from browser to Node.js
         await exposeFunctionIfAbsent(
             this.pupPage,
@@ -1199,12 +1231,43 @@ class Client extends EventEmitter {
                     }
                 }
 
-                if (!ACCEPTED_STATES.includes(state)) {
+                const willDisconnect = !ACCEPTED_STATES.includes(state);
+                console.log('[wwjs-diag] onAppStateChangedEvent', {
+                    state,
+                    willDisconnect,
+                    acceptedStates: ACCEPTED_STATES,
+                    takeoverOnConflict: !!this.options.takeoverOnConflict,
+                    ts: Date.now(),
+                });
+
+                if (willDisconnect) {
                     /**
                      * Emitted when the client has been disconnected
                      * @event Client#disconnected
                      * @param {WAState|"LOGOUT"} reason reason that caused the disconnect
                      */
+                    console.warn(
+                        '[wwjs-diag] onAppStateChangedEvent DISCONNECTED emitting',
+                        { state, ts: Date.now() },
+                    );
+                    let browserState = null;
+                    try {
+                        browserState = await this.pupPage.evaluate(() => ({
+                            socketState:
+                                window.require?.('WAWebSocketModel')?.Socket
+                                    ?.state,
+                            hasSynced:
+                                window.require?.('WAWebSocketModel')?.Socket
+                                    ?.hasSynced,
+                            storeInjected: typeof window.WWebJS !== 'undefined',
+                        }));
+                    } catch (_) {
+                        /* page may be closing */
+                    }
+                    console.warn(
+                        '[wwjs-diag] onAppStateChangedEvent DISCONNECTED browserState',
+                        { browserState, ts: Date.now() },
+                    );
                     await this.authStrategy.disconnect();
                     this.emit(Events.DISCONNECTED, state);
                     this.destroy();
@@ -1471,6 +1534,14 @@ class Client extends EventEmitter {
                 );
             });
             AppState.on('change:state', (_AppState, state) => {
+                console.warn(
+                    '[wwjs-diag] attachListeners:change:state FIRED ' +
+                        JSON.stringify({
+                            state,
+                            hasSynced: AppState.hasSynced,
+                            ts: Date.now(),
+                        }),
+                );
                 window.onAppStateChangedEvent(state);
             });
             window
@@ -1697,6 +1768,7 @@ class Client extends EventEmitter {
             'Store.Msg listener count',
             JSON.stringify(listenerCount),
         );
+        console.log('[wwjs-diag] attachEventListeners:end', { ts: Date.now() });
     }
 
     async initWebVersionCache() {
@@ -1739,6 +1811,11 @@ class Client extends EventEmitter {
     async destroy() {
         const browser = this.pupBrowser;
         const isConnected = browser?.isConnected?.();
+        console.warn('[wwjs-diag] destroy CALLED', {
+            browserIsConnected: isConnected,
+            ts: Date.now(),
+            stack: new Error().stack?.split('\n').slice(1, 5).join(' | '),
+        });
         if (isConnected) {
             await browser.close();
         }

--- a/src/Client.js
+++ b/src/Client.js
@@ -288,7 +288,9 @@ class Client extends EventEmitter {
                         !pairWithPhoneNumber.phoneNumber
                     ) {
                         // refresh qr code
-                        window.require('WAWebCmd').Cmd.refreshQR();
+                        await this.pupPage.evaluate(() => {
+                            window.require('WAWebCmd').Cmd.refreshQR();
+                        });
                     }
                 },
             );

--- a/src/Client.js
+++ b/src/Client.js
@@ -357,6 +357,7 @@ class Client extends EventEmitter {
                             // Inject diagnostic hooks (media download, signal/crypto, receipts, etc.)
                             await this.pupPage.evaluate(InjectDiagHooks);
                             console.log('[wwjs-diag] onAppStateHasSyncedEvent Store exposed, waiting for readiness...');
+                            const _readyStart = Date.now();
 
                             await this.pupPage
                                 .waitForFunction(
@@ -367,7 +368,7 @@ class Client extends EventEmitter {
                                     console.warn('[wwjs-diag] onAppStateHasSyncedEvent READY TIMEOUT after 30s');
                                     throw 'ready timeout';
                                 });
-                            console.log('[wwjs-diag] onAppStateHasSyncedEvent Store ready');
+                            console.log('[wwjs-diag] onAppStateHasSyncedEvent Store ready', JSON.stringify({ durationMs: Date.now() - _readyStart }));
 
                             this.info = new ClientInfo(
                                 this,

--- a/src/Client.js
+++ b/src/Client.js
@@ -115,323 +115,343 @@ class Client extends EventEmitter {
         if (this._injectInProgress) return;
         this._injectInProgress = true;
 
-        const authTimeout = this.options.authTimeoutMs || 30000;
-        await this.pupPage
-            .waitForFunction('window.Debug?.VERSION != undefined', {
-                timeout: authTimeout,
-            })
-            .catch(() => {
-                this._injectInProgress = false;
-                throw 'auth timeout';
-            });
-        await this.setDeviceName(
-            this.options.deviceName,
-            this.options.browserName,
-        );
-        const pairWithPhoneNumber = this.options.pairWithPhoneNumber;
-        const version = await this.getWWebVersion();
-
-        await this.pupPage.evaluate(ExposeAuthStore);
-
-        const needAuthHandle = await this.pupPage.waitForFunction(
-            () => {
-                const state =
-                    window.require?.('WAWebSocketModel')?.Socket?.state;
-                if (
-                    !state ||
-                    state === 'OPENING' ||
-                    state === 'UNLAUNCHED' ||
-                    state === 'PAIRING'
-                ) {
-                    return false;
-                }
-                return {
-                    need: state === 'UNPAIRED' || state === 'UNPAIRED_IDLE',
-                    state,
-                };
-            },
-            { timeout: authTimeout },
-        );
-        const needAuthentication = await needAuthHandle.jsonValue();
-
-        if (needAuthentication.need) {
-            const { failed, failureEventPayload, restart } =
-                await this.authStrategy.onAuthenticationNeeded();
-
-            if (failed) {
-                /**
-                 * Emitted when there has been an error while trying to restore an existing session
-                 * @event Client#auth_failure
-                 * @param {string} message
-                 */
-                this.emit(Events.AUTHENTICATION_FAILURE, failureEventPayload);
-                await this.destroy();
-                if (restart) {
-                    // session restore failed so try again but without session to force new authentication
-                    return this.initialize();
-                }
-                return;
-            }
-
-            // Register qr/code events
-            if (pairWithPhoneNumber.phoneNumber) {
-                await exposeFunctionIfAbsent(
-                    this.pupPage,
-                    'onCodeReceivedEvent',
-                    async (code) => {
-                        /**
-                         * Emitted when a pairing code is received
-                         * @event Client#code
-                         * @param {string} code Code
-                         * @returns {string} Code that was just received
-                         */
-                        this.emit(Events.CODE_RECEIVED, code);
-                        return code;
-                    },
-                );
-                this.requestPairingCode(
-                    pairWithPhoneNumber.phoneNumber,
-                    pairWithPhoneNumber.showNotification,
-                    pairWithPhoneNumber.intervalMs,
-                );
-            } else {
-                let qrRetries = 0;
-                await exposeFunctionIfAbsent(
-                    this.pupPage,
-                    'onQRChangedEvent',
-                    async (qr) => {
-                        /**
-                         * Emitted when a QR code is received
-                         * @event Client#qr
-                         * @param {string} qr QR Code
-                         */
-                        this.emit(Events.QR_RECEIVED, qr);
-                        if (this.options.qrMaxRetries > 0) {
-                            qrRetries++;
-                            if (qrRetries > this.options.qrMaxRetries) {
-                                this.emit(
-                                    Events.DISCONNECTED,
-                                    'Max qrcode retries reached',
-                                );
-                                await this.destroy();
-                            }
-                        }
-                    },
-                );
-
-                await this.pupPage.evaluate(async () => {
-                    const registrationInfo =
-                        await window.AuthStore.RegistrationUtils.waSignalStore.getRegistrationInfo();
-                    const noiseKeyPair =
-                        await window.AuthStore.RegistrationUtils.waNoiseInfo.get();
-                    const staticKeyB64 = window.AuthStore.Base64Tools.encodeB64(
-                        noiseKeyPair.staticKeyPair.pubKey,
-                    );
-                    const identityKeyB64 =
-                        window.AuthStore.Base64Tools.encodeB64(
-                            registrationInfo.identityKeyPair.pubKey,
-                        );
-                    const advSecretKey =
-                        await window.AuthStore.RegistrationUtils.getADVSecretKey();
-                    const platform =
-                        window.AuthStore.RegistrationUtils.DEVICE_PLATFORM;
-                    const getQR = (ref) =>
-                        ref +
-                        ',' +
-                        staticKeyB64 +
-                        ',' +
-                        identityKeyB64 +
-                        ',' +
-                        advSecretKey +
-                        ',' +
-                        platform;
-
-                    window.onQRChangedEvent(getQR(window.AuthStore.Conn.ref)); // initial qr
-                    window.AuthStore.Conn.on('change:ref', (_, ref) => {
-                        window.onQRChangedEvent(getQR(ref));
-                    }); // future QR changes
+        try {
+            const authTimeout = this.options.authTimeoutMs || 30000;
+            await this.pupPage
+                .waitForFunction('window.Debug?.VERSION != undefined', {
+                    timeout: authTimeout,
+                })
+                .catch(() => {
+                    throw 'auth timeout';
                 });
-            }
-        }
+            await this.setDeviceName(
+                this.options.deviceName,
+                this.options.browserName,
+            );
+            const pairWithPhoneNumber = this.options.pairWithPhoneNumber;
+            const version = await this.getWWebVersion();
 
-        await exposeFunctionIfAbsent(
-            this.pupPage,
-            'onAuthAppStateChangedEvent',
-            async (state) => {
-                if (
-                    state == 'UNPAIRED_IDLE' &&
-                    !pairWithPhoneNumber.phoneNumber
-                ) {
-                    // refresh qr code
-                    window.require('WAWebCmd').Cmd.refreshQR();
-                }
-            },
-        );
+            await this.pupPage.evaluate(ExposeAuthStore);
 
-        await exposeFunctionIfAbsent(
-            this.pupPage,
-            'onAppStateHasSyncedEvent',
-            async () => {
-                const authEventPayload =
-                    await this.authStrategy.getAuthEventPayload();
-                /**
-                 * Emitted when authentication is successful
-                 * @event Client#authenticated
-                 */
-                this.emit(Events.AUTHENTICATED, authEventPayload);
-
-                const injected = await this.pupPage.evaluate(async () => {
-                    return typeof window.WWebJS !== 'undefined';
-                });
-
-                if (!injected) {
+            const needAuthHandle = await this.pupPage.waitForFunction(
+                () => {
+                    const state =
+                        window.require?.('WAWebSocketModel')?.Socket?.state;
                     if (
-                        this.options.webVersionCache.type === 'local' &&
-                        this.currentIndexHtml
+                        !state ||
+                        state === 'OPENING' ||
+                        state === 'UNLAUNCHED' ||
+                        state === 'PAIRING'
                     ) {
-                        const { type: webCacheType, ...webCacheOptions } =
-                            this.options.webVersionCache;
-                        const webCache = WebCacheFactory.createWebCache(
-                            webCacheType,
-                            webCacheOptions,
-                        );
-
-                        await webCache.persist(this.currentIndexHtml, version);
+                        return false;
                     }
+                    return {
+                        need: state === 'UNPAIRED' || state === 'UNPAIRED_IDLE',
+                        state,
+                    };
+                },
+                { timeout: authTimeout },
+            );
+            const needAuthentication = await needAuthHandle.jsonValue();
 
-                    //Load util functions (serializers, helper functions)
-                    await this.pupPage.evaluate(LoadUtils);
+            if (needAuthentication.need) {
+                const { failed, failureEventPayload, restart } =
+                    await this.authStrategy.onAuthenticationNeeded();
 
-                    await this.pupPage
-                        .waitForFunction(
-                            'typeof window.WWebJS !== "undefined"',
-                            { timeout: 30000 },
-                        )
-                        .catch(() => {
-                            throw 'ready timeout';
-                        });
-
+                if (failed) {
                     /**
-                     * Current connection information
-                     * @type {ClientInfo}
+                     * Emitted when there has been an error while trying to restore an existing session
+                     * @event Client#auth_failure
+                     * @param {string} message
                      */
-                    this.info = new ClientInfo(
-                        this,
-                        await this.pupPage.evaluate(() => {
-                            return {
-                                ...window
-                                    .require('WAWebConnModel')
-                                    .Conn.serialize(),
-                                wid:
-                                    window
-                                        .require('WAWebUserPrefsMeUser')
-                                        .getMaybeMePnUser() ||
-                                    window
-                                        .require('WAWebUserPrefsMeUser')
-                                        .getMaybeMeLidUser(),
-                            };
-                        }),
+                    this.emit(
+                        Events.AUTHENTICATION_FAILURE,
+                        failureEventPayload,
+                    );
+                    await this.destroy();
+                    if (restart) {
+                        // session restore failed so try again but without session to force new authentication
+                        return this.initialize();
+                    }
+                    return;
+                }
+
+                // Register qr/code events
+                if (pairWithPhoneNumber.phoneNumber) {
+                    await exposeFunctionIfAbsent(
+                        this.pupPage,
+                        'onCodeReceivedEvent',
+                        async (code) => {
+                            /**
+                             * Emitted when a pairing code is received
+                             * @event Client#code
+                             * @param {string} code Code
+                             * @returns {string} Code that was just received
+                             */
+                            this.emit(Events.CODE_RECEIVED, code);
+                            return code;
+                        },
+                    );
+                    this.requestPairingCode(
+                        pairWithPhoneNumber.phoneNumber,
+                        pairWithPhoneNumber.showNotification,
+                        pairWithPhoneNumber.intervalMs,
+                    );
+                } else {
+                    let qrRetries = 0;
+
+                    this.on(Events.LOADING_SCREEN, () => {
+                        qrRetries = 0;
+                    });
+
+                    await exposeFunctionIfAbsent(
+                        this.pupPage,
+                        'onQRChangedEvent',
+                        async (qr) => {
+                            /**
+                             * Emitted when a QR code is received
+                             * @event Client#qr
+                             * @param {string} qr QR Code
+                             */
+                            this.emit(Events.QR_RECEIVED, qr);
+                            if (this.options.qrMaxRetries > 0) {
+                                qrRetries++;
+                                if (qrRetries > this.options.qrMaxRetries) {
+                                    this.emit(
+                                        Events.DISCONNECTED,
+                                        'Max qrcode retries reached',
+                                    );
+                                    await this.destroy();
+                                }
+                            }
+                        },
                     );
 
-                    this.interface = new InterfaceController(this);
+                    await this.pupPage.evaluate(async () => {
+                        const registrationInfo =
+                            await window.AuthStore.RegistrationUtils.waSignalStore.getRegistrationInfo();
+                        const noiseKeyPair =
+                            await window.AuthStore.RegistrationUtils.waNoiseInfo.get();
+                        const staticKeyB64 =
+                            window.AuthStore.Base64Tools.encodeB64(
+                                noiseKeyPair.staticKeyPair.pubKey,
+                            );
+                        const identityKeyB64 =
+                            window.AuthStore.Base64Tools.encodeB64(
+                                registrationInfo.identityKeyPair.pubKey,
+                            );
+                        const advSecretKey =
+                            await window.AuthStore.RegistrationUtils.getADVSecretKey();
+                        const platform =
+                            window.AuthStore.RegistrationUtils.DEVICE_PLATFORM;
+                        const getQR = (ref) =>
+                            ref +
+                            ',' +
+                            staticKeyB64 +
+                            ',' +
+                            identityKeyB64 +
+                            ',' +
+                            advSecretKey +
+                            ',' +
+                            platform;
 
-                    await this.attachEventListeners();
+                        window.onQRChangedEvent(
+                            getQR(window.AuthStore.Conn.ref),
+                        ); // initial qr
+                        window.AuthStore.Conn.on('change:ref', (_, ref) => {
+                            if (ref == null) return;
+                            window.onQRChangedEvent(getQR(ref));
+                        }); // future QR changes
+                    });
                 }
-                /**
-                 * Emitted when the client has initialized and is ready to receive messages.
-                 * @event Client#ready
-                 */
-                this.emit(Events.READY);
-                this.authStrategy.afterAuthReady();
-            },
-        );
-        let lastPercent = null;
-        await exposeFunctionIfAbsent(
-            this.pupPage,
-            'onOfflineProgressUpdateEvent',
-            async (percent) => {
-                if (lastPercent !== percent) {
-                    lastPercent = percent;
-                    this.emit(Events.LOADING_SCREEN, percent, 'WhatsApp'); // Message is hardcoded as "WhatsApp" for now
-                }
-            },
-        );
-        await exposeFunctionIfAbsent(
-            this.pupPage,
-            'onLogoutEvent',
-            async () => {
-                this.lastLoggedOut = true;
-                await this.pupPage
-                    .waitForNavigation({ waitUntil: 'load', timeout: 5000 })
-                    .catch((_) => _);
-            },
-        );
-        await this.pupPage.evaluate(() => {
-            const Socket = window.require('WAWebSocketModel').Socket;
-            const Cmd = window.require('WAWebCmd').Cmd;
+            }
 
-            const listeners = [
-                [
-                    Socket,
-                    'change:state',
-                    (_AppState, state) => {
-                        window.onAuthAppStateChangedEvent(state);
-                    },
-                ],
-                [
-                    Socket,
-                    'change:hasSynced',
-                    () => {
-                        window.onAppStateHasSyncedEvent();
-                    },
-                ],
-                [
-                    Cmd,
-                    'offline_progress_update_from_bridge',
-                    () => {
-                        window.onOfflineProgressUpdateEvent(
-                            window.AuthStore.OfflineMessageHandler.getOfflineDeliveryProgress(),
+            await exposeFunctionIfAbsent(
+                this.pupPage,
+                'onAuthAppStateChangedEvent',
+                async (state) => {
+                    if (
+                        state == 'UNPAIRED_IDLE' &&
+                        !pairWithPhoneNumber.phoneNumber
+                    ) {
+                        // refresh qr code
+                        window.require('WAWebCmd').Cmd.refreshQR();
+                    }
+                },
+            );
+
+            await exposeFunctionIfAbsent(
+                this.pupPage,
+                'onAppStateHasSyncedEvent',
+                async () => {
+                    const authEventPayload =
+                        await this.authStrategy.getAuthEventPayload();
+                    /**
+                     * Emitted when authentication is successful
+                     * @event Client#authenticated
+                     */
+                    this.emit(Events.AUTHENTICATED, authEventPayload);
+
+                    const injected = await this.pupPage.evaluate(async () => {
+                        return typeof window.WWebJS !== 'undefined';
+                    });
+
+                    if (!injected) {
+                        if (
+                            this.options.webVersionCache.type === 'local' &&
+                            this.currentIndexHtml
+                        ) {
+                            const { type: webCacheType, ...webCacheOptions } =
+                                this.options.webVersionCache;
+                            const webCache = WebCacheFactory.createWebCache(
+                                webCacheType,
+                                webCacheOptions,
+                            );
+
+                            await webCache.persist(
+                                this.currentIndexHtml,
+                                version,
+                            );
+                        }
+
+                        //Load util functions (serializers, helper functions)
+                        await this.pupPage.evaluate(LoadUtils);
+
+                        await this.pupPage
+                            .waitForFunction(
+                                'typeof window.WWebJS !== "undefined"',
+                                { timeout: 30000 },
+                            )
+                            .catch(() => {
+                                throw 'ready timeout';
+                            });
+
+                        /**
+                         * Current connection information
+                         * @type {ClientInfo}
+                         */
+                        this.info = new ClientInfo(
+                            this,
+                            await this.pupPage.evaluate(() => {
+                                return {
+                                    ...window
+                                        .require('WAWebConnModel')
+                                        .Conn.serialize(),
+                                    wid:
+                                        window
+                                            .require('WAWebUserPrefsMeUser')
+                                            .getMaybeMePnUser() ||
+                                        window
+                                            .require('WAWebUserPrefsMeUser')
+                                            .getMaybeMeLidUser(),
+                                };
+                            }),
                         );
-                    },
-                ],
-                [
-                    Cmd,
-                    'logout',
-                    async () => {
-                        await window.onLogoutEvent();
-                    },
-                ],
-                [
-                    Cmd,
-                    'logout_from_bridge',
-                    async () => {
-                        await window.onLogoutEvent();
-                    },
-                ],
-            ];
 
-            if (window._wwjsListeners) {
-                for (const [obj, event, handler] of window._wwjsListeners) {
-                    obj.off(event, handler);
-                }
-            }
+                        this.interface = new InterfaceController(this);
 
-            for (const [obj, event, handler] of listeners) {
-                obj.on(event, handler);
-            }
-            window._wwjsListeners = listeners;
-        });
-
-        const hasSynced = await this.pupPage.evaluate(
-            () => window.require('WAWebSocketModel').Socket.hasSynced,
-        );
-        if (hasSynced) {
+                        await this.attachEventListeners();
+                    }
+                    /**
+                     * Emitted when the client has initialized and is ready to receive messages.
+                     * @event Client#ready
+                     */
+                    this.emit(Events.READY);
+                    this.authStrategy.afterAuthReady();
+                },
+            );
+            let lastPercent = null;
+            await exposeFunctionIfAbsent(
+                this.pupPage,
+                'onOfflineProgressUpdateEvent',
+                async (percent) => {
+                    if (lastPercent !== percent) {
+                        lastPercent = percent;
+                        this.emit(Events.LOADING_SCREEN, percent, 'WhatsApp'); // Message is hardcoded as "WhatsApp" for now
+                    }
+                },
+            );
+            await exposeFunctionIfAbsent(
+                this.pupPage,
+                'onLogoutEvent',
+                async () => {
+                    this.lastLoggedOut = true;
+                    await this.pupPage
+                        .waitForNavigation({ waitUntil: 'load', timeout: 5000 })
+                        .catch((_) => _);
+                },
+            );
             await this.pupPage.evaluate(() => {
-                window.onAppStateHasSyncedEvent();
-            });
-        }
+                const Socket = window.require('WAWebSocketModel').Socket;
+                const Cmd = window.require('WAWebCmd').Cmd;
 
-        this._injectInProgress = false;
+                const listeners = [
+                    [
+                        Socket,
+                        'change:state',
+                        (_AppState, state) => {
+                            window.onAuthAppStateChangedEvent(state);
+                        },
+                    ],
+                    [
+                        Socket,
+                        'change:hasSynced',
+                        () => {
+                            window.onAppStateHasSyncedEvent();
+                        },
+                    ],
+                    [
+                        Cmd,
+                        'offline_progress_update_from_bridge',
+                        () => {
+                            window.onOfflineProgressUpdateEvent(
+                                window.AuthStore.OfflineMessageHandler.getOfflineDeliveryProgress(),
+                            );
+                        },
+                    ],
+                    [
+                        Cmd,
+                        'logout',
+                        async () => {
+                            await window.onLogoutEvent();
+                        },
+                    ],
+                    [
+                        Cmd,
+                        'logout_from_bridge',
+                        async () => {
+                            await window.onLogoutEvent();
+                        },
+                    ],
+                ];
+
+                // Clean up old listeners to prevent accumulation on re-inject
+                if (window._wwjsListeners) {
+                    for (const [obj, event, handler] of window._wwjsListeners) {
+                        try {
+                            obj.off(event, handler);
+                        } catch (e) {
+                            /* listeners may already be gone */
+                        }
+                    }
+                }
+
+                for (const [obj, event, handler] of listeners) {
+                    obj.on(event, handler);
+                }
+                window._wwjsListeners = listeners;
+
+                // Atomic hasSynced check in the same synchronous block as listener registration.
+                // If hasSynced is already true, Backbone won't fire change:hasSynced (no transition).
+                // If hasSynced is false, the listener above will catch the future transition.
+                const storeInjected = typeof window.WWebJS !== 'undefined';
+                if (Socket.hasSynced === true && !storeInjected) {
+                    window.onAppStateHasSyncedEvent();
+                }
+            });
+        } finally {
+            this._injectInProgress = false;
+        }
     }
 
     /**
@@ -506,7 +526,10 @@ class Client extends EventEmitter {
         this.pupPage.on('framenavigated', async (frame) => {
             if (frame.parentFrame() !== null) return;
 
-            if (frame.url().includes('post_logout=1') || this.lastLoggedOut) {
+            const isLogout =
+                frame.url().includes('post_logout=1') || this.lastLoggedOut;
+
+            if (isLogout) {
                 this.emit(Events.DISCONNECTED, 'LOGOUT');
                 await this.authStrategy.logout();
                 await this.authStrategy.beforeBrowserInitialized();
@@ -514,15 +537,21 @@ class Client extends EventEmitter {
                 this.lastLoggedOut = false;
             }
 
-            const storeAvailable = await this.pupPage
-                .evaluate('typeof window.WWebJS !== "undefined"')
-                .catch(() => false);
-            if (storeAvailable) return;
+            let storeAvailable = false;
+            try {
+                storeAvailable = await this.pupPage.evaluate(() => {
+                    return typeof window.WWebJS !== 'undefined';
+                });
+            } catch (e) {
+                /* page may not be ready */
+            }
+
+            if (!isLogout && storeAvailable) return;
 
             try {
                 await this.inject();
             } catch (err) {
-                this._injectInProgress = false;
+                // inject() may fail if page is still loading after navigation
             }
         });
     }
@@ -539,6 +568,14 @@ class Client extends EventEmitter {
         showNotification = true,
         intervalMs = 180000,
     ) {
+        await exposeFunctionIfAbsent(
+            this.pupPage,
+            'onCodeReceivedEvent',
+            async (code) => {
+                this.emit(Events.CODE_RECEIVED, code);
+                return code;
+            },
+        );
         return await this.pupPage.evaluate(
             async (phoneNumber, showNotification, intervalMs) => {
                 const getCode = async () => {

--- a/src/Client.js
+++ b/src/Client.js
@@ -957,11 +957,27 @@ class Client extends EventEmitter {
             'onAddMessageCiphertextEvent',
             (msg) => {
                 /**
-                 * Emitted when messages are edited
+                 * Emitted when a message is received as ciphertext (not yet decrypted)
                  * @event Client#message_ciphertext
                  * @param {Message} message
                  */
                 this.emit(Events.MESSAGE_CIPHERTEXT, new Message(this, msg));
+            },
+        );
+
+        await exposeFunctionIfAbsent(
+            this.pupPage,
+            'onCiphertextFailedEvent',
+            (msg) => {
+                /**
+                 * Emitted when a ciphertext message failed to decrypt after recovery attempt
+                 * @event Client#message_ciphertext_failed
+                 * @param {Message} message
+                 */
+                this.emit(
+                    Events.MESSAGE_CIPHERTEXT_FAILED,
+                    new Message(this, msg),
+                );
             },
         );
 
@@ -984,6 +1000,15 @@ class Client extends EventEmitter {
             const { Msg, Chat, WAWebCallCollection } =
                 window.require('WAWebCollections');
             const AppState = window.require('WAWebSocketModel').Socket;
+
+            // Enable placeholder message resend (recovery for ciphertext messages)
+            try {
+                const gatingUtils = window.require('WAWebSyncGatingUtils');
+                gatingUtils.isPlaceholderMessageResendEnabled = () => true;
+            } catch (_) {
+                // Module may not be available in all versions
+            }
+
             Msg.on('change', (msg) => {
                 window.onChangeMessageEvent(window.WWebJS.getMessageModel(msg));
             });
@@ -1049,11 +1074,31 @@ class Client extends EventEmitter {
                 if (msg.isNewMsg) {
                     if (msg.type === 'ciphertext') {
                         // defer message event until ciphertext is resolved (type changed)
-                        msg.once('change:type', (_msg) =>
+                        const resendTimer = setTimeout(() => {
+                            try {
+                                const { sendPeerDataOperationRequest } =
+                                    window.require(
+                                        'WAWebSendNonMessageDataRequest',
+                                    );
+                                sendPeerDataOperationRequest(4, {
+                                    msgKeys: [msg.id],
+                                }).catch(() => {});
+                            } catch (_) {
+                                // module may not be available
+                            }
+                        }, 5000);
+                        const failTimer = setTimeout(() => {
+                            window.onCiphertextFailedEvent(
+                                window.WWebJS.getMessageModel(msg),
+                            );
+                        }, 15000);
+                        msg.once('change:type', (_msg) => {
+                            clearTimeout(resendTimer);
+                            clearTimeout(failTimer);
                             window.onAddMessageEvent(
                                 window.WWebJS.getMessageModel(_msg),
-                            ),
-                        );
+                            );
+                        });
                         window.onAddMessageCiphertextEvent(
                             window.WWebJS.getMessageModel(msg),
                         );

--- a/src/Client.js
+++ b/src/Client.js
@@ -112,27 +112,18 @@ class Client extends EventEmitter {
      * Private function
      */
     async inject() {
-        if (
-            this.options.authTimeoutMs === undefined ||
-            this.options.authTimeoutMs == 0
-        ) {
-            this.options.authTimeoutMs = 30000;
-        }
-        let start = Date.now();
-        let timeout = this.options.authTimeoutMs;
-        let res = false;
-        while (start > Date.now() - timeout) {
-            res = await this.pupPage.evaluate(
-                'window.Debug?.VERSION != undefined',
-            );
-            if (res) {
-                break;
-            }
-            await new Promise((r) => setTimeout(r, 200));
-        }
-        if (!res) {
-            throw 'auth timeout';
-        }
+        if (this._injectInProgress) return;
+        this._injectInProgress = true;
+
+        const authTimeout = this.options.authTimeoutMs || 30000;
+        await this.pupPage
+            .waitForFunction('window.Debug?.VERSION != undefined', {
+                timeout: authTimeout,
+            })
+            .catch(() => {
+                this._injectInProgress = false;
+                throw 'auth timeout';
+            });
         await this.setDeviceName(
             this.options.deviceName,
             this.options.browserName,
@@ -142,43 +133,28 @@ class Client extends EventEmitter {
 
         await this.pupPage.evaluate(ExposeAuthStore);
 
-        const needAuthentication = await this.pupPage.evaluate(async () => {
-            let state = window.require('WAWebSocketModel').Socket.state;
+        const needAuthHandle = await this.pupPage.waitForFunction(
+            () => {
+                const state =
+                    window.require?.('WAWebSocketModel')?.Socket?.state;
+                if (
+                    !state ||
+                    state === 'OPENING' ||
+                    state === 'UNLAUNCHED' ||
+                    state === 'PAIRING'
+                ) {
+                    return false;
+                }
+                return {
+                    need: state === 'UNPAIRED' || state === 'UNPAIRED_IDLE',
+                    state,
+                };
+            },
+            { timeout: authTimeout },
+        );
+        const needAuthentication = await needAuthHandle.jsonValue();
 
-            if (
-                state === 'OPENING' ||
-                state === 'UNLAUNCHED' ||
-                state === 'PAIRING'
-            ) {
-                // wait till state changes
-                await new Promise((r) => {
-                    window
-                        .require('WAWebSocketModel')
-                        .Socket.on(
-                            'change:state',
-                            function waitTillInit(_AppState, state) {
-                                if (
-                                    state !== 'OPENING' &&
-                                    state !== 'UNLAUNCHED' &&
-                                    state !== 'PAIRING'
-                                ) {
-                                    window
-                                        .require('WAWebSocketModel')
-                                        .Socket.off(
-                                            'change:state',
-                                            waitTillInit,
-                                        );
-                                    r();
-                                }
-                            },
-                        );
-                });
-            }
-            state = window.require('WAWebSocketModel').Socket.state;
-            return state == 'UNPAIRED' || state == 'UNPAIRED_IDLE';
-        });
-
-        if (needAuthentication) {
+        if (needAuthentication.need) {
             const { failed, failureEventPayload, restart } =
                 await this.authStrategy.onAuthenticationNeeded();
 
@@ -326,21 +302,14 @@ class Client extends EventEmitter {
                     //Load util functions (serializers, helper functions)
                     await this.pupPage.evaluate(LoadUtils);
 
-                    let start = Date.now();
-                    let res = false;
-                    while (start > Date.now() - 30000) {
-                        // Check window.WWebJS Injection
-                        res = await this.pupPage.evaluate(
-                            'window.WWebJS != undefined',
-                        );
-                        if (res) {
-                            break;
-                        }
-                        await new Promise((r) => setTimeout(r, 200));
-                    }
-                    if (!res) {
-                        throw 'ready timeout';
-                    }
+                    await this.pupPage
+                        .waitForFunction(
+                            'typeof window.WWebJS !== "undefined"',
+                            { timeout: 30000 },
+                        )
+                        .catch(() => {
+                            throw 'ready timeout';
+                        });
 
                     /**
                      * Current connection information
@@ -398,29 +367,71 @@ class Client extends EventEmitter {
             },
         );
         await this.pupPage.evaluate(() => {
-            window
-                .require('WAWebSocketModel')
-                .Socket.on('change:state', (_AppState, state) => {
-                    window.onAuthAppStateChangedEvent(state);
-                });
-            window
-                .require('WAWebSocketModel')
-                .Socket.on('change:hasSynced', () => {
-                    window.onAppStateHasSyncedEvent();
-                });
+            const Socket = window.require('WAWebSocketModel').Socket;
             const Cmd = window.require('WAWebCmd').Cmd;
-            Cmd.on('offline_progress_update_from_bridge', () => {
-                window.onOfflineProgressUpdateEvent(
-                    window.AuthStore.OfflineMessageHandler.getOfflineDeliveryProgress(),
-                );
-            });
-            Cmd.on('logout', async () => {
-                await window.onLogoutEvent();
-            });
-            Cmd.on('logout_from_bridge', async () => {
-                await window.onLogoutEvent();
-            });
+
+            const listeners = [
+                [
+                    Socket,
+                    'change:state',
+                    (_AppState, state) => {
+                        window.onAuthAppStateChangedEvent(state);
+                    },
+                ],
+                [
+                    Socket,
+                    'change:hasSynced',
+                    () => {
+                        window.onAppStateHasSyncedEvent();
+                    },
+                ],
+                [
+                    Cmd,
+                    'offline_progress_update_from_bridge',
+                    () => {
+                        window.onOfflineProgressUpdateEvent(
+                            window.AuthStore.OfflineMessageHandler.getOfflineDeliveryProgress(),
+                        );
+                    },
+                ],
+                [
+                    Cmd,
+                    'logout',
+                    async () => {
+                        await window.onLogoutEvent();
+                    },
+                ],
+                [
+                    Cmd,
+                    'logout_from_bridge',
+                    async () => {
+                        await window.onLogoutEvent();
+                    },
+                ],
+            ];
+
+            if (window._wwjsListeners) {
+                for (const [obj, event, handler] of window._wwjsListeners) {
+                    obj.off(event, handler);
+                }
+            }
+
+            for (const [obj, event, handler] of listeners) {
+                obj.on(event, handler);
+            }
+            window._wwjsListeners = listeners;
         });
+
+        const hasSynced = await this.pupPage.evaluate(
+            () => window.require('WAWebSocketModel').Socket.hasSynced,
+        );
+        if (hasSynced) {
+            await this.pupPage.evaluate(() => {
+                window.onAppStateHasSyncedEvent();
+            });
+        }
+
+        this._injectInProgress = false;
     }
 
     /**
@@ -493,6 +504,8 @@ class Client extends EventEmitter {
         await this.inject();
 
         this.pupPage.on('framenavigated', async (frame) => {
+            if (frame.parentFrame() !== null) return;
+
             if (frame.url().includes('post_logout=1') || this.lastLoggedOut) {
                 this.emit(Events.DISCONNECTED, 'LOGOUT');
                 await this.authStrategy.logout();
@@ -500,7 +513,17 @@ class Client extends EventEmitter {
                 await this.authStrategy.afterBrowserInitialized();
                 this.lastLoggedOut = false;
             }
-            await this.inject();
+
+            const storeAvailable = await this.pupPage
+                .evaluate('typeof window.WWebJS !== "undefined"')
+                .catch(() => false);
+            if (storeAvailable) return;
+
+            try {
+                await this.inject();
+            } catch (err) {
+                this._injectInProgress = false;
+            }
         });
     }
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -255,13 +255,25 @@ class Client extends EventEmitter {
                             ',' +
                             platform;
 
+                        const onRefChange = (_, ref) => {
+                            if (ref == null) return;
+                            window.onQRChangedEvent(getQR(ref));
+                        };
+
                         window.onQRChangedEvent(
                             getQR(window.AuthStore.Conn.ref),
                         ); // initial qr
-                        window.AuthStore.Conn.on('change:ref', (_, ref) => {
-                            if (ref == null) return;
-                            window.onQRChangedEvent(getQR(ref));
-                        }); // future QR changes
+                        window.AuthStore.Conn.on('change:ref', onRefChange); // future QR changes
+
+                        // Remove QR listener once authentication succeeds
+                        window
+                            .require('WAWebSocketModel')
+                            .Socket.on('change:hasSynced', () => {
+                                window.AuthStore.Conn.off(
+                                    'change:ref',
+                                    onRefChange,
+                                );
+                            });
                     });
                 }
             }

--- a/src/Client.js
+++ b/src/Client.js
@@ -580,14 +580,6 @@ class Client extends EventEmitter {
         showNotification = true,
         intervalMs = 180000,
     ) {
-        await exposeFunctionIfAbsent(
-            this.pupPage,
-            'onCodeReceivedEvent',
-            async (code) => {
-                this.emit(Events.CODE_RECEIVED, code);
-                return code;
-            },
-        );
         return await this.pupPage.evaluate(
             async (phoneNumber, showNotification, intervalMs) => {
                 const getCode = async () => {

--- a/src/Client.js
+++ b/src/Client.js
@@ -665,7 +665,11 @@ class Client extends EventEmitter {
         await this.authStrategy.beforeBrowserInitialized();
 
         const puppeteerOpts = this.options.puppeteer;
-        if (
+        if (puppeteerOpts && puppeteerOpts.browser && puppeteerOpts.page) {
+            // External browser + page provided by caller
+            browser = puppeteerOpts.browser;
+            page = puppeteerOpts.page;
+        } else if (
             puppeteerOpts &&
             (puppeteerOpts.browserWSEndpoint || puppeteerOpts.browserURL)
         ) {
@@ -1964,7 +1968,11 @@ class Client extends EventEmitter {
             stack: new Error().stack?.split('\n').slice(1, 5).join(' | '),
         });
         if (isConnected) {
-            await browser.close();
+            if (browser.process()) {
+                await browser.close();
+            } else {
+                browser.disconnect();
+            }
         }
         await this.authStrategy.destroy();
     }
@@ -1976,13 +1984,17 @@ class Client extends EventEmitter {
         await this.pupPage.evaluate(() => {
             return window.require('WAWebSocketModel').Socket.logout();
         });
-        await this.pupBrowser.close();
 
-        let maxDelay = 0;
-        while (this.pupBrowser.isConnected() && maxDelay < 10) {
-            // waits a maximum of 1 second before calling the AuthStrategy
-            await new Promise((resolve) => setTimeout(resolve, 100));
-            maxDelay++;
+        if (this.pupBrowser.process()) {
+            await this.pupBrowser.close();
+
+            let maxDelay = 0;
+            while (this.pupBrowser.isConnected() && maxDelay < 10) {
+                await new Promise((resolve) => setTimeout(resolve, 100));
+                maxDelay++;
+            }
+        } else {
+            this.pupBrowser.disconnect();
         }
 
         await this.authStrategy.logout();

--- a/src/structures/Contact.js
+++ b/src/structures/Contact.js
@@ -155,10 +155,10 @@ class Contact extends Base {
         if (this.isGroup) return false;
 
         await this.client.pupPage.evaluate(async (contactId) => {
-            const chat = await window.WWebJS.getChat(contactId);
+            const contact = await window.WWebJS.findContact(contactId);
             await window
                 .require('WAWebBlockContactAction')
-                .blockContact({ contact: chat });
+                .blockContact({ contact });
         }, this.id._serialized);
 
         this.isBlocked = true;
@@ -173,9 +173,7 @@ class Contact extends Base {
         if (this.isGroup) return false;
 
         await this.client.pupPage.evaluate(async (contactId) => {
-            const contact = window
-                .require('WAWebCollections')
-                .Contact.get(contactId);
+            const contact = await window.WWebJS.findContact(contactId);
             await window
                 .require('WAWebBlockContactAction')
                 .unblockContact(contact);

--- a/src/structures/Contact.js
+++ b/src/structures/Contact.js
@@ -155,7 +155,9 @@ class Contact extends Base {
         if (this.isGroup) return false;
 
         await this.client.pupPage.evaluate(async (contactId) => {
-            const contact = await window.WWebJS.findContact(contactId);
+            const contact = await window
+                .require('WAWebCollections')
+                .Contact.find(contactId);
             await window
                 .require('WAWebBlockContactAction')
                 .blockContact({ contact });
@@ -173,7 +175,9 @@ class Contact extends Base {
         if (this.isGroup) return false;
 
         await this.client.pupPage.evaluate(async (contactId) => {
-            const contact = await window.WWebJS.findContact(contactId);
+            const contact = await window
+                .require('WAWebCollections')
+                .Contact.find(contactId);
             await window
                 .require('WAWebBlockContactAction')
                 .unblockContact(contact);

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -49,13 +49,23 @@ class Message extends Base {
         this.hasMedia = Boolean(data.directPath);
 
         // [L11] Log when image/video/document has no directPath (hasMedia=false)
-        if (!this.hasMedia && ['image', 'video', 'document', 'ptt', 'audio', 'sticker'].includes(data.type)) {
-            this.client?.emit?.('diag', 'warn', 'Media type without directPath', JSON.stringify({
-                id: data.id?._serialized || data.id?.id,
-                type: data.type,
-                hasDirectPath: !!data.directPath,
-                hasMediaKey: !!data.mediaKey
-            }));
+        if (
+            !this.hasMedia &&
+            ['image', 'video', 'document', 'ptt', 'audio', 'sticker'].includes(
+                data.type,
+            )
+        ) {
+            this.client?.emit?.(
+                'diag',
+                'warn',
+                'Media type without directPath',
+                JSON.stringify({
+                    id: data.id?._serialized || data.id?.id,
+                    type: data.type,
+                    hasDirectPath: !!data.directPath,
+                    hasMediaKey: !!data.mediaKey,
+                }),
+            );
         }
 
         /**
@@ -537,10 +547,15 @@ class Message extends Base {
     async downloadMedia() {
         if (!this.hasMedia) {
             // [L12] Log when downloadMedia called but hasMedia=false
-            this.client?.emit?.('diag', 'warn', 'downloadMedia: hasMedia=false', JSON.stringify({
-                id: this.id?._serialized,
-                type: this.type
-            }));
+            this.client?.emit?.(
+                'diag',
+                'warn',
+                'downloadMedia: hasMedia=false',
+                JSON.stringify({
+                    id: this.id?._serialized,
+                    type: this.type,
+                }),
+            );
             return undefined;
         }
 
@@ -560,19 +575,30 @@ class Message extends Base {
                 msg.mediaData.mediaStage === 'REUPLOADING'
             ) {
                 // [L12] Log silent null return
-                if (window.onDiagLog) window.onDiagLog('warn', 'downloadMedia: returning null', JSON.stringify({
-                    id: msgId,
-                    hasMsg: !!msg,
-                    hasMediaData: !!msg?.mediaData,
-                    mediaStage: msg?.mediaData?.mediaStage
-                }));
+                if (window.onDiagLog)
+                    window.onDiagLog(
+                        'warn',
+                        'downloadMedia: returning null',
+                        JSON.stringify({
+                            id: msgId,
+                            hasMsg: !!msg,
+                            hasMediaData: !!msg?.mediaData,
+                            mediaStage: msg?.mediaData?.mediaStage,
+                        }),
+                    );
                 return null;
             }
             if (msg.mediaData.mediaStage != 'RESOLVED') {
                 // [L13] Snapshot crypto fields BEFORE resolve attempt
                 const cryptoBefore = {
                     directPath: msg.directPath,
-                    mediaKey: msg.mediaKey ? btoa(String.fromCharCode(...new Uint8Array(msg.mediaKey.slice(0, 4)))) : null,
+                    mediaKey: msg.mediaKey
+                        ? btoa(
+                              String.fromCharCode(
+                                  ...new Uint8Array(msg.mediaKey.slice(0, 4)),
+                              ),
+                          )
+                        : null,
                     mediaKeyTimestamp: msg.mediaKeyTimestamp,
                     encFilehash: msg.encFilehash,
                     filehash: msg.filehash,
@@ -591,34 +617,50 @@ class Message extends Base {
                         rmrReason: 1,
                     });
                 } catch (re) {
-                    resolveError = { message: String(re?.message || re), name: re?.name };
+                    resolveError = {
+                        message: String(re?.message || re),
+                        name: re?.name,
+                    };
                 }
 
                 // [L13] Snapshot AFTER resolve attempt
                 const cryptoAfter = {
                     directPath: msg.directPath,
-                    mediaKey: msg.mediaKey ? btoa(String.fromCharCode(...new Uint8Array(msg.mediaKey.slice(0, 4)))) : null,
+                    mediaKey: msg.mediaKey
+                        ? btoa(
+                              String.fromCharCode(
+                                  ...new Uint8Array(msg.mediaKey.slice(0, 4)),
+                              ),
+                          )
+                        : null,
                     encFilehash: msg.encFilehash,
                     filehash: msg.filehash,
                     mediaStage: msg.mediaData.mediaStage,
                     mediaStageTimestamp: msg.mediaData.mediaStageTimestamp,
                 };
                 const fieldsChanged = {
-                    directPath: cryptoBefore.directPath !== cryptoAfter.directPath,
+                    directPath:
+                        cryptoBefore.directPath !== cryptoAfter.directPath,
                     mediaKey: cryptoBefore.mediaKey !== cryptoAfter.mediaKey,
-                    encFilehash: cryptoBefore.encFilehash !== cryptoAfter.encFilehash,
+                    encFilehash:
+                        cryptoBefore.encFilehash !== cryptoAfter.encFilehash,
                     filehash: cryptoBefore.filehash !== cryptoAfter.filehash,
                 };
 
-                if (window.onDiagLog) window.onDiagLog('info', 'downloadMedia: resolve attempt', JSON.stringify({
-                    id: msgId,
-                    stageBefore: cryptoBefore.mediaStage,
-                    stageAfter: cryptoAfter.mediaStage,
-                    fieldsChanged,
-                    resolveError,
-                    cryptoBefore,
-                    cryptoAfter,
-                }));
+                if (window.onDiagLog)
+                    window.onDiagLog(
+                        'info',
+                        'downloadMedia: resolve attempt',
+                        JSON.stringify({
+                            id: msgId,
+                            stageBefore: cryptoBefore.mediaStage,
+                            stageAfter: cryptoAfter.mediaStage,
+                            fieldsChanged,
+                            resolveError,
+                            cryptoBefore,
+                            cryptoAfter,
+                        }),
+                    );
             }
 
             if (
@@ -626,13 +668,26 @@ class Message extends Base {
                 msg.mediaData.mediaStage === 'FETCHING'
             ) {
                 // [L12] Log silent undefined return (error/fetching)
-                if (window.onDiagLog) window.onDiagLog('warn', 'downloadMedia: error/fetching stage', JSON.stringify({
-                    id: msgId,
-                    mediaStage: msg.mediaData.mediaStage
-                }));
+                if (window.onDiagLog)
+                    window.onDiagLog(
+                        'warn',
+                        'downloadMedia: error/fetching stage',
+                        JSON.stringify({
+                            id: msgId,
+                            mediaStage: msg.mediaData.mediaStage,
+                        }),
+                    );
                 // media could not be downloaded
                 return undefined;
             }
+
+            const usingMessageSecret =
+                msg.mediaKey === '' &&
+                msg.messageSecret instanceof Uint8Array &&
+                msg.messageSecret.byteLength === 32;
+            const effectiveMediaKey = usingMessageSecret
+                ? btoa(String.fromCharCode(...msg.messageSecret))
+                : msg.mediaKey;
 
             try {
                 const mockQpl = {
@@ -662,27 +717,44 @@ class Message extends Base {
                     },
                 };
                 // [L13] Log the exact params going into downloadAndMaybeDecrypt
-                if (window.onDiagLog) window.onDiagLog('info', 'downloadMedia: attempting downloadAndMaybeDecrypt', JSON.stringify({
-                    id: msgId,
-                    directPath: msg.directPath,
-                    encFilehash: msg.encFilehash,
-                    filehash: msg.filehash,
-                    mediaKeyPrefix: msg.mediaKey ? btoa(String.fromCharCode(...new Uint8Array(msg.mediaKey.slice(0, 4)))) : null,
-                    mediaKeyTimestamp: msg.mediaKeyTimestamp,
-                    type: msg.type,
-                }));
+                if (window.onDiagLog)
+                    window.onDiagLog(
+                        'info',
+                        'downloadMedia: attempting downloadAndMaybeDecrypt',
+                        JSON.stringify({
+                            id: msgId,
+                            directPath: msg.directPath,
+                            encFilehash: msg.encFilehash,
+                            filehash: msg.filehash,
+                            mediaKeyPrefix: effectiveMediaKey
+                                ? effectiveMediaKey.substring(0, 8)
+                                : null,
+                            mediaKeyTimestamp: msg.mediaKeyTimestamp,
+                            type: msg.type,
+                            usingMessageSecret,
+                        }),
+                    );
                 const decryptedMedia = await window
                     .require('WAWebDownloadManager')
                     .downloadManager.downloadAndMaybeDecrypt({
                         directPath: msg.directPath,
                         encFilehash: msg.encFilehash,
                         filehash: msg.filehash,
-                        mediaKey: msg.mediaKey,
+                        mediaKey: effectiveMediaKey,
                         mediaKeyTimestamp: msg.mediaKeyTimestamp,
                         type: msg.type,
                         signal: new AbortController().signal,
                         downloadQpl: mockQpl,
                     });
+                if (usingMessageSecret && window.onDiagLog)
+                    window.onDiagLog(
+                        'info',
+                        'downloadMedia: mediakey-debug success',
+                        JSON.stringify({
+                            id: msgId,
+                            bytes: decryptedMedia?.byteLength,
+                        }),
+                    );
 
                 const data =
                     await window.WWebJS.arrayBufferToBase64Async(
@@ -703,17 +775,36 @@ class Message extends Base {
                     message: String(e?.message || e).substring(0, 500),
                     status: e?.status,
                     code: e?.code,
+                    usingMessageSecret,
+                    mediaKeyEmpty: msg.mediaKey === '',
+                    messageSecretType: typeof msg.messageSecret,
+                    messageSecretIsUint8Array:
+                        msg.messageSecret instanceof Uint8Array,
+                    messageSecretByteLen:
+                        msg.messageSecret instanceof Uint8Array
+                            ? msg.messageSecret.byteLength
+                            : 0,
                     props: {},
                 };
                 try {
                     for (const k of Object.keys(e || {})) {
                         if (!['message', 'stack', 'name'].includes(k)) {
-                            errorDetail.props[k] = typeof e[k] === 'object' ? JSON.stringify(e[k]).substring(0, 200) : String(e[k]);
+                            errorDetail.props[k] =
+                                typeof e[k] === 'object'
+                                    ? JSON.stringify(e[k]).substring(0, 200)
+                                    : String(e[k]);
                         }
                     }
-                } catch (_) { /* ignore */ }
+                } catch (_) {
+                    /* ignore */
+                }
 
-                if (window.onDiagLog) window.onDiagLog('error', 'downloadMedia: downloadAndMaybeDecrypt failed', JSON.stringify(errorDetail));
+                if (window.onDiagLog)
+                    window.onDiagLog(
+                        'error',
+                        'downloadMedia: downloadAndMaybeDecrypt failed',
+                        JSON.stringify(errorDetail),
+                    );
 
                 if (e.status && e.status === 404) {
                     return undefined;

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -639,7 +639,25 @@ class Message extends Base {
                     addAnnotations: function () {
                         return this;
                     },
+                    addAnnotation: function () {
+                        return this;
+                    },
                     addPoint: function () {
+                        return this;
+                    },
+                    start: function () {
+                        return this;
+                    },
+                    end: function () {
+                        return this;
+                    },
+                    cancel: function () {
+                        return this;
+                    },
+                    success: function () {
+                        return this;
+                    },
+                    fail: function () {
                         return this;
                     },
                 };

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -48,6 +48,16 @@ class Message extends Base {
          */
         this.hasMedia = Boolean(data.directPath);
 
+        // [L11] Log when image/video/document has no directPath (hasMedia=false)
+        if (!this.hasMedia && ['image', 'video', 'document', 'ptt', 'audio', 'sticker'].includes(data.type)) {
+            this.client?.emit?.('diag', 'warn', 'Media type without directPath', JSON.stringify({
+                id: data.id?._serialized || data.id?.id,
+                type: data.type,
+                hasDirectPath: !!data.directPath,
+                hasMediaKey: !!data.mediaKey
+            }));
+        }
+
         /**
          * Message content
          * @type {string}
@@ -526,6 +536,11 @@ class Message extends Base {
      */
     async downloadMedia() {
         if (!this.hasMedia) {
+            // [L12] Log when downloadMedia called but hasMedia=false
+            this.client?.emit?.('diag', 'warn', 'downloadMedia: hasMedia=false', JSON.stringify({
+                id: this.id?._serialized,
+                type: this.type
+            }));
             return undefined;
         }
 
@@ -544,20 +559,77 @@ class Message extends Base {
                 !msg.mediaData ||
                 msg.mediaData.mediaStage === 'REUPLOADING'
             ) {
+                // [L12] Log silent null return
+                if (window.onDiagLog) window.onDiagLog('warn', 'downloadMedia: returning null', JSON.stringify({
+                    id: msgId,
+                    hasMsg: !!msg,
+                    hasMediaData: !!msg?.mediaData,
+                    mediaStage: msg?.mediaData?.mediaStage
+                }));
                 return null;
             }
             if (msg.mediaData.mediaStage != 'RESOLVED') {
+                // [L13] Snapshot crypto fields BEFORE resolve attempt
+                const cryptoBefore = {
+                    directPath: msg.directPath,
+                    mediaKey: msg.mediaKey ? btoa(String.fromCharCode(...new Uint8Array(msg.mediaKey.slice(0, 4)))) : null,
+                    mediaKeyTimestamp: msg.mediaKeyTimestamp,
+                    encFilehash: msg.encFilehash,
+                    filehash: msg.filehash,
+                    mediaStage: msg.mediaData.mediaStage,
+                    mediaStageTimestamp: msg.mediaData.mediaStageTimestamp,
+                    isBackfill: !!(msg.__x_isBackfill || msg.isBackfill),
+                    protocolMessageType: msg.protocolMessageType,
+                    ephemeralDuration: msg.ephemeralDuration,
+                    messageSecret: !!msg.messageSecret,
+                };
                 // try to resolve media
-                await msg.downloadMedia({
-                    downloadEvenIfExpensive: true,
-                    rmrReason: 1,
-                });
+                let resolveError = null;
+                try {
+                    await msg.downloadMedia({
+                        downloadEvenIfExpensive: true,
+                        rmrReason: 1,
+                    });
+                } catch (re) {
+                    resolveError = { message: String(re?.message || re), name: re?.name };
+                }
+
+                // [L13] Snapshot AFTER resolve attempt
+                const cryptoAfter = {
+                    directPath: msg.directPath,
+                    mediaKey: msg.mediaKey ? btoa(String.fromCharCode(...new Uint8Array(msg.mediaKey.slice(0, 4)))) : null,
+                    encFilehash: msg.encFilehash,
+                    filehash: msg.filehash,
+                    mediaStage: msg.mediaData.mediaStage,
+                    mediaStageTimestamp: msg.mediaData.mediaStageTimestamp,
+                };
+                const fieldsChanged = {
+                    directPath: cryptoBefore.directPath !== cryptoAfter.directPath,
+                    mediaKey: cryptoBefore.mediaKey !== cryptoAfter.mediaKey,
+                    encFilehash: cryptoBefore.encFilehash !== cryptoAfter.encFilehash,
+                    filehash: cryptoBefore.filehash !== cryptoAfter.filehash,
+                };
+
+                if (window.onDiagLog) window.onDiagLog('info', 'downloadMedia: resolve attempt', JSON.stringify({
+                    id: msgId,
+                    stageBefore: cryptoBefore.mediaStage,
+                    stageAfter: cryptoAfter.mediaStage,
+                    fieldsChanged,
+                    resolveError,
+                    cryptoBefore,
+                    cryptoAfter,
+                }));
             }
 
             if (
                 msg.mediaData.mediaStage.includes('ERROR') ||
                 msg.mediaData.mediaStage === 'FETCHING'
             ) {
+                // [L12] Log silent undefined return (error/fetching)
+                if (window.onDiagLog) window.onDiagLog('warn', 'downloadMedia: error/fetching stage', JSON.stringify({
+                    id: msgId,
+                    mediaStage: msg.mediaData.mediaStage
+                }));
                 // media could not be downloaded
                 return undefined;
             }
@@ -571,6 +643,16 @@ class Message extends Base {
                         return this;
                     },
                 };
+                // [L13] Log the exact params going into downloadAndMaybeDecrypt
+                if (window.onDiagLog) window.onDiagLog('info', 'downloadMedia: attempting downloadAndMaybeDecrypt', JSON.stringify({
+                    id: msgId,
+                    directPath: msg.directPath,
+                    encFilehash: msg.encFilehash,
+                    filehash: msg.filehash,
+                    mediaKeyPrefix: msg.mediaKey ? btoa(String.fromCharCode(...new Uint8Array(msg.mediaKey.slice(0, 4)))) : null,
+                    mediaKeyTimestamp: msg.mediaKeyTimestamp,
+                    type: msg.type,
+                }));
                 const decryptedMedia = await window
                     .require('WAWebDownloadManager')
                     .downloadManager.downloadAndMaybeDecrypt({
@@ -596,7 +678,28 @@ class Message extends Base {
                     filesize: msg.size,
                 };
             } catch (e) {
-                if (e.status && e.status === 404) return undefined;
+                // [L13] Detailed error analysis for download failures
+                const errorDetail = {
+                    id: msgId,
+                    name: e?.name,
+                    message: String(e?.message || e).substring(0, 500),
+                    status: e?.status,
+                    code: e?.code,
+                    props: {},
+                };
+                try {
+                    for (const k of Object.keys(e || {})) {
+                        if (!['message', 'stack', 'name'].includes(k)) {
+                            errorDetail.props[k] = typeof e[k] === 'object' ? JSON.stringify(e[k]).substring(0, 200) : String(e[k]);
+                        }
+                    }
+                } catch (_) { /* ignore */ }
+
+                if (window.onDiagLog) window.onDiagLog('error', 'downloadMedia: downloadAndMaybeDecrypt failed', JSON.stringify(errorDetail));
+
+                if (e.status && e.status === 404) {
+                    return undefined;
+                }
                 throw e;
             }
         }, this.id._serialized);

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -51,6 +51,7 @@ exports.Events = {
     CHAT_ARCHIVED: 'chat_archived',
     MESSAGE_RECEIVED: 'message',
     MESSAGE_CIPHERTEXT: 'message_ciphertext',
+    MESSAGE_CIPHERTEXT_FAILED: 'message_ciphertext_failed',
     MESSAGE_CREATE: 'message_create',
     MESSAGE_REVOKED_EVERYONE: 'message_revoke_everyone',
     MESSAGE_REVOKED_ME: 'message_revoke_me',

--- a/src/util/Injected/DiagCommon.js
+++ b/src/util/Injected/DiagCommon.js
@@ -1,0 +1,99 @@
+'use strict';
+
+/**
+ * Diagnostic filter helpers.
+ *
+ * Browser: InjectDiagCommon is passed to page.evaluate() — the function body
+ *          must be self-contained (no outer-scope references).
+ * Node:    exports.shouldSkipMsg / shouldSkipReceipt / isStatusOrGroup are
+ *          plain requires for Client.js.
+ *
+ * To keep one source of truth the helpers are written as a string template
+ * that both paths evaluate.
+ */
+
+/* ---------- shared source (runs in both contexts) ---------- */
+
+const HELPERS_SOURCE = `
+function isStatusOrGroup(jid) {
+    if (!jid) return false;
+    var s = typeof jid === 'string' ? jid : (jid._serialized || jid.user || '');
+    return s.indexOf('@g.us') !== -1 || s.indexOf('status@broadcast') !== -1 || s.indexOf('@newsletter') !== -1;
+}
+
+function isThumbnailType(type) {
+    return typeof type === 'string' && type.indexOf('thumbnail-') === 0;
+}
+
+function wid(v) {
+    if (v == null) return null;
+    if (typeof v === 'string') return v;
+    return v._serialized || v.user || (v.$1 && (v.$1._serialized || v.$1.user)) || null;
+}
+
+function safeStr(v) {
+    if (v == null) return String(v);
+    if (typeof v !== 'object') return String(v);
+    try {
+        var s = JSON.stringify(v);
+        return s.length > 500 ? s.slice(0, 500) + '...' : s;
+    } catch (e) { return String(v); }
+}
+
+function shouldSkipMsg(msg) {
+    if (!msg) return false;
+    if (msg.fromMe || (msg.id && msg.id.fromMe)) return true;
+    if (msg.type === 'sticker') return true;
+    if (isThumbnailType(msg.type)) return true;
+    if (msg.isStatusV3) return true;
+    var from = msg.from ? (typeof msg.from === 'string' ? msg.from : (msg.from._serialized || '')) : '';
+    var to = msg.to ? (typeof msg.to === 'string' ? msg.to : (msg.to._serialized || '')) : '';
+    var idRemote = (msg.id && msg.id.remote) ? (typeof msg.id.remote === 'string' ? msg.id.remote : (msg.id.remote._serialized || '')) : '';
+    if (isStatusOrGroup(from) || isStatusOrGroup(to) || isStatusOrGroup(idRemote)) return true;
+    if (!msg.hasMedia && !msg.directPath && !msg.mediaKey) return true;
+    return false;
+}
+
+function shouldSkipReceipt(receipt) {
+    if (!receipt) return false;
+    if (receipt.fromMe) return true;
+    var from = String(receipt.from || '');
+    var to = String(receipt.to || '');
+    var chatId = String(receipt.chatId || '');
+    if (isStatusOrGroup(from) || isStatusOrGroup(to) || isStatusOrGroup(chatId)) return true;
+    if (receipt.type === 'status' || receipt.type === 'other_status') return true;
+    if (receipt.msgType === 'sticker') return true;
+    var nonMedia = ['text', 'e2e_notification', 'notification_template', 'chat', 'protocol', 'revoked', 'reaction', 'album', 'ptt', 'vcard', 'unknown'];
+    if (receipt.msgType && nonMedia.indexOf(receipt.msgType) !== -1) return true;
+    return false;
+}
+`;
+
+/* ---------- Node-side: eval once to get real functions ---------- */
+
+const _node = new Function(HELPERS_SOURCE + `
+return { isStatusOrGroup, isThumbnailType, wid, safeStr, shouldSkipMsg, shouldSkipReceipt };
+`)();
+
+/* ---------- Browser-side: self-contained function for page.evaluate ---------- */
+
+exports.InjectDiagCommon = new Function(`
+${HELPERS_SOURCE}
+window.__diag = {
+    safeDiagLog: function(level, tag, data) {
+        try { window.onDiagLog(level, tag, typeof data === 'string' ? data : JSON.stringify(data)); } catch(e) {}
+    },
+    safeStr: safeStr,
+    wid: wid,
+    isStatusOrGroup: isStatusOrGroup,
+    isThumbnailType: isThumbnailType,
+    shouldSkipMsg: shouldSkipMsg,
+    shouldSkipReceipt: shouldSkipReceipt
+};
+`);
+
+/* ---------- Node exports ---------- */
+
+exports.shouldSkipMsg = _node.shouldSkipMsg;
+exports.shouldSkipReceipt = _node.shouldSkipReceipt;
+exports.isStatusOrGroup = _node.isStatusOrGroup;

--- a/src/util/Injected/DiagHooks.js
+++ b/src/util/Injected/DiagHooks.js
@@ -1,0 +1,887 @@
+'use strict';
+
+/**
+ * Diagnostic hooks for monitoring WhatsApp Web internals.
+ *
+ * This file is meant to be injected via page.evaluate() AFTER both
+ * DiagCommon (window.__diag) and Utils (window.WWebJS) have been loaded.
+ *
+ * It hooks into WAWeb modules to log encryption, decryption, media download,
+ * signal session, receipt, identity change, and message pipeline events.
+ *
+ * All window.Store references from the original fork have been replaced
+ * with direct window.require('WAWebXxx') calls matching the new upstream
+ * structure.
+ */
+exports.InjectDiagHooks = () => {
+    // Use shared helpers from DiagCommon (injected before this file)
+    var safeDiagLog = window.__diag.safeDiagLog;
+    var safeStr = window.__diag.safeStr;
+    var wid = window.__diag.wid;
+    var _isStatusOrGroup = window.__diag.isStatusOrGroup;
+    var _isThumbnailType = window.__diag.isThumbnailType;
+    var _shouldSkipDiag = window.__diag.shouldSkipMsg;
+    var _shouldSkipReceipt = window.__diag.shouldSkipReceipt;
+
+    /**
+     * Hook a function inside a WAWeb module.
+     * Signature: callback(originalFunction, ...args)
+     */
+    window.injectToFunction = (target, callback) => {
+        var hookId = target.module + '.' + target.function;
+        try {
+            let module = window.require(target.module);
+            if (!module) {
+                safeDiagLog('warn', 'HOOK_FAIL', { hook: hookId, reason: 'module not found' });
+                return;
+            }
+
+            const path = target.function.split('.');
+            const funcName = path.pop();
+
+            for (const key of path) {
+                if (!module[key]) {
+                    safeDiagLog('warn', 'HOOK_FAIL', { hook: hookId, reason: 'path not found: ' + key });
+                    return;
+                }
+                module = module[key];
+            }
+
+            const originalFunction = module[funcName];
+            if (typeof originalFunction !== 'function') {
+                safeDiagLog('warn', 'HOOK_FAIL', { hook: hookId, reason: 'not a function' });
+                return;
+            }
+
+            module[funcName] = function(...args) {
+                try {
+                    return callback(originalFunction.bind(this), ...args);
+                } catch {
+                    return originalFunction.apply(this, args);
+                }
+            };
+
+            safeDiagLog('debug', 'HOOK_OK', hookId);
+        } catch(e) {
+            safeDiagLog('warn', 'HOOK_FAIL', { hook: hookId, reason: e ? (e.message || String(e)) : 'unknown' });
+            return;
+        }
+    };
+
+    // --- Retry receipt monitoring ---
+    window.injectToFunction({ module: 'WAWebSendRetryReceiptJob', function: 'sendRetryReceipt' }, function(func, ...args) {
+        var params = args[0] || {};
+        if (_isStatusOrGroup(params.to)) return func.apply(this, args);
+        safeDiagLog('debug', 'RETRY_RECEIPT_SENT', {
+            externalId: params.externalId,
+            to: wid(params.to),
+            retryCount: params.retryCount,
+            retryReason: params.retryReason,
+            isPeer: params.isPeer,
+        });
+        return func.apply(this, args);
+    });
+
+    // --- Decrypt receipt decision logging ---
+    window.injectToFunction({ module: 'WAWebHandleMsgSendReceipt', function: 'sendReceipt' }, function(func, ...args) {
+        var receipt = args[0] || {};
+        var msgInfo = args[1];
+        var decryptResult = args[2];
+        var from = wid(receipt.senderPn) || wid(receipt.participant) || wid(receipt.senderLid) || wid(receipt.peerRecipientPn) || wid(receipt.peerRecipientLid) || wid(receipt.from);
+        var isFromMe = !!(msgInfo && msgInfo.id && msgInfo.id.fromMe);
+        // Unified receipt filter (groups, status, newsletters, stickers, non-media, fromMe)
+        if (_shouldSkipReceipt({ from: from, to: wid(receipt.to), chatId: wid(receipt.chatId), type: receipt.type, msgType: msgInfo ? msgInfo.type : null, fromMe: isFromMe })) {
+            return func.apply(this, args);
+        }
+        var participant = wid(receipt.participant);
+        var resultStr = safeStr(decryptResult);
+        var logData = {
+            msgId: receipt.externalId,
+            from: from,
+            fromMe: isFromMe,
+            participant: participant !== from ? participant : null,
+            type: receipt.type,
+            pushname: receipt.pushname,
+            msgType: msgInfo ? msgInfo.type : null,
+            result: resultStr,
+        };
+        if (resultStr && resultStr.indexOf('BACKFILL') !== -1) {
+            logData.receiptKeys = Object.keys(receipt).sort().join(',');
+            logData.receiptRaw = safeStr(receipt);
+            logData.msgInfoRaw = safeStr(msgInfo);
+            logData.decryptResultRaw = safeStr(decryptResult);
+        }
+        safeDiagLog('debug', 'DECRYPT_RECEIPT_DECISION', logData);
+        return func.apply(this, args);
+    });
+
+    // --- E2E identity change monitoring ---
+    window.injectToFunction({ module: 'WAWebHandleIdentityChange', function: 'handleE2eIdentityChange' }, function(func, ...args) {
+        var node = args[0] || {};
+        var from = wid(node.senderPn) || wid(node.participant) || wid(node.from);
+        var participant = null;
+        var arg0Keys = [];
+        try {
+            arg0Keys = Object.keys(node).sort();
+            if (!from && node.attrs) {
+                from = wid(node.attrs.from) || wid(node.attrs.participant) || wid(node.attrs.sender_pn);
+                participant = wid(node.attrs.participant) || wid(node.attrs.participant_lid);
+            }
+            if (!from && node.content && Array.isArray(node.content)) {
+                for (var i = 0; i < node.content.length; i++) {
+                    var child = node.content[i];
+                    if (child && child.attrs) {
+                        from = from || wid(child.attrs.from) || wid(child.attrs.jid);
+                    }
+                }
+            }
+            if (!from && args[1]) {
+                from = wid(args[1].from) || wid(args[1].jid) || wid(args[1]);
+            }
+            if (!participant) {
+                participant = wid(node.participantLid) || wid(node.participant);
+            }
+        } catch(e) {}
+        // Filter group and status identity changes - not relevant for 1:1 diagnostics
+        if (!_isStatusOrGroup(from)) {
+            safeDiagLog('debug', 'IDENTITY_CHANGE', {
+                from: from,
+                participant: participant !== from ? participant : null,
+                argCount: args.length,
+                arg0Keys: arg0Keys.join(','),
+                arg0Raw: safeStr(node),
+            });
+        }
+        return func.apply(this, args);
+    });
+
+    // --- Encrypted message handling ---
+    window.injectToFunction({ module: 'WAWebHandleEncMsg', function: 'handleEncMsg' }, function(func, ...args) {
+        var stanza = args[0];
+        var traceId = '';
+        var encType = '';
+        var senderJid = '';
+        try {
+            if (stanza && stanza.attrs) {
+                traceId = stanza.attrs.id || '';
+                senderJid = stanza.attrs.participant || stanza.attrs.from || '';
+            }
+            if (stanza && Array.isArray(stanza.content)) {
+                for (var i = 0; i < stanza.content.length; i++) {
+                    var child = stanza.content[i];
+                    if (child && child.tag === 'enc') {
+                        encType = child.attrs ? child.attrs.type || '' : '';
+                        break;
+                    }
+                }
+            }
+        } catch(e) {}
+        var skipDiag = _isStatusOrGroup(senderJid) || _isStatusOrGroup(stanza && stanza.attrs && stanza.attrs.from);
+        var startTime = Date.now();
+        var result = func.apply(this, args);
+        if (result && typeof result.then === 'function') {
+            return result.then(function(res) {
+                if (!skipDiag) {
+                    var resultInfo = {
+                        traceId: traceId,
+                        sender: senderJid,
+                        encType: encType,
+                        elapsed: Date.now() - startTime,
+                    };
+                    try {
+                        if (res !== undefined && res !== null) {
+                            resultInfo.resultType = typeof res;
+                            if (typeof res === 'object') {
+                                resultInfo.resultKeys = Object.keys(res).slice(0, 15).join(',');
+                                if (res.type) resultInfo.msgType = res.type;
+                                if (res.id) resultInfo.msgId = typeof res.id === 'object' ? res.id._serialized || res.id.id : String(res.id);
+                                if (res.body !== undefined) resultInfo.hasBody = !!res.body;
+                                if (res.isNewMsg !== undefined) resultInfo.isNewMsg = res.isNewMsg;
+                            }
+                        }
+                    } catch(e2) {}
+                    safeDiagLog('debug', 'ENC_MSG_RESULT', resultInfo);
+                }
+                return res;
+            }).catch(function(err) {
+                if (!skipDiag) {
+                    safeDiagLog('warn', 'ENC_MSG_FAIL', {
+                        traceId: traceId,
+                        sender: senderJid,
+                        encType: encType,
+                        elapsed: Date.now() - startTime,
+                        error: err ? (err.message || String(err)) : 'unknown',
+                        errorName: err ? err.name : null,
+                    });
+                }
+                throw err;
+            });
+        }
+        return result;
+    });
+
+    // --- Peer message handling (PDO, history sync) ---
+    window.injectToFunction({ module: 'WAWebHandlePeerMsg', function: 'handlePeerMsg' }, function(func, ...args) {
+        var peerMsg = args[0];
+        var msgType = 'unknown';
+        var details = {};
+        try {
+            if (peerMsg) {
+                if (peerMsg.peerDataOperationRequestMessage) {
+                    msgType = 'PDO_REQUEST';
+                    var req = peerMsg.peerDataOperationRequestMessage;
+                    details.requestType = req.peerDataOperationRequestType;
+                    if (req.placeholderMessageResendRequest && req.placeholderMessageResendRequest.length > 0) {
+                        details.resendMsgIds = req.placeholderMessageResendRequest.map(function(r) {
+                            return r.messageKey ? r.messageKey.id : null;
+                        });
+                    }
+                }
+                if (peerMsg.peerDataOperationRequestResponseMessage) {
+                    msgType = 'PDO_RESPONSE';
+                    var resp = peerMsg.peerDataOperationRequestResponseMessage;
+                    details.requestType = resp.peerDataOperationRequestType;
+                    details.resultCount = resp.peerDataOperationResult ? resp.peerDataOperationResult.length : 0;
+                    if (resp.peerDataOperationResult) {
+                        details.results = resp.peerDataOperationResult.map(function(r) {
+                            return {
+                                hasPlaceholder: !!r.placeholderMessageResendResponse,
+                                hasMedia: !!r.mediaUploadResult,
+                            };
+                        });
+                    }
+                }
+                if (peerMsg.historySyncNotification) {
+                    msgType = 'HISTORY_SYNC';
+                    details.syncType = peerMsg.historySyncNotification.syncType;
+                    details.progress = peerMsg.historySyncNotification.progress;
+                }
+            }
+        } catch(e) { details.parseError = String(e); }
+        // Peer messages are self-to-self protocol messages (PDO, history sync) - skip to reduce noise (fromMe equivalent)
+        // Only log errors for debugging protocol failures
+        var result = func.apply(this, args);
+        if (result && typeof result.then === 'function') {
+            return result.catch(function(err) {
+                safeDiagLog('debug', 'PEER_MSG_ERROR', {
+                    msgType: msgType,
+                    error: err ? (err.message || String(err)) : 'unknown',
+                });
+                throw err;
+            });
+        }
+        return result;
+    });
+
+    // --- PDO request sending ---
+    try {
+        window.injectToFunction({ module: 'WAWebSendNonMessageDataRequest', function: 'sendPeerDataOperationRequest' }, function(func, ...args) {
+            var requestType = args[0];
+            safeDiagLog('debug', 'PDO_REQUEST_SENT', {
+                requestType: requestType,
+                params: safeStr(args[1]),
+            });
+            var result = func.apply(this, args);
+            if (result && typeof result.then === 'function') {
+                return result.then(function(res) {
+                    safeDiagLog('debug', 'PDO_REQUEST_ACK', { requestType: requestType });
+                    return res;
+                }).catch(function(err) {
+                    safeDiagLog('warn', 'PDO_REQUEST_FAIL', {
+                        requestType: requestType,
+                        error: err ? (err.message || String(err)) : 'unknown',
+                    });
+                    throw err;
+                });
+            }
+            return result;
+        });
+    } catch(e) {}
+
+    // --- Signal crypto hooks (decrypt/encrypt) ---
+    // NOTE: Signal crypto hooks only have raw crypto args - cannot filter by message type/sender
+    var signalFns = ['Cipher.decryptSignalProto', 'Cipher.decryptGroupSignalProto', 'Cipher.encryptSignalProto'];
+    for (var si = 0; si < signalFns.length; si++) {
+        try {
+            (function(fnName) {
+                window.injectToFunction({ module: 'WAWebSignal', function: fnName }, function(func, ...args) {
+                    var result;
+                    try { result = func.apply(this, args); } catch(err) {
+                        safeDiagLog('warn', 'SIGNAL_DECRYPT_ERROR', {
+                            op: fnName, error: err ? (err.message || String(err)) : 'unknown',
+                        });
+                        throw err;
+                    }
+                    if (result && typeof result.then === 'function') {
+                        return result.catch(function(err) {
+                            safeDiagLog('warn', 'SIGNAL_DECRYPT_ERROR', {
+                                op: fnName, error: err ? (err.message || String(err)) : 'unknown',
+                            });
+                            throw err;
+                        });
+                    }
+                    return result;
+                });
+            })(signalFns[si]);
+        } catch(e) {}
+    }
+
+    // --- E2E session management ---
+    var sessionFns = ['ensureE2ESessions'];
+    for (var ei = 0; ei < sessionFns.length; ei++) {
+        try {
+            (function(fnName) {
+                window.injectToFunction({ module: 'WAWebManageE2ESessionsJob', function: fnName }, function(func, ...args) {
+                    var jid = '';
+                    try {
+                        if (typeof args[0] === 'string') jid = args[0];
+                        else if (args[0] && args[0]._serialized) jid = args[0]._serialized;
+                        else if (args[0] && args[0].jid) jid = args[0].jid;
+                    } catch(e) {}
+                    if (!_isStatusOrGroup(jid)) {
+                        safeDiagLog('debug', 'E2E_SESSION_OP', { op: fnName, jid: jid });
+                    }
+                    var result = func.apply(this, args);
+                    if (result && typeof result.then === 'function') {
+                        return result.catch(function(err) {
+                            if (!_isStatusOrGroup(jid)) {
+                                safeDiagLog('debug', 'E2E_SESSION_ERROR', {
+                                    op: fnName, jid: jid, error: err ? (err.message || String(err)) : 'unknown',
+                                });
+                            }
+                            throw err;
+                        });
+                    }
+                    return result;
+                });
+            })(sessionFns[ei]);
+        } catch(e) {}
+    }
+
+    // --- Signal session lifecycle (create/delete) for debugging session corruption ---
+    var signalSessionFns = ['createSignalSession', 'deleteRemoteSession', 'deleteRemoteInfo'];
+    for (var ssi = 0; ssi < signalSessionFns.length; ssi++) {
+        try {
+            (function(fnName) {
+                window.injectToFunction({ module: 'WAWebSignal', function: 'Session.' + fnName }, function(func, ...args) {
+                    var jid = '';
+                    try {
+                        if (typeof args[0] === 'string') jid = args[0];
+                        else if (args[0] && args[0]._serialized) jid = args[0]._serialized;
+                        else if (args[0] && args[0].user) jid = args[0].user;
+                    } catch(e) {}
+                    if (!_isStatusOrGroup(jid)) {
+                        safeDiagLog('debug', 'SIGNAL_SESSION_OP', { op: fnName, jid: wid(args[0]) || jid });
+                    }
+                    var result = func.apply(this, args);
+                    if (result && typeof result.then === 'function') {
+                        return result.catch(function(err) {
+                            if (!_isStatusOrGroup(jid)) {
+                                safeDiagLog('debug', 'SIGNAL_SESSION_ERROR', {
+                                    op: fnName, jid: wid(args[0]) || jid, error: err ? (err.message || String(err)) : 'unknown',
+                                });
+                            }
+                            throw err;
+                        });
+                    }
+                    return result;
+                });
+            })(signalSessionFns[ssi]);
+        } catch(e) {}
+    }
+
+    // --- Sender key message handling ---
+    try {
+        window.injectToFunction({ module: 'WAWebSenderKeyMsgHandler', function: 'handleSenderKeyMsg' }, function(func, ...args) {
+            var stanza = args[0];
+            var traceId = stanza && stanza.attrs ? stanza.attrs.id : '';
+            var sender = stanza && stanza.attrs ? (stanza.attrs.participant || stanza.attrs.from || '') : '';
+            // Sender keys are used exclusively for group encryption - filter group senders
+            var fromJid = stanza && stanza.attrs ? (stanza.attrs.from || '') : '';
+            var result = func.apply(this, args);
+            if (result && typeof result.then === 'function') {
+                return result.catch(function(err) {
+                    if (!_isStatusOrGroup(fromJid)) {
+                        safeDiagLog('warn', 'SENDER_KEY_FAIL', {
+                            traceId: traceId, sender: sender,
+                            error: err ? (err.message || String(err)) : 'unknown',
+                        });
+                    }
+                    throw err;
+                });
+            }
+            return result;
+        });
+    } catch(e) {}
+
+    // --- Media download monitoring (downloadMediaBlob) ---
+    // NOTE: Cannot filter by message type - only has download URL/directPath, no message context
+    try {
+        window.injectToFunction({ module: 'WAWebMediaDownloadUtils', function: 'downloadMediaBlob' }, function(func, ...args) {
+            var startTime = Date.now();
+            var url = '';
+            try { url = typeof args[0] === 'string' ? args[0].slice(0, 100) : (args[0] && args[0].directPath ? args[0].directPath.slice(0, 100) : ''); } catch(e) {}
+            var result = func.apply(this, args);
+            if (result && typeof result.then === 'function') {
+                return result.then(function(res) {
+                    safeDiagLog('debug', 'MEDIA_DOWNLOAD_OK', {
+                        elapsed: Date.now() - startTime,
+                        url: url,
+                        size: res ? (res.byteLength || res.size || res.length || 0) : 0,
+                    });
+                    return res;
+                }).catch(function(err) {
+                    safeDiagLog('debug', 'MEDIA_DOWNLOAD_FAIL', {
+                        elapsed: Date.now() - startTime,
+                        url: url,
+                        error: err ? (err.message || String(err)) : 'unknown',
+                    });
+                    throw err;
+                });
+            }
+            return result;
+        });
+    } catch(e) {}
+
+    // --- Media download monitoring (downloadMedia) ---
+    try {
+        window.injectToFunction({ module: 'WAWebMediaDownloadUtils', function: 'downloadMedia' }, function(func, ...args) {
+            var startTime = Date.now();
+            var directPath = '';
+            try { directPath = (args[0] && args[0].directPath) ? args[0].directPath.slice(0, 100) : ''; } catch(e) {}
+            var result = func.apply(this, args);
+            if (result && typeof result.then === 'function') {
+                return result.then(function(res) {
+                    safeDiagLog('debug', 'MEDIA_DOWNLOAD2_OK', {
+                        elapsed: Date.now() - startTime, directPath: directPath,
+                    });
+                    return res;
+                }).catch(function(err) {
+                    safeDiagLog('debug', 'MEDIA_DOWNLOAD2_FAIL', {
+                        elapsed: Date.now() - startTime, directPath: directPath,
+                        error: err ? (err.message || String(err)) : 'unknown',
+                    });
+                    throw err;
+                });
+            }
+            return result;
+        });
+    } catch(e) {}
+
+    // --- PreKey get/upload ---
+    try {
+        window.injectToFunction({ module: 'WAWebPreKeyUtils', function: 'getOrGenPreKeys' }, function(func, ...args) {
+            var result = func.apply(this, args);
+            if (result && typeof result.then === 'function') {
+                return result.then(function(res) {
+                    var count = Array.isArray(res) ? res.length : (res ? 1 : 0);
+                    safeDiagLog('debug', 'PREKEY_GET', { count: count });
+                    return res;
+                }).catch(function(err) {
+                    safeDiagLog('warn', 'PREKEY_GET_FAIL', {
+                        error: err ? (err.message || String(err)) : 'unknown',
+                    });
+                    throw err;
+                });
+            }
+            return result;
+        });
+    } catch(e) {}
+
+    try {
+        window.injectToFunction({ module: 'WAWebPreKeyUtils', function: 'uploadPreKeys' }, function(func, ...args) {
+            safeDiagLog('debug', 'PREKEY_UPLOAD', { count: Array.isArray(args[0]) ? args[0].length : 0 });
+            var result = func.apply(this, args);
+            if (result && typeof result.then === 'function') {
+                return result.catch(function(err) {
+                    safeDiagLog('warn', 'PREKEY_UPLOAD_FAIL', {
+                        error: err ? (err.message || String(err)) : 'unknown',
+                    });
+                    throw err;
+                });
+            }
+            return result;
+        });
+    } catch(e) {}
+
+    // --- Session deletion ---
+    try {
+        window.injectToFunction({ module: 'WAWebDeleteSessionJob', function: 'deleteRemoteSession' }, function(func, ...args) {
+            var jid = '';
+            try { jid = wid(args[0]) || safeStr(args[0]); } catch(e) {}
+            if (!_isStatusOrGroup(jid)) {
+                safeDiagLog('warn', 'SESSION_DELETE', { jid: jid });
+            }
+            return func.apply(this, args);
+        });
+    } catch(e) {}
+
+    // --- Socket close monitoring ---
+    try {
+        var connMods = ['WAWebSocketConnectModel', 'WAWebSocketModel'];
+        for (var ci = 0; ci < connMods.length; ci++) {
+            try {
+                window.injectToFunction({ module: connMods[ci], function: 'onSocketClose' }, function(func, ...args) {
+                    var code = args[0];
+                    var reason = args[1];
+                    safeDiagLog('warn', 'SOCKET_CLOSE', {
+                        code: code, reason: typeof reason === 'string' ? reason.slice(0, 200) : String(reason),
+                    });
+                    return func.apply(this, args);
+                });
+            } catch(e) {}
+        }
+    } catch(e) {}
+
+    // --- History sync processing ---
+    try {
+        window.injectToFunction({ module: 'WAWebHistorySyncJobUtils', function: 'processHistorySyncData' }, function(func, ...args) {
+            var data = args[0];
+            var msgCount = 0;
+            try {
+                if (data && data.conversations) {
+                    for (var hi = 0; hi < data.conversations.length; hi++) {
+                        msgCount += (data.conversations[hi].messages || []).length;
+                    }
+                }
+            } catch(e) {}
+            safeDiagLog('debug', 'HISTORY_SYNC_PROCESS', {
+                conversationCount: data && data.conversations ? data.conversations.length : 0,
+                msgCount: msgCount,
+                syncType: data ? data.syncType : null,
+                progress: data ? data.progress : null,
+            });
+            return func.apply(this, args);
+        });
+    } catch(e) {}
+
+    // --- [L13] downloadAndMaybeDecrypt hook for filehash mismatch root cause ---
+    // NOTE: Limited filtering - only opts.type available (no from/fromMe). Can filter stickers.
+    try {
+        window.injectToFunction({ module: 'WAWebDownloadManager', function: 'downloadManager.downloadAndMaybeDecrypt' }, function(func, ...args) {
+            var opts = args[0] || {};
+            // Skip sticker and thumbnail downloads from diagnostics
+            if (opts.type === 'sticker' || _isThumbnailType(opts.type)) return func.apply(this, args);
+            var startTime = Date.now();
+            var inputLog = {
+                directPath: opts.directPath ? opts.directPath.slice(0, 80) : null,
+                encFilehash: opts.encFilehash || null,
+                filehash: opts.filehash || null,
+                mediaKeyPrefix: null,
+                mediaKeyTimestamp: opts.mediaKeyTimestamp,
+                type: opts.type,
+                hasSignal: !!opts.signal,
+            };
+            try {
+                if (opts.mediaKey) {
+                    var keyBytes = new Uint8Array(opts.mediaKey.slice(0, 8));
+                    inputLog.mediaKeyPrefix = btoa(String.fromCharCode.apply(null, keyBytes));
+                    inputLog.mediaKeyLength = opts.mediaKey.byteLength || opts.mediaKey.length;
+                }
+            } catch(e) {}
+
+            safeDiagLog('debug', 'DL_DECRYPT_START', inputLog);
+
+            var result = func.apply(this, args);
+            if (result && typeof result.then === 'function') {
+                return result.then(function(decrypted) {
+                    safeDiagLog('debug', 'DL_DECRYPT_OK', {
+                        elapsed: Date.now() - startTime,
+                        byteLength: decrypted ? (decrypted.byteLength || 0) : 0,
+                        type: opts.type,
+                    });
+                    return decrypted;
+                }).catch(function(err) {
+                    var errorInfo = {
+                        elapsed: Date.now() - startTime,
+                        type: opts.type,
+                        errorName: err ? err.name : null,
+                        errorMessage: err ? (typeof err.message === 'object' ? JSON.stringify(err.message) : String(err.message || err)).substring(0, 500) : null,
+                        errorStatus: err ? err.status : null,
+                        errorCode: err ? err.code : null,
+                        expectedEncFilehash: opts.encFilehash,
+                        expectedFilehash: opts.filehash,
+                        directPath: opts.directPath ? opts.directPath.slice(0, 80) : null,
+                        mediaKeyTimestamp: opts.mediaKeyTimestamp,
+                    };
+                    try {
+                        var allProps = {};
+                        for (var k in err) {
+                            if (err.hasOwnProperty(k) && !['message', 'stack', 'name'].includes(k)) {
+                                var v = err[k];
+                                allProps[k] = (typeof v === 'object' && v !== null)
+                                    ? JSON.stringify(v).substring(0, 300)
+                                    : String(v);
+                            }
+                        }
+                        errorInfo.errorProps = allProps;
+                        var proto = Object.getPrototypeOf(err);
+                        if (proto && proto !== Error.prototype) {
+                            var descriptors = Object.getOwnPropertyNames(proto);
+                            var protoProps = {};
+                            for (var pi = 0; pi < descriptors.length; pi++) {
+                                var pn = descriptors[pi];
+                                if (!['constructor', 'message', 'stack', 'name', 'toString'].includes(pn)) {
+                                    try { protoProps[pn] = String(err[pn]).substring(0, 200); } catch(e2) {}
+                                }
+                            }
+                            if (Object.keys(protoProps).length > 0) errorInfo.errorProtoProps = protoProps;
+                        }
+                    } catch(e2) {}
+                    safeDiagLog('warn', 'DL_DECRYPT_FAIL', errorInfo);
+                    throw err;
+                });
+            }
+            return result;
+        });
+    } catch(e) {
+        safeDiagLog('warn', 'HOOK_FAIL_MANUAL', { hook: 'downloadAndMaybeDecrypt', error: String(e) });
+    }
+
+    // --- [L13] WAWebMmsClient.download hook - wraps ciphertextValidator to capture actual vs expected hash ---
+    // NOTE: Limited filtering - only opts.type available. Can filter stickers.
+    try {
+        window.injectToFunction({ module: 'WAWebMmsClient', function: 'download' }, function(func, ...args) {
+            var opts = args[0] || {};
+            // Skip sticker and thumbnail downloads from diagnostics
+            if (opts.type === 'sticker' || _isThumbnailType(opts.type)) return func.apply(this, args);
+            var originalValidator = opts.ciphertextValidator;
+            var expectedHash = opts.filehash || opts.encFilehash; // download() receives encFilehash as 'filehash' param
+
+            if (originalValidator) {
+                args[0] = Object.assign({}, opts, { ciphertextValidator: function(downloadedBytes) {
+                    // Compute hash once and compare - avoids double SHA-256 computation
+                    var size = downloadedBytes ? (downloadedBytes.byteLength || 0) : 0;
+                    return window.require('WAMediaCalculateFilehash').calculateFilehash(downloadedBytes).then(function(computedHash) {
+                        var isValid = computedHash === expectedHash;
+                        if (!isValid) {
+                            safeDiagLog('error', 'ENC_HASH_MISMATCH_DETAIL', {
+                                computedEncHash: computedHash,
+                                expectedEncHash: expectedHash,
+                                downloadedSize: size,
+                                directPath: opts.directPath ? opts.directPath.slice(0, 80) : null,
+                                debugString: opts.debugString || null,
+                            });
+                        }
+                        return isValid;
+                    }).catch(function(e) {
+                        safeDiagLog('debug', 'ENC_HASH_CALC_ERROR', {
+                            error: String(e),
+                            downloadedSize: size,
+                        });
+                        return originalValidator(downloadedBytes);
+                    });
+                } });
+                opts = args[0];
+            }
+
+            safeDiagLog('debug', 'MMS_DOWNLOAD_START', {
+                directPath: opts.directPath ? opts.directPath.slice(0, 80) : null,
+                expectedHash: expectedHash,
+                hasValidator: !!originalValidator,
+                type: opts.type,
+                mode: opts.mode,
+                staticUrl: opts.staticUrl ? 'present' : null,
+            });
+
+            var result = func.apply(this, args);
+            if (result && typeof result.then === 'function') {
+                return result.then(function(data) {
+                    safeDiagLog('debug', 'MMS_DOWNLOAD_OK', {
+                        directPath: opts.directPath ? opts.directPath.slice(0, 80) : null,
+                        size: data ? (data.byteLength || 0) : 0,
+                    });
+                    return data;
+                }).catch(function(err) {
+                    safeDiagLog('warn', 'MMS_DOWNLOAD_FAIL', {
+                        directPath: opts.directPath ? opts.directPath.slice(0, 80) : null,
+                        errorName: err ? err.name : null,
+                        errorMessage: err ? (typeof err.message === 'object' ? JSON.stringify(err.message) : String(err.message || err)).substring(0, 300) : null,
+                    });
+                    throw err;
+                });
+            }
+            return result;
+        });
+    } catch(e) {
+        safeDiagLog('warn', 'HOOK_FAIL_MANUAL', { hook: 'WAWebMmsClient.download', error: String(e) });
+    }
+
+    // --- [L13] WAWebCryptoDecryptMedia hook - capture decryption details ---
+    // NOTE: Cannot filter by message type here - only has crypto params, no message context
+    try {
+        window.injectToFunction({ module: 'WAWebCryptoDecryptMedia', function: 'default' }, function(func, ...args) {
+            var opts = args[0] || {};
+            var startTime = Date.now();
+            safeDiagLog('debug', 'DECRYPT_MEDIA_START', {
+                expectedPlaintextHash: opts.expectedPlaintextHash || null,
+                ciphertextSize: opts.ciphertextHmac ? (opts.ciphertextHmac.byteLength || 0) : 0,
+                hasMediaKeys: !!opts.mediaKeys,
+                debugString: opts.debugString || null,
+            });
+
+            var result = func.apply(this, args);
+            if (result && typeof result.then === 'function') {
+                return result.then(function(plaintext) {
+                    safeDiagLog('debug', 'DECRYPT_MEDIA_OK', {
+                        elapsed: Date.now() - startTime,
+                        plaintextSize: plaintext ? (plaintext.byteLength || 0) : 0,
+                    });
+                    return plaintext;
+                }).catch(function(err) {
+                    safeDiagLog('warn', 'DECRYPT_MEDIA_FAIL', {
+                        elapsed: Date.now() - startTime,
+                        errorName: err ? err.name : null,
+                        errorMessage: err ? (typeof err.message === 'object' ? JSON.stringify(err.message) : String(err.message || err)).substring(0, 500) : null,
+                        expectedPlaintextHash: opts.expectedPlaintextHash,
+                        ciphertextSize: opts.ciphertextHmac ? (opts.ciphertextHmac.byteLength || 0) : 0,
+                    });
+                    throw err;
+                });
+            }
+            return result;
+        });
+    } catch(e) {
+        safeDiagLog('warn', 'HOOK_FAIL_MANUAL', { hook: 'WAWebCryptoDecryptMedia', error: String(e) });
+    }
+
+    // --- [L13] WAWebValidateMediaFilehash hook - capture unencrypted media hash validation ---
+    try {
+        window.injectToFunction({ module: 'WAWebValidateMediaFilehash', function: 'validateFileash' }, function(func, ...args) {
+            var data = args[0];
+            var expectedHash = args[1];
+            var result = func.apply(this, args);
+            if (result && typeof result.then === 'function') {
+                return result.then(function(isValid) {
+                    if (!isValid) {
+                        // Hash mismatch on unencrypted media - compute actual hash
+                        return window.require('WAMediaCalculateFilehash').calculateFilehash(data).then(function(actual) {
+                            safeDiagLog('error', 'PLAINTEXT_HASH_MISMATCH_DETAIL', {
+                                computedHash: actual,
+                                expectedHash: expectedHash,
+                                dataSize: data ? (data.byteLength || 0) : 0,
+                            });
+                            return isValid;
+                        }).catch(function() { return isValid; });
+                    }
+                    return isValid;
+                });
+            }
+            return result;
+        });
+    } catch(e) {}
+
+    // --- [L13] Detect BACKFILL/placeholder messages ---
+    try {
+        window.injectToFunction({ module: 'WAWebMsgModel', function: 'default.prototype.isPlaceholder' }, function(func, ...args) {
+            var result = func.apply(this, args);
+            if (result && !_shouldSkipDiag(this)) {
+                safeDiagLog('debug', 'MSG_IS_PLACEHOLDER', {
+                    id: this.id ? this.id._serialized : null,
+                    type: this.type,
+                    hasMedia: this.hasMedia,
+                });
+            }
+            return result;
+        });
+    } catch(e) {}
+
+    // --- [SILENT_LOSS] Wrap Msg.add to trace ALL add attempts ---
+    // window.Store.Msg -> window.require('WAWebCollections').Msg
+    try {
+        var MsgCollection = window.require('WAWebCollections').Msg;
+        const origMsgAdd = MsgCollection.add.bind(MsgCollection);
+        MsgCollection.add = function(...args) {
+            try {
+                const models = Array.isArray(args[0]) ? args[0] : [args[0]];
+                const opts = args[1] || {};
+                for (const m of models) {
+                    if (!m) continue;
+                    const id = m.id?._serialized || m.id?.id || '';
+                    const from = m.from?._serialized || m.from?.user || '';
+                    if (_shouldSkipDiag(m)) continue;
+                    const alreadyExists = MsgCollection.get(id);
+                    // Skip no-op re-adds (existing msg, not new) - these fire dozens of times/sec during sync
+                    if (alreadyExists && !m.isNewMsg) continue;
+                    safeDiagLog('debug', 'MSG_ADD_ATTEMPT', {
+                        traceId: id,
+                        from: from,
+                        type: m.type,
+                        isNewMsg: !!m.isNewMsg,
+                        alreadyExists: !!alreadyExists,
+                        mergeOption: !!opts.merge,
+                        hasBody: !!(m.body || m.caption),
+                    });
+                }
+            } catch(e) {}
+            return origMsgAdd(...args);
+        };
+        safeDiagLog('debug', 'HOOK_OK', 'Msg.add-wrapper');
+    } catch(e) {
+        safeDiagLog('warn', 'HOOK_FAIL', { hook: 'Msg.add-wrapper', reason: String(e) });
+    }
+
+    // --- [SILENT_LOSS] Hook Msg.addAndGet if it exists ---
+    // window.Store.Msg -> window.require('WAWebCollections').Msg
+    try {
+        var MsgCollection2 = window.require('WAWebCollections').Msg;
+        if (typeof MsgCollection2.addAndGet === 'function') {
+            var origAddAndGet = MsgCollection2.addAndGet.bind(MsgCollection2);
+            MsgCollection2.addAndGet = function(...args) {
+                try {
+                    var m = args[0];
+                    var id = m?.id?._serialized || m?.id?.id || '';
+                    var from = m?.from?._serialized || m?.from?.user || '';
+                    if (!_shouldSkipDiag(m)) {
+                        safeDiagLog('debug', 'MSG_ADD_AND_GET', {
+                            traceId: id, from: from, type: m?.type, isNewMsg: !!m?.isNewMsg,
+                        });
+                    }
+                } catch(e) {}
+                return origAddAndGet(...args);
+            };
+            safeDiagLog('debug', 'HOOK_OK', 'Msg.addAndGet-wrapper');
+        }
+    } catch(e) {}
+
+    // --- [SILENT_LOSS] Discover message processing modules ---
+    var msgProcessModules = [
+        'WAWebHandleReceivedMsg',
+        'WAWebMsgHandler',
+        'WAWebProcessMsg',
+        'WAWebChatMsgHandler',
+        'WAWebAddMsgToChat',
+        'WAWebMsgProcessing',
+        'WAWebProcessReceivedMessages',
+        'WAWebHandleIncomingMsg',
+    ];
+
+    for (var mi = 0; mi < msgProcessModules.length; mi++) {
+        try {
+            var modName = msgProcessModules[mi];
+            var mod = window.require(modName);
+            if (mod) {
+                var fnNames = Object.keys(mod).filter(function(k) { return typeof mod[k] === 'function'; });
+                safeDiagLog('debug', 'MSG_PROCESS_MODULE_FOUND', {
+                    module: modName,
+                    functions: fnNames.slice(0, 20).join(','),
+                });
+            }
+        } catch(e) {}
+    }
+
+    // --- Message revoke monitoring ---
+    try {
+        window.injectToFunction({ module: 'WAWebMsgDeleteCollection', function: 'sendRevoke' }, function(func, ...args) {
+            var msg = args[0];
+            if (!_shouldSkipDiag(msg)) {
+                safeDiagLog('debug', 'MSG_REVOKE', {
+                    id: msg && msg.id ? msg.id._serialized : '',
+                    from: msg ? wid(msg.from) : null,
+                    type: msg ? msg.type : null,
+                });
+            }
+            return func.apply(this, args);
+        });
+    } catch(e) {}
+};

--- a/src/util/Injected/DiagHooks.js
+++ b/src/util/Injected/DiagHooks.js
@@ -31,10 +31,7 @@ exports.InjectDiagHooks = () => {
         var hookId = target.module + '.' + target.function;
         try {
             let module = window.require(target.module);
-            if (!module) {
-                safeDiagLog('warn', 'HOOK_FAIL', { hook: hookId, reason: 'module not found' });
-                return;
-            }
+            if (!module) return;
 
             const path = target.function.split('.');
             const funcName = path.pop();
@@ -415,144 +412,203 @@ exports.InjectDiagHooks = () => {
     } catch(e) {}
 
     // --- Media download monitoring (downloadMediaBlob) ---
-    // NOTE: Cannot filter by message type - only has download URL/directPath, no message context
+    // NOTE: WAWebMediaDownloadUtils was removed in WAWeb 2.3000+. downloadMediaBlob is inlined.
+    //       The DL_DECRYPT hook on downloadAndMaybeDecrypt covers the main download path.
+    //       Try WAWebMediaDownloadUtils first, fall back to WAWebMedia.downloadMsg if available.
     try {
-        window.injectToFunction({ module: 'WAWebMediaDownloadUtils', function: 'downloadMediaBlob' }, function(func, ...args) {
-            var startTime = Date.now();
-            var url = '';
-            try { url = typeof args[0] === 'string' ? args[0].slice(0, 100) : (args[0] && args[0].directPath ? args[0].directPath.slice(0, 100) : ''); } catch(e) {}
-            var result = func.apply(this, args);
-            if (result && typeof result.then === 'function') {
-                return result.then(function(res) {
-                    safeDiagLog('debug', 'MEDIA_DOWNLOAD_OK', {
-                        elapsed: Date.now() - startTime,
-                        url: url,
-                        size: res ? (res.byteLength || res.size || res.length || 0) : 0,
+        var _mediaDownloadMod = window.require('WAWebMediaDownloadUtils') ? 'WAWebMediaDownloadUtils' : null;
+        if (_mediaDownloadMod) {
+            window.injectToFunction({ module: _mediaDownloadMod, function: 'downloadMediaBlob' }, function(func, ...args) {
+                var startTime = Date.now();
+                var url = '';
+                try { url = typeof args[0] === 'string' ? args[0].slice(0, 100) : (args[0] && args[0].directPath ? args[0].directPath.slice(0, 100) : ''); } catch(e) {}
+                var result = func.apply(this, args);
+                if (result && typeof result.then === 'function') {
+                    return result.then(function(res) {
+                        safeDiagLog('debug', 'MEDIA_DOWNLOAD_OK', {
+                            elapsed: Date.now() - startTime,
+                            url: url,
+                            size: res ? (res.byteLength || res.size || res.length || 0) : 0,
+                        });
+                        return res;
+                    }).catch(function(err) {
+                        safeDiagLog('debug', 'MEDIA_DOWNLOAD_FAIL', {
+                            elapsed: Date.now() - startTime,
+                            url: url,
+                            error: err ? (err.message || String(err)) : 'unknown',
+                        });
+                        throw err;
                     });
-                    return res;
-                }).catch(function(err) {
-                    safeDiagLog('debug', 'MEDIA_DOWNLOAD_FAIL', {
-                        elapsed: Date.now() - startTime,
-                        url: url,
-                        error: err ? (err.message || String(err)) : 'unknown',
-                    });
-                    throw err;
-                });
-            }
-            return result;
-        });
-    } catch(e) {}
+                }
+                return result;
+            });
 
-    // --- Media download monitoring (downloadMedia) ---
-    try {
-        window.injectToFunction({ module: 'WAWebMediaDownloadUtils', function: 'downloadMedia' }, function(func, ...args) {
-            var startTime = Date.now();
-            var directPath = '';
-            try { directPath = (args[0] && args[0].directPath) ? args[0].directPath.slice(0, 100) : ''; } catch(e) {}
-            var result = func.apply(this, args);
-            if (result && typeof result.then === 'function') {
-                return result.then(function(res) {
-                    safeDiagLog('debug', 'MEDIA_DOWNLOAD2_OK', {
-                        elapsed: Date.now() - startTime, directPath: directPath,
+            window.injectToFunction({ module: _mediaDownloadMod, function: 'downloadMedia' }, function(func, ...args) {
+                var startTime = Date.now();
+                var directPath = '';
+                try { directPath = (args[0] && args[0].directPath) ? args[0].directPath.slice(0, 100) : ''; } catch(e) {}
+                var result = func.apply(this, args);
+                if (result && typeof result.then === 'function') {
+                    return result.then(function(res) {
+                        safeDiagLog('debug', 'MEDIA_DOWNLOAD2_OK', {
+                            elapsed: Date.now() - startTime, directPath: directPath,
+                        });
+                        return res;
+                    }).catch(function(err) {
+                        safeDiagLog('debug', 'MEDIA_DOWNLOAD2_FAIL', {
+                            elapsed: Date.now() - startTime, directPath: directPath,
+                            error: err ? (err.message || String(err)) : 'unknown',
+                        });
+                        throw err;
                     });
-                    return res;
-                }).catch(function(err) {
-                    safeDiagLog('debug', 'MEDIA_DOWNLOAD2_FAIL', {
-                        elapsed: Date.now() - startTime, directPath: directPath,
-                        error: err ? (err.message || String(err)) : 'unknown',
-                    });
-                    throw err;
-                });
-            }
-            return result;
-        });
+                }
+                return result;
+            });
+        } else {
+            // WAWebMediaDownloadUtils removed in 2.3000+, covered by DL_DECRYPT
+        }
     } catch(e) {}
 
     // --- PreKey get/upload ---
+    // NOTE: WAWebPreKeyUtils was removed in WAWeb 2.3000+. getOrGenPreKeys is inlined.
+    //       uploadPreKeys moved to WAWebUploadPreKeysJob.
     try {
-        window.injectToFunction({ module: 'WAWebPreKeyUtils', function: 'getOrGenPreKeys' }, function(func, ...args) {
-            var result = func.apply(this, args);
-            if (result && typeof result.then === 'function') {
-                return result.then(function(res) {
-                    var count = Array.isArray(res) ? res.length : (res ? 1 : 0);
-                    safeDiagLog('debug', 'PREKEY_GET', { count: count });
-                    return res;
-                }).catch(function(err) {
-                    safeDiagLog('warn', 'PREKEY_GET_FAIL', {
-                        error: err ? (err.message || String(err)) : 'unknown',
+        var _preKeyGetMod = window.require('WAWebPreKeyUtils') ? 'WAWebPreKeyUtils' : null;
+        if (_preKeyGetMod) {
+            window.injectToFunction({ module: _preKeyGetMod, function: 'getOrGenPreKeys' }, function(func, ...args) {
+                var result = func.apply(this, args);
+                if (result && typeof result.then === 'function') {
+                    return result.then(function(res) {
+                        var count = Array.isArray(res) ? res.length : (res ? 1 : 0);
+                        safeDiagLog('debug', 'PREKEY_GET', { count: count });
+                        return res;
+                    }).catch(function(err) {
+                        safeDiagLog('warn', 'PREKEY_GET_FAIL', {
+                            error: err ? (err.message || String(err)) : 'unknown',
+                        });
+                        throw err;
                     });
-                    throw err;
-                });
-            }
-            return result;
-        });
+                }
+                return result;
+            });
+        } else {
+            // WAWebPreKeyUtils.getOrGenPreKeys inlined in 2.3000+
+        }
     } catch(e) {}
 
+    // uploadPreKeys: try WAWebUploadPreKeysJob (2.3000+), fall back to WAWebPreKeyUtils
     try {
-        window.injectToFunction({ module: 'WAWebPreKeyUtils', function: 'uploadPreKeys' }, function(func, ...args) {
-            safeDiagLog('debug', 'PREKEY_UPLOAD', { count: Array.isArray(args[0]) ? args[0].length : 0 });
-            var result = func.apply(this, args);
-            if (result && typeof result.then === 'function') {
-                return result.catch(function(err) {
-                    safeDiagLog('warn', 'PREKEY_UPLOAD_FAIL', {
-                        error: err ? (err.message || String(err)) : 'unknown',
+        var _preKeyUploadMod = window.require('WAWebUploadPreKeysJob') ? 'WAWebUploadPreKeysJob'
+            : window.require('WAWebPreKeyUtils') ? 'WAWebPreKeyUtils' : null;
+        if (_preKeyUploadMod) {
+            window.injectToFunction({ module: _preKeyUploadMod, function: 'uploadPreKeys' }, function(func, ...args) {
+                safeDiagLog('debug', 'PREKEY_UPLOAD', { count: Array.isArray(args[0]) ? args[0].length : 0 });
+                var result = func.apply(this, args);
+                if (result && typeof result.then === 'function') {
+                    return result.catch(function(err) {
+                        safeDiagLog('warn', 'PREKEY_UPLOAD_FAIL', {
+                            error: err ? (err.message || String(err)) : 'unknown',
+                        });
+                        throw err;
                     });
-                    throw err;
-                });
-            }
-            return result;
-        });
+                }
+                return result;
+            });
+        } else {
+            // uploadPreKeys module not available
+        }
     } catch(e) {}
 
     // --- Session deletion ---
+    // NOTE: WAWebDeleteSessionJob was removed in WAWeb 2.3000+.
+    //       deleteRemoteSession is still available via WAWebSignal.Session (hooked above).
+    //       Try WAWebDeleteSessionJob first, then fall back to WAWebSignal.Session hook.
     try {
-        window.injectToFunction({ module: 'WAWebDeleteSessionJob', function: 'deleteRemoteSession' }, function(func, ...args) {
-            var jid = '';
-            try { jid = wid(args[0]) || safeStr(args[0]); } catch(e) {}
-            if (!_isStatusOrGroup(jid)) {
-                safeDiagLog('warn', 'SESSION_DELETE', { jid: jid });
-            }
-            return func.apply(this, args);
-        });
+        var _deleteSessionMod = window.require('WAWebDeleteSessionJob') ? 'WAWebDeleteSessionJob' : null;
+        if (_deleteSessionMod) {
+            window.injectToFunction({ module: _deleteSessionMod, function: 'deleteRemoteSession' }, function(func, ...args) {
+                var jid = '';
+                try { jid = wid(args[0]) || safeStr(args[0]); } catch(e) {}
+                if (!_isStatusOrGroup(jid)) {
+                    safeDiagLog('warn', 'SESSION_DELETE', { jid: jid });
+                }
+                return func.apply(this, args);
+            });
+        } else {
+            // WAWebDeleteSessionJob removed in 2.3000+, covered by WAWebSignal.Session hooks
+        }
     } catch(e) {}
 
     // --- Socket close monitoring ---
+    // NOTE: WAWebSocketConnectModel and onSocketClose were removed in WAWeb 2.3000+.
+    //       In newer versions, hook SocketBridgeApi.triggerSocketStreamDisconnectedFromBridge
+    //       and also listen to Socket change:state events for disconnect detection.
     try {
+        var _socketHooked = false;
+        // Try legacy approach first
         var connMods = ['WAWebSocketConnectModel', 'WAWebSocketModel'];
         for (var ci = 0; ci < connMods.length; ci++) {
             try {
-                window.injectToFunction({ module: connMods[ci], function: 'onSocketClose' }, function(func, ...args) {
-                    var code = args[0];
-                    var reason = args[1];
-                    safeDiagLog('warn', 'SOCKET_CLOSE', {
-                        code: code, reason: typeof reason === 'string' ? reason.slice(0, 200) : String(reason),
+                var _connMod = window.require(connMods[ci]);
+                if (_connMod && typeof _connMod.onSocketClose === 'function') {
+                    window.injectToFunction({ module: connMods[ci], function: 'onSocketClose' }, function(func, ...args) {
+                        var code = args[0];
+                        var reason = args[1];
+                        safeDiagLog('warn', 'SOCKET_CLOSE', {
+                            code: code, reason: typeof reason === 'string' ? reason.slice(0, 200) : String(reason),
+                        });
+                        return func.apply(this, args);
                     });
+                    _socketHooked = true;
+                    break;
+                }
+            } catch(e) {}
+        }
+        // Fallback: hook SocketBridgeApi disconnect trigger (WAWeb 2.3000+)
+        if (!_socketHooked) {
+            try {
+                window.injectToFunction({ module: 'WAWebSocketBridgeApi', function: 'SocketBridgeApi.triggerSocketStreamDisconnectedFromBridge' }, function(func, ...args) {
+                    safeDiagLog('warn', 'SOCKET_CLOSE', { source: 'bridgeApi', args: safeStr(args[0]) });
                     return func.apply(this, args);
                 });
-            } catch(e) {}
+            } catch(e) {
+                // SOCKET_CLOSE: no hookable module found
+            }
         }
     } catch(e) {}
 
     // --- History sync processing ---
+    // NOTE: WAWebHistorySyncJobUtils.processHistorySyncData was removed in WAWeb 2.3000+.
+    //       Replaced by WAWebHandleHistorySyncChunk.handleHistorySyncChunk.
     try {
-        window.injectToFunction({ module: 'WAWebHistorySyncJobUtils', function: 'processHistorySyncData' }, function(func, ...args) {
-            var data = args[0];
-            var msgCount = 0;
-            try {
-                if (data && data.conversations) {
-                    for (var hi = 0; hi < data.conversations.length; hi++) {
-                        msgCount += (data.conversations[hi].messages || []).length;
+        var _historySyncMod = window.require('WAWebHistorySyncJobUtils') ? 'WAWebHistorySyncJobUtils' : null;
+        var _historySyncFn = _historySyncMod ? 'processHistorySyncData' : null;
+        if (!_historySyncMod) {
+            _historySyncMod = window.require('WAWebHandleHistorySyncChunk') ? 'WAWebHandleHistorySyncChunk' : null;
+            _historySyncFn = _historySyncMod ? 'handleHistorySyncChunk' : null;
+        }
+        if (_historySyncMod && _historySyncFn) {
+            window.injectToFunction({ module: _historySyncMod, function: _historySyncFn }, function(func, ...args) {
+                var data = args[0];
+                var msgCount = 0;
+                try {
+                    if (data && data.conversations) {
+                        for (var hi = 0; hi < data.conversations.length; hi++) {
+                            msgCount += (data.conversations[hi].messages || []).length;
+                        }
                     }
-                }
-            } catch(e) {}
-            safeDiagLog('debug', 'HISTORY_SYNC_PROCESS', {
-                conversationCount: data && data.conversations ? data.conversations.length : 0,
-                msgCount: msgCount,
-                syncType: data ? data.syncType : null,
-                progress: data ? data.progress : null,
+                } catch(e) {}
+                safeDiagLog('debug', 'HISTORY_SYNC_PROCESS', {
+                    conversationCount: data && data.conversations ? data.conversations.length : 0,
+                    msgCount: msgCount,
+                    syncType: data ? data.syncType : null,
+                    progress: data ? data.progress : null,
+                });
+                return func.apply(this, args);
             });
-            return func.apply(this, args);
-        });
+        } else {
+            // HISTORY_SYNC_PROCESS: no module found
+        }
     } catch(e) {}
 
     // --- [L13] downloadAndMaybeDecrypt hook for filehash mismatch root cause ---
@@ -709,38 +765,47 @@ exports.InjectDiagHooks = () => {
 
     // --- [L13] WAWebCryptoDecryptMedia hook - capture decryption details ---
     // NOTE: Cannot filter by message type here - only has crypto params, no message context
+    // NOTE: In newer WAWeb (2.3000+), the module IS the default export function directly
+    //       (typeof module === 'function', no .default property). We cannot replace it in
+    //       Metro's registry, but the DL_DECRYPT hook on downloadAndMaybeDecrypt already
+    //       covers the main decrypt path. We still try the .default hook for older versions.
     try {
-        window.injectToFunction({ module: 'WAWebCryptoDecryptMedia', function: 'default' }, function(func, ...args) {
-            var opts = args[0] || {};
-            var startTime = Date.now();
-            safeDiagLog('debug', 'DECRYPT_MEDIA_START', {
-                expectedPlaintextHash: opts.expectedPlaintextHash || null,
-                ciphertextSize: opts.ciphertextHmac ? (opts.ciphertextHmac.byteLength || 0) : 0,
-                hasMediaKeys: !!opts.mediaKeys,
-                debugString: opts.debugString || null,
-            });
-
-            var result = func.apply(this, args);
-            if (result && typeof result.then === 'function') {
-                return result.then(function(plaintext) {
-                    safeDiagLog('debug', 'DECRYPT_MEDIA_OK', {
-                        elapsed: Date.now() - startTime,
-                        plaintextSize: plaintext ? (plaintext.byteLength || 0) : 0,
-                    });
-                    return plaintext;
-                }).catch(function(err) {
-                    safeDiagLog('warn', 'DECRYPT_MEDIA_FAIL', {
-                        elapsed: Date.now() - startTime,
-                        errorName: err ? err.name : null,
-                        errorMessage: err ? (typeof err.message === 'object' ? JSON.stringify(err.message) : String(err.message || err)).substring(0, 500) : null,
-                        expectedPlaintextHash: opts.expectedPlaintextHash,
-                        ciphertextSize: opts.ciphertextHmac ? (opts.ciphertextHmac.byteLength || 0) : 0,
-                    });
-                    throw err;
+        var _cryptoMod = window.require('WAWebCryptoDecryptMedia');
+        if (typeof _cryptoMod === 'function' && !('default' in _cryptoMod)) {
+            // WAWebCryptoDecryptMedia is module-level function in 2.3000+, covered by DL_DECRYPT
+        } else {
+            window.injectToFunction({ module: 'WAWebCryptoDecryptMedia', function: 'default' }, function(func, ...args) {
+                var opts = args[0] || {};
+                var startTime = Date.now();
+                safeDiagLog('debug', 'DECRYPT_MEDIA_START', {
+                    expectedPlaintextHash: opts.expectedPlaintextHash || null,
+                    ciphertextSize: opts.ciphertextHmac ? (opts.ciphertextHmac.byteLength || 0) : 0,
+                    hasMediaKeys: !!opts.mediaKeys,
+                    debugString: opts.debugString || null,
                 });
-            }
-            return result;
-        });
+
+                var result = func.apply(this, args);
+                if (result && typeof result.then === 'function') {
+                    return result.then(function(plaintext) {
+                        safeDiagLog('debug', 'DECRYPT_MEDIA_OK', {
+                            elapsed: Date.now() - startTime,
+                            plaintextSize: plaintext ? (plaintext.byteLength || 0) : 0,
+                        });
+                        return plaintext;
+                    }).catch(function(err) {
+                        safeDiagLog('warn', 'DECRYPT_MEDIA_FAIL', {
+                            elapsed: Date.now() - startTime,
+                            errorName: err ? err.name : null,
+                            errorMessage: err ? (typeof err.message === 'object' ? JSON.stringify(err.message) : String(err.message || err)).substring(0, 500) : null,
+                            expectedPlaintextHash: opts.expectedPlaintextHash,
+                            ciphertextSize: opts.ciphertextHmac ? (opts.ciphertextHmac.byteLength || 0) : 0,
+                        });
+                        throw err;
+                    });
+                }
+                return result;
+            });
+        }
     } catch(e) {
         safeDiagLog('warn', 'HOOK_FAIL_MANUAL', { hook: 'WAWebCryptoDecryptMedia', error: String(e) });
     }
@@ -772,18 +837,29 @@ exports.InjectDiagHooks = () => {
     } catch(e) {}
 
     // --- [L13] Detect BACKFILL/placeholder messages ---
+    // NOTE: In newer WAWeb (2.3000+), isPlaceholder was removed from Msg prototype.
+    //       We try Msg.prototype first (via WAWebMsgModel.Msg), then fall back to .default.
     try {
-        window.injectToFunction({ module: 'WAWebMsgModel', function: 'default.prototype.isPlaceholder' }, function(func, ...args) {
-            var result = func.apply(this, args);
-            if (result && !_shouldSkipDiag(this)) {
-                safeDiagLog('debug', 'MSG_IS_PLACEHOLDER', {
-                    id: this.id ? this.id._serialized : null,
-                    type: this.type,
-                    hasMedia: this.hasMedia,
-                });
-            }
-            return result;
-        });
+        var _msgModelMod = window.require('WAWebMsgModel');
+        var _msgProto = (_msgModelMod && _msgModelMod.Msg && _msgModelMod.Msg.prototype)
+            || (_msgModelMod && _msgModelMod.default && _msgModelMod.default.prototype);
+        if (_msgProto && typeof _msgProto.isPlaceholder === 'function') {
+            var _origIsPlaceholder = _msgProto.isPlaceholder;
+            _msgProto.isPlaceholder = function() {
+                var result = _origIsPlaceholder.apply(this, arguments);
+                if (result && !_shouldSkipDiag(this)) {
+                    safeDiagLog('debug', 'MSG_IS_PLACEHOLDER', {
+                        id: this.id ? this.id._serialized : null,
+                        type: this.type,
+                        hasMedia: this.hasMedia,
+                    });
+                }
+                return result;
+            };
+            safeDiagLog('debug', 'HOOK_OK', 'WAWebMsgModel.isPlaceholder');
+        } else {
+            // WAWebMsgModel.isPlaceholder removed in 2.3000+
+        }
     } catch(e) {}
 
     // --- [SILENT_LOSS] Wrap Msg.add to trace ALL add attempts ---
@@ -871,8 +947,12 @@ exports.InjectDiagHooks = () => {
     }
 
     // --- Message revoke monitoring ---
+    // NOTE: WAWebMsgDeleteCollection was removed in WAWeb 2.3000+. Use WAWebRevokeMsgAction instead.
     try {
-        window.injectToFunction({ module: 'WAWebMsgDeleteCollection', function: 'sendRevoke' }, function(func, ...args) {
+        var _revokeModule = window.require('WAWebRevokeMsgAction') ? 'WAWebRevokeMsgAction'
+            : window.require('WAWebMsgDeleteCollection') ? 'WAWebMsgDeleteCollection' : null;
+        if (!_revokeModule) throw 'no revoke module found';
+        window.injectToFunction({ module: _revokeModule, function: 'sendRevoke' }, function(func, ...args) {
             var msg = args[0];
             if (!_shouldSkipDiag(msg)) {
                 safeDiagLog('debug', 'MSG_REVOKE', {

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -286,7 +286,9 @@ exports.LoadUtils = () => {
 
         let vcardOptions = {};
         if (options.contactCard) {
-            let contact = await window.WWebJS.findContact(options.contactCard);
+            let contact = await window
+                .require('WAWebCollections')
+                .Contact.find(options.contactCard);
             vcardOptions = {
                 body: window
                     .require('WAWebFrontendVcardUtils')
@@ -298,7 +300,7 @@ exports.LoadUtils = () => {
         } else if (options.contactCardList) {
             let contacts = await Promise.all(
                 options.contactCardList.map((c) =>
-                    window.WWebJS.findContact(c),
+                    window.require('WAWebCollections').Contact.find(c),
                 ),
             );
             let vcards = contacts.map((c) =>
@@ -983,14 +985,10 @@ exports.LoadUtils = () => {
                 window.require('WAWebCollections').GroupMetadata ||
                 window.require('WAWebCollections').WAWebGroupMetadataCollection;
             await groupMetadata.update(chatWid);
+            const { toPn } = window.require('WAWebLidMigrationUtils');
             const serializedMetadata = chat.groupMetadata.serialize();
-            const participantModels = chat.groupMetadata.participants._models;
             for (const p of serializedMetadata.participants || []) {
-                if (!p.id?._serialized?.endsWith('@lid')) continue;
-                const phone = participantModels.find(
-                    (m) => m.id?._serialized === p.id._serialized,
-                )?.contact?.phoneNumber;
-                if (phone) p.id = phone;
+                p.id = toPn(p.id) ?? p.id;
             }
             model.groupMetadata = serializedMetadata;
             model.isReadOnly = chat.groupMetadata.announce;
@@ -1034,15 +1032,13 @@ exports.LoadUtils = () => {
         return model;
     };
 
-    window.WWebJS.findContact = async (id) => {
-        const wid = window.require('WAWebWidFactory').createWid(id);
-        return window.require('WAWebCollections').Contact.find(wid);
-    };
-
     window.WWebJS.getContactModel = (contact) => {
         let res = contact.serialize();
 
-        if (res.id?._serialized?.endsWith('@lid') && contact.phoneNumber) {
+        const wid = window
+            .require('WAWebWidFactory')
+            .createWidFromWidLike(contact.id);
+        if (wid.isLid() && contact.phoneNumber) {
             res.id = contact.phoneNumber;
         }
 
@@ -1084,15 +1080,14 @@ exports.LoadUtils = () => {
         let findTook = -1;
         let bizTook = -1;
         try {
-            const wid = window.require('WAWebWidFactory').createWid(contactId);
             const contact = await window
                 .require('WAWebCollections')
-                .Contact.find(wid);
+                .Contact.find(contactId);
             findTook = Date.now() - start;
             const bizStart = Date.now();
             const bizProfile = await window
                 .require('WAWebCollections')
-                .BusinessProfile.find(wid);
+                .BusinessProfile.find(contactId);
             bizTook = Date.now() - bizStart;
             bizProfile.profileOptions && (contact.businessProfile = bizProfile);
             const totalTook = Date.now() - start;

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1055,14 +1055,10 @@ exports.LoadUtils = () => {
         const contact = await window
             .require('WAWebCollections')
             .Contact.find(wid);
-        try {
-            const bizProfile = await window
-                .require('WAWebCollections')
-                .BusinessProfile.find(wid);
-            bizProfile.profileOptions && (contact.businessProfile = bizProfile);
-        } catch (_) {
-            /* find() can fail for non-business contacts */
-        }
+        const bizProfile = await window
+            .require('WAWebCollections')
+            .BusinessProfile.find(wid);
+        bizProfile.profileOptions && (contact.businessProfile = bizProfile);
         return window.WWebJS.getContactModel(contact);
     };
 

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -286,9 +286,7 @@ exports.LoadUtils = () => {
 
         let vcardOptions = {};
         if (options.contactCard) {
-            let contact = window
-                .require('WAWebCollections')
-                .Contact.get(options.contactCard);
+            let contact = await window.WWebJS.findContact(options.contactCard);
             vcardOptions = {
                 body: window
                     .require('WAWebFrontendVcardUtils')
@@ -298,8 +296,10 @@ exports.LoadUtils = () => {
             };
             delete options.contactCard;
         } else if (options.contactCardList) {
-            let contacts = options.contactCardList.map((c) =>
-                window.require('WAWebCollections').Contact.get(c),
+            let contacts = await Promise.all(
+                options.contactCardList.map((c) =>
+                    window.WWebJS.findContact(c),
+                ),
             );
             let vcards = contacts.map((c) =>
                 window
@@ -956,14 +956,16 @@ exports.LoadUtils = () => {
                 window.require('WAWebCollections').GroupMetadata ||
                 window.require('WAWebCollections').WAWebGroupMetadataCollection;
             await groupMetadata.update(chatWid);
-            chat.groupMetadata.participants._models
-                .filter((x) => x.id?._serialized?.endsWith('@lid'))
-                .forEach(
-                    (x) =>
-                        x.contact?.phoneNumber &&
-                        (x.id = x.contact.phoneNumber),
-                );
-            model.groupMetadata = chat.groupMetadata.serialize();
+            const serializedMetadata = chat.groupMetadata.serialize();
+            const participantModels = chat.groupMetadata.participants._models;
+            for (const p of serializedMetadata.participants || []) {
+                if (!p.id?._serialized?.endsWith('@lid')) continue;
+                const phone = participantModels.find(
+                    (m) => m.id?._serialized === p.id._serialized,
+                )?.contact?.phoneNumber;
+                if (phone) p.id = phone;
+            }
+            model.groupMetadata = serializedMetadata;
             model.isReadOnly = chat.groupMetadata.announce;
         }
 
@@ -1005,8 +1007,18 @@ exports.LoadUtils = () => {
         return model;
     };
 
+    window.WWebJS.findContact = async (id) => {
+        const wid = window.require('WAWebWidFactory').createWid(id);
+        return window.require('WAWebCollections').Contact.find(wid);
+    };
+
     window.WWebJS.getContactModel = (contact) => {
         let res = contact.serialize();
+
+        if (res.id?._serialized?.endsWith('@lid') && contact.phoneNumber) {
+            res.id = contact.phoneNumber;
+        }
+
         res.isBusiness =
             contact.isBusiness === undefined ? false : contact.isBusiness;
 
@@ -1040,16 +1052,17 @@ exports.LoadUtils = () => {
 
     window.WWebJS.getContact = async (contactId) => {
         const wid = window.require('WAWebWidFactory').createWid(contactId);
-        let contact = await window
+        const contact = await window
             .require('WAWebCollections')
             .Contact.find(wid);
-        if (contact.id._serialized.endsWith('@lid')) {
-            contact.id = contact.phoneNumber;
+        try {
+            const bizProfile = await window
+                .require('WAWebCollections')
+                .BusinessProfile.fetchBizProfile(wid);
+            bizProfile.profileOptions && (contact.businessProfile = bizProfile);
+        } catch (_) {
+            /* fetchBizProfile can fail for non-business contacts */
         }
-        const bizProfile = await window
-            .require('WAWebCollections')
-            .BusinessProfile.fetchBizProfile(wid);
-        bizProfile.profileOptions && (contact.businessProfile = bizProfile);
         return window.WWebJS.getContactModel(contact);
     };
 

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1084,12 +1084,15 @@ exports.LoadUtils = () => {
                 .require('WAWebCollections')
                 .Contact.find(contactId);
             findTook = Date.now() - start;
-            const bizStart = Date.now();
-            const bizProfile = await window
-                .require('WAWebCollections')
-                .BusinessProfile.find(contactId);
-            bizTook = Date.now() - bizStart;
-            bizProfile.profileOptions && (contact.businessProfile = bizProfile);
+            if (contact.isBusiness || contact.isEnterprise) {
+                const bizStart = Date.now();
+                const bizProfile = await window
+                    .require('WAWebCollections')
+                    .BusinessProfile.find(contactId);
+                bizTook = Date.now() - bizStart;
+                bizProfile.profileOptions &&
+                    (contact.businessProfile = bizProfile);
+            }
             const totalTook = Date.now() - start;
             if (totalTook > 200) {
                 if (window.onDiagLog)

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -799,7 +799,24 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.getMessageModel = (message) => {
-        const msg = message.serialize();
+        let msg;
+        try {
+            msg = message.serialize();
+        } catch (e) {
+            if (window.onDiagLog) window.onDiagLog('error', 'getMessageModel serialize FAILED', JSON.stringify({
+                id: message.id?._serialized,
+                type: message.type,
+                error: e?.message || String(e)
+            }));
+            throw e;
+        }
+        if (!msg) {
+            if (window.onDiagLog) window.onDiagLog('error', 'getMessageModel serialize returned falsy', JSON.stringify({
+                id: message.id?._serialized,
+                type: message.type
+            }));
+            return null;
+        }
 
         const { findLinks } = window.require('WALinkify');
 
@@ -1051,19 +1068,42 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.getContact = async (contactId) => {
-        const wid = window.require('WAWebWidFactory').createWid(contactId);
-        const contact = await window
-            .require('WAWebCollections')
-            .Contact.find(wid);
+        const start = Date.now();
+        const isLid = typeof contactId === 'string' && contactId.endsWith('@lid');
+        let findTook = -1;
+        let bizTook = -1;
         try {
-            const bizProfile = await window
+            const wid = window.require('WAWebWidFactory').createWid(contactId);
+            const contact = await window
                 .require('WAWebCollections')
-                .BusinessProfile.find(wid);
-            bizProfile.profileOptions && (contact.businessProfile = bizProfile);
-        } catch (_) {
-            /* find() can fail for non-business contacts */
+                .Contact.find(wid);
+            findTook = Date.now() - start;
+            try {
+                const bizStart = Date.now();
+                const bizProfile = await window
+                    .require('WAWebCollections')
+                    .BusinessProfile.find(wid);
+                bizTook = Date.now() - bizStart;
+                bizProfile.profileOptions && (contact.businessProfile = bizProfile);
+            } catch (_) {
+                /* find() can fail for non-business contacts */
+            }
+            const totalTook = Date.now() - start;
+            if (totalTook > 200) {
+                if (window.onDiagLog) window.onDiagLog('warn', 'getContact:slow', JSON.stringify({
+                    contactId: contactId.substring(0, 20), isLid, findTook, bizTook, totalTook
+                }));
+            }
+            return window.WWebJS.getContactModel(contact);
+        } catch (e) {
+            if (window.onDiagLog) window.onDiagLog('error', 'getContact:error', JSON.stringify({
+                contactId: contactId.substring(0, 20), isLid, findTook, bizTook,
+                totalTook: Date.now() - start,
+                error: String(e?.message || e).substring(0, 200),
+                stage: findTook < 0 ? 'find' : bizTook < 0 ? 'bizProfile' : 'model'
+            }));
+            throw e;
         }
-        return window.WWebJS.getContactModel(contact);
     };
 
     window.WWebJS.getContacts = () => {

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1058,10 +1058,10 @@ exports.LoadUtils = () => {
         try {
             const bizProfile = await window
                 .require('WAWebCollections')
-                .BusinessProfile.fetchBizProfile(wid);
+                .BusinessProfile.find(wid);
             bizProfile.profileOptions && (contact.businessProfile = bizProfile);
         } catch (_) {
-            /* fetchBizProfile can fail for non-business contacts */
+            /* find() can fail for non-business contacts */
         }
         return window.WWebJS.getContactModel(contact);
     };

--- a/src/util/Puppeteer.js
+++ b/src/util/Puppeteer.js
@@ -15,9 +15,11 @@ async function exposeFunctionIfAbsent(page, name, fn) {
         return !!window[name];
     }, name);
     if (exist) {
+        console.warn('[wwjs-diag] exposeFunctionIfAbsent SKIPPED', name);
         return;
     }
     await page.exposeFunction(name, fn);
+    console.warn('[wwjs-diag] exposeFunctionIfAbsent EXPOSED', name);
 }
 
 module.exports = { exposeFunctionIfAbsent };


### PR DESCRIPTION
Adds support for passing a pre-existing `browser` and `page` via `options.puppeteer`, so the Client can work with a browser you already control (e.g. Electron's built-in Chromium, or a shared browser pool).

When both `browser` and `page` are provided, the Client skips `puppeteer.launch()` / `puppeteer.connect()` and uses them directly. Existing behavior is unchanged when these options are not set.

### What changed

**`initialize()`** - new `if` branch before the existing `browserWSEndpoint` check:
```js
if (puppeteerOpts.browser && puppeteerOpts.page) {
    browser = puppeteerOpts.browser;
    page = puppeteerOpts.page;
}
```

**`destroy()` / `logout()`** - use `browser.process()` to decide cleanup:
- `process() !== null` (we launched it) -> `browser.close()` as before
- `process() === null` (external browser) -> `browser.disconnect()` only

Without this, `browser.close()` sends CDP `Browser.close` which kills the entire external browser, not just this client's session. `disconnect()` only closes the WebSocket, leaving the browser running.

This is the same pattern puppeteer uses internally in `Symbol.dispose`.

### Example

```js
const browser = await puppeteer.connect({ browserWSEndpoint: '...' });
const page = /* your page */;

const client = new Client({
    puppeteer: { browser, page }
});
await client.initialize();
```