### PR TITLE
fix: RemoteAuth use consistent session key and prefer local session

### DIFF
--- a/src/authStrategies/RemoteAuth.js
+++ b/src/authStrategies/RemoteAuth.js
@@ -66,10 +66,8 @@ class RemoteAuth extends BaseAuthStrategy {
 
     async beforeBrowserInitialized() {
         const puppeteerOpts = this.client.options.puppeteer;
-        const sessionDirName = this.clientId
-            ? `RemoteAuth-${this.clientId}`
-            : 'RemoteAuth';
-        const dirPath = path.join(this.dataPath, sessionDirName);
+        const sessionDirName = this.clientId ? `RemoteAuth-${this.clientId}` : 'RemoteAuth'
+        const dirPath = path.join(this.dataPath, sessionDirName)
 
         if (
             puppeteerOpts.userDataDir &&
@@ -82,6 +80,11 @@ class RemoteAuth extends BaseAuthStrategy {
 
         this.userDataDir = dirPath;
         this.sessionName = sessionDirName;
+
+        // Ensure parent directories exist so extract can write temp zip
+        try {
+            fs.mkdirSync(this.dataPath, { recursive: true })
+        } catch (e) {}
 
         await this.extractRemoteSession();
 
@@ -158,24 +161,28 @@ class RemoteAuth extends BaseAuthStrategy {
 
     async extractRemoteSession() {
         const pathExists = await this.isValidPath(this.userDataDir);
-        const compressedSessionPath = path.join(
-            this.dataPath,
-            `${this.sessionName}.zip`,
-        );
-        const sessionKey = path.join(this.dataPath, this.sessionName);
-        const sessionExists = await this.store.sessionExists({ session: sessionKey });
+        const compressedSessionPath = path.join(this.dataPath, `${this.sessionName}.zip`)
+        const sessionKey = path.join(this.dataPath, this.sessionName)
+        const sessionExists = await this.store.sessionExists({ session: sessionKey })
 
         // If a local user data dir already exists, prefer it over remote extraction
         if (pathExists) {
-            console.log('[REMOTE AUTH] Local session found at:', this.userDataDir);
-            return;
+            console.log('[REMOTE AUTH] Local session found at:', this.userDataDir)
+            return
         }
 
         if (sessionExists) {
-            await this.store.extract({ session: sessionKey, path: compressedSessionPath });
-            await this.unCompressSession(compressedSessionPath);
+            // Ask the store to write the compressed session to disk (ensures parent dir exists)
+            await this.store.extract({ session: sessionKey, path: compressedSessionPath })
+            // Verify downloaded zip exists before attempting to uncompress
+            try {
+                await fs.promises.access(compressedSessionPath, fs.constants.R_OK)
+            } catch (err) {
+                throw new Error(`Failed to download remote session to ${compressedSessionPath}: ${err.message}`)
+            }
+            await this.unCompressSession(compressedSessionPath)
         } else {
-            fs.mkdirSync(this.userDataDir, { recursive: true });
+            fs.mkdirSync(this.userDataDir, { recursive: true })
         }
     }
 

--- a/src/authStrategies/RemoteAuth.js
+++ b/src/authStrategies/RemoteAuth.js
@@ -116,13 +116,10 @@ class RemoteAuth extends BaseAuthStrategy {
     }
 
     async afterAuthReady() {
-        const sessionExists = await this.store.sessionExists({
-            session: this.sessionName,
-        });
+        const sessionKey = path.join(this.dataPath, this.sessionName);
+        const sessionExists = await this.store.sessionExists({ session: sessionKey });
         if (!sessionExists) {
-            await this.delay(
-                60000,
-            ); /* Initial delay sync required for session to be stable enough to recover */
+            await this.delay(60000); /* Initial delay sync required for session to be stable enough to recover */
             await this.storeRemoteSession({ emit: true });
         }
         var self = this;
@@ -138,9 +135,8 @@ class RemoteAuth extends BaseAuthStrategy {
         let compressedSessionPath;
         try {
             compressedSessionPath = await this.compressSession();
-            await this.store.save({
-                session: this.sessionName,
-            });
+            const sessionKey = path.join(this.dataPath, this.sessionName);
+            await this.store.save({ session: sessionKey });
             if (options && options.emit)
                 this.client.emit(Events.REMOTE_SESSION_SAVED);
         } finally {
@@ -166,23 +162,17 @@ class RemoteAuth extends BaseAuthStrategy {
             this.dataPath,
             `${this.sessionName}.zip`,
         );
-        const sessionExists = await this.store.sessionExists({
-            session: this.sessionName,
-        });
+        const sessionKey = path.join(this.dataPath, this.sessionName);
+        const sessionExists = await this.store.sessionExists({ session: sessionKey });
+
+        // If a local user data dir already exists, prefer it over remote extraction
         if (pathExists) {
-            await fs.promises
-                .rm(this.userDataDir, {
-                    recursive: true,
-                    force: true,
-                    maxRetries: this.rmMaxRetries,
-                })
-                .catch(() => {});
+            console.log('[REMOTE AUTH] Local session found at:', this.userDataDir);
+            return;
         }
+
         if (sessionExists) {
-            await this.store.extract({
-                session: this.sessionName,
-                path: compressedSessionPath,
-            });
+            await this.store.extract({ session: sessionKey, path: compressedSessionPath });
             await this.unCompressSession(compressedSessionPath);
         } else {
             fs.mkdirSync(this.userDataDir, { recursive: true });
@@ -190,11 +180,9 @@ class RemoteAuth extends BaseAuthStrategy {
     }
 
     async deleteRemoteSession() {
-        const sessionExists = await this.store.sessionExists({
-            session: this.sessionName,
-        });
-        if (sessionExists)
-            await this.store.delete({ session: this.sessionName });
+        const sessionKey = path.join(this.dataPath, this.sessionName);
+        const sessionExists = await this.store.sessionExists({ session: sessionKey });
+        if (sessionExists) await this.store.delete({ session: sessionKey });
     }
 
     async compressSession() {


### PR DESCRIPTION
This patch makes RemoteAuth use a consistent session key when saving/extracting/checking sessions against remote stores, and prefers an existing local userDataDir instead of removing it. This fixes cases where a session uploaded to remote storage couldn't be found on restart due to mismatched session identifiers.\n\nChanges: use path.join(dataPath, sessionName) as the session key for store.save/sessionExists/extract/delete; prefer local userDataDir if present; add logging.