### PR TITLE
fix: deviceType name

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -103,7 +103,7 @@ class Message extends Base {
          * @type {string}
          */
         this.deviceType =
-            typeof data.id.id === 'string' && data.id.id.length > 21
+            typeof data.id.id === 'string' && data.id.id.length > 25
                 ? 'android'
                 : typeof data.id.id === 'string' &&
                     data.id.id.substring(0, 2) === '3A'


### PR DESCRIPTION
## Description

Change to the new standard for the number of WhatsApp IDs.

## Testing Summary

### Test Details

I carried out small tests on different platforms and numbers, it worked smoothly between web and Android, I don't have IOS to test, but it already worked before the correction

### Environment

WIndows 11
Node v24.13.0

- Machine OS:

Android 16

- Phone OS:

Latest version github

- Library Version:

latest

## Type of Change

<!-- Select all that apply: -->

- [ ] **Dependency change** _(package changes such as removals, upgrades, or additions)_
- [x] **Bug fix** _(non-breaking change that fixes an issue)_
- [ ] **New feature** _(non-breaking change that adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to change)_
- [ ] **Non-code change** _(documentation, README, etc.)_

## Checklist

<!-- Please confirm that all relevant items below have been completed. -->

- [x] My code follows the style guidelines of this project.
- [x] All new and existing tests pass (`npm test`).
- [ ] Typings (e.g. `index.d.ts`) have been updated if necessary.
- [ ] Usage examples (e.g. `example.js`) / documentation have been updated if applicable.
