### PR TITLE
fix: circumvent newsletter crash on profile pictures

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -2042,19 +2042,30 @@ class Client extends EventEmitter {
      * @returns {Promise<string>}
      */
     async getProfilePicUrl(contactId) {
-        const profilePic = await this.pupPage.evaluate(async (contactId) => {
+        const profilePicUrl = await this.pupPage.evaluate(async (contactId) => {
             try {
-                const chat = await window.WWebJS.getChat(contactId);
-                return await window
-                    .require('WAWebContactProfilePicThumbBridge')
-                    .requestProfilePicFromServer(chat);
+                const chatWid = window.require('WAWebWidFactory').createWid(contactId);
+                
+                // We force the synchronization so the thumb/picture is loaded 
+                // from the server if it's not already in memory.
+                // Using .catch() to silently ignore if it fails to find the thumbnail
+                await window.require('WAWebCollections').ProfilePicThumb.find(chatWid).catch(() => {});
+                
+                // We extract the URL directly from the ProfilePicThumb collection
+                // bypassing requestProfilePicFromServer completely
+                const thumb = window.require('WAWebCollections').ProfilePicThumb.get(chatWid);
+                if (thumb && thumb.eurl) {
+                    return thumb.eurl;
+                }
+                
+                return undefined;
             } catch (err) {
                 if (err.name === 'ServerStatusCodeError') return undefined;
                 throw err;
             }
         }, contactId);
 
-        return profilePic ? profilePic.eurl : undefined;
+        return profilePicUrl || undefined;
     }
 
     /**


### PR DESCRIPTION
## Description

This PR fixes a critical breaking change in WhatsApp Web's internal profile picture fetching logic. Recently, the method `Store.ProfilePic.requestProfilePicFromServer(wid)` began throwing a `TypeError: Cannot read properties of undefined (reading 'isNewsletter')` because it now expects a payload structure tailored for Newsletter (Channel) objects, causing it to crash when encountering standard contact WIDs.

The fix bypasses this broken method by:
1. Using `Store.ProfilePicThumb.find(wid)` to force a server-side fetch/cache of the thumbnail.
2. Directly retrieving the `eurl` (high-res URL) from the `ProfilePicThumb` collection, which does not trigger the `isNewsletter` validation crash.

## Related Issue(s)

Fixes several reports of profile pictures returning undefined or crashing since the latest WA Web updates.

## Testing Summary

### Test Details

- Manually tested by calling `client.getProfilePicUrl(jid)` for both saved and unsaved contacts.
- Verified that the high-resolution URL is correctly returned.
- Verified that failure to find a thumbnail (privacy settings) returns `undefined` gracefully instead of throwing a TypeError.

### Environment

- Machine OS: Windows 11
- Phone OS: Independent (Android/iOS)
- Library Version: 1.34.6
- WhatsApp Web Version: 2.3000.x (Latest)
- Browser Type and Version: Chromium (Puppeteer default)
- Node Version: 18+

## Type of Change

- [ ] **Dependency change**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Breaking change**
- [ ] **Non-code change**

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] All new and existing tests pass (`npm test`).
- [ ] Typings (e.g. `index.d.ts`) have been updated if necessary.
- [ ] Usage examples (e.g. `example.js`) / documentation have been updated if applicable.
