### PR TITLE
feat: support big file downloads (read from WA cache + streaming)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,6 +3,7 @@ dist
 coverage
 docs
 *.min.js
+*.d.ts
 .wa-version
 .wwebjs_auth
 .wwebjs_cache

--- a/example.js
+++ b/example.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const { Client, Location, Poll, List, Buttons, LocalAuth } = require('./index');
 
 const client = new Client({
@@ -232,6 +233,18 @@ client.on('message', async (msg) => {
             Platform: ${info.platform}
         `,
         );
+    } else if (msg.body === '!streamdownload' && msg.hasMedia) {
+        const result = await msg.downloadMediaStream();
+        if (result) {
+            const filePath = `./${result.filename || 'download'}`;
+            const writeStream = fs.createWriteStream(filePath);
+            result.stream.pipe(writeStream);
+            writeStream.on('finish', () => {
+                msg.reply(
+                    `Media saved to ${filePath} (${result.mimetype}, ${result.filesize} bytes)`,
+                );
+            });
+        }
     } else if (msg.body === '!mediainfo' && msg.hasMedia) {
         const attachmentData = await msg.downloadMedia();
         msg.reply(`

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import { Readable } from 'stream';
 import { RequestInit } from 'node-fetch';
 import * as puppeteer from 'puppeteer';
 import InterfaceController from './src/util/InterfaceController';
@@ -198,7 +199,7 @@ declare namespace WAWebJS {
         ): Promise<string>;
 
         /** Cancels an active pairing code session and returns to QR code mode */
-        cancelPairingCode(): Promise<void>
+        cancelPairingCode(): Promise<void>;
 
         /** Force reset of connection state for the client */
         resetState(): Promise<void>;
@@ -1302,7 +1303,9 @@ declare namespace WAWebJS {
         /** Deletes the message from the chat */
         delete: (everyone?: boolean, clearMedia?: boolean) => Promise<void>;
         /** Downloads and returns the attached message media */
-        downloadMedia: () => Promise<MessageMedia>;
+        downloadMedia: () => Promise<MessageMedia | undefined>;
+        /** Downloads the attached message media as a Node.js Readable stream */
+        downloadMediaStream: () => Promise<MessageMediaStream | undefined>;
         /** Returns the Chat this message was sent in */
         getChat: () => Promise<Chat>;
         /** Returns the Contact this message was sent from */
@@ -1610,8 +1613,18 @@ declare namespace WAWebJS {
         reqOptions?: RequestInit;
     }
 
+    /** Common metadata for media attached to a message */
+    export interface MessageMediaMetadata {
+        /** MIME type of the attachment */
+        mimetype: string;
+        /** Document file name. Value can be null */
+        filename?: string | null;
+        /** Document file size in bytes. Value can be null. */
+        filesize?: number | null;
+    }
+
     /** Media attached to a message */
-    export class MessageMedia {
+    export class MessageMedia implements MessageMediaMetadata {
         /** MIME type of the attachment */
         mimetype: string;
         /** Base64-encoded data of the file */
@@ -1642,6 +1655,11 @@ declare namespace WAWebJS {
             url: string,
             options?: MediaFromURLOptions,
         ) => Promise<MessageMedia>;
+    }
+
+    /** Result of downloadMediaStream: a Readable stream with media metadata */
+    export interface MessageMediaStream extends MessageMediaMetadata {
+        stream: Readable;
     }
 
     export type MessageContent =

--- a/index.d.ts
+++ b/index.d.ts
@@ -1305,7 +1305,9 @@ declare namespace WAWebJS {
         /** Downloads and returns the attached message media */
         downloadMedia: () => Promise<MessageMedia | undefined>;
         /** Downloads the attached message media as a Node.js Readable stream */
-        downloadMediaStream: () => Promise<MessageMediaStream | undefined>;
+        downloadMediaStream: (
+            options?: MediaStreamOptions,
+        ) => Promise<MessageMediaStream | undefined>;
         /** Returns the Chat this message was sent in */
         getChat: () => Promise<Chat>;
         /** Returns the Contact this message was sent from */
@@ -1655,6 +1657,12 @@ declare namespace WAWebJS {
             url: string,
             options?: MediaFromURLOptions,
         ) => Promise<MessageMedia>;
+    }
+
+    /** Options for downloadMediaStream */
+    export interface MediaStreamOptions {
+        /** Size in bytes of each chunk read from the browser (default 10MB) */
+        chunkSize?: number;
     }
 
     /** Result of downloadMediaStream: a Readable stream with media metadata */

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { Readable } = require('stream');
 const Base = require('./Base');
 const MessageMedia = require('./MessageMedia');
 const Location = require('./Location');
@@ -524,84 +525,25 @@ class Message extends Base {
     }
 
     /**
-     * Downloads and returns the attatched message media
-     * @returns {Promise<MessageMedia>}
+     * Downloads and returns the attached message media
+     * @returns {Promise<MessageMedia|undefined>}
      */
     async downloadMedia() {
-        if (!this.hasMedia) {
-            return undefined;
-        }
+        if (!this.hasMedia) return undefined;
 
         const result = await this.client.pupPage.evaluate(async (msgId) => {
-            const msg =
-                window.require('WAWebCollections').Msg.get(msgId) ||
-                (
-                    await window
-                        .require('WAWebCollections')
-                        .Msg.getMessagesById([msgId])
-                )?.messages?.[0];
+            const resolved = await window.WWebJS.resolveMediaBlob(msgId);
+            if (!resolved) return null;
 
-            // REUPLOADING mediaStage means the media is expired and the download button is spinning, cannot be downloaded now
-            if (
-                !msg ||
-                !msg.mediaData ||
-                msg.mediaData.mediaStage === 'REUPLOADING'
-            ) {
-                return null;
-            }
-            if (msg.mediaData.mediaStage != 'RESOLVED') {
-                // try to resolve media
-                await msg.downloadMedia({
-                    downloadEvenIfExpensive: true,
-                    rmrReason: 1,
-                });
-            }
-
-            if (
-                msg.mediaData.mediaStage.includes('ERROR') ||
-                msg.mediaData.mediaStage === 'FETCHING'
-            ) {
-                // media could not be downloaded
-                return undefined;
-            }
-
-            try {
-                const mockQpl = {
-                    addAnnotations: function () {
-                        return this;
-                    },
-                    addPoint: function () {
-                        return this;
-                    },
-                };
-                const decryptedMedia = await window
-                    .require('WAWebDownloadManager')
-                    .downloadManager.downloadAndMaybeDecrypt({
-                        directPath: msg.directPath,
-                        encFilehash: msg.encFilehash,
-                        filehash: msg.filehash,
-                        mediaKey: msg.mediaKey,
-                        mediaKeyTimestamp: msg.mediaKeyTimestamp,
-                        type: msg.type,
-                        signal: new AbortController().signal,
-                        downloadQpl: mockQpl,
-                    });
-
-                const data =
-                    await window.WWebJS.arrayBufferToBase64Async(
-                        decryptedMedia,
-                    );
-
-                return {
-                    data,
-                    mimetype: msg.mimetype,
-                    filename: msg.filename,
-                    filesize: msg.size,
-                };
-            } catch (e) {
-                if (e.status && e.status === 404) return undefined;
-                throw e;
-            }
+            const data = await window.WWebJS.arrayBufferToBase64Async(
+                await resolved.blob.arrayBuffer(),
+            );
+            return {
+                data,
+                mimetype: resolved.mimetype,
+                filename: resolved.filename,
+                filesize: resolved.filesize,
+            };
         }, this.id._serialized);
 
         if (!result) return undefined;
@@ -611,6 +553,91 @@ class Message extends Base {
             result.filename,
             result.filesize,
         );
+    }
+
+    /**
+     * Like downloadMedia(), but returns a Readable stream instead of loading the entire file into memory.
+     * @returns {Promise<MessageMediaStream|undefined>} undefined if media is unavailable
+     */
+    async downloadMediaStream() {
+        if (!this.hasMedia) return undefined;
+
+        const page = this.client.pupPage;
+        const resultHandle = await page.evaluateHandle(
+            (msgId) => window.WWebJS.resolveMediaBlob(msgId),
+            this.id._serialized,
+        );
+
+        const metadata = await resultHandle.evaluate((r) =>
+            r
+                ? {
+                      mimetype: r.mimetype,
+                      filename: r.filename,
+                      filesize: r.filesize,
+                  }
+                : null,
+        );
+        if (!metadata) {
+            await resultHandle.dispose();
+            return undefined;
+        }
+
+        const blobHandle = await resultHandle.evaluateHandle((r) => r.blob);
+        await resultHandle.dispose();
+
+        let cdp, ioHandle;
+        try {
+            cdp = await page.createCDPSession();
+            const { uuid } = await cdp.send('IO.resolveBlob', {
+                objectId: blobHandle.remoteObject().objectId,
+            });
+            ioHandle = `blob:${uuid}`;
+        } catch (err) {
+            await Promise.all([
+                cdp?.detach().catch(() => {}),
+                blobHandle.dispose(),
+            ]);
+            throw err;
+        }
+
+        const cleanup = () =>
+            Promise.all([
+                cdp.send('IO.close', { handle: ioHandle }).catch(() => {}),
+                cdp.detach().catch(() => {}),
+                blobHandle.dispose(),
+            ]);
+
+        const stream = new Readable({
+            read() {
+                cdp.send('IO.read', { handle: ioHandle, size: 65536 })
+                    .then(({ data, base64Encoded, eof }) => {
+                        this.push(
+                            Buffer.from(
+                                data,
+                                base64Encoded ? 'base64' : 'utf8',
+                            ),
+                        );
+                        if (eof) {
+                            this.push(null);
+                            cleanup();
+                        }
+                    })
+                    .catch((err) => {
+                        cleanup().then(
+                            () => this.destroy(err),
+                            () => this.destroy(err),
+                        );
+                    });
+            },
+            destroy(err, callback) {
+                cleanup().then(
+                    () => callback(err),
+                    () => callback(err),
+                );
+            },
+        });
+
+        return { stream, ...metadata };
     }
 
     /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -557,9 +557,11 @@ class Message extends Base {
 
     /**
      * Like downloadMedia(), but returns a Readable stream instead of loading the entire file into memory.
+     * @param {Object} [options]
+     * @param {number} [options.chunkSize=10485760] Size in bytes of each chunk read from the browser (default 10MB)
      * @returns {Promise<MessageMediaStream|undefined>} undefined if media is unavailable
      */
-    async downloadMediaStream() {
+    async downloadMediaStream({ chunkSize = 10 * 1024 * 1024 } = {}) {
         if (!this.hasMedia) return undefined;
 
         const page = this.client.pupPage;
@@ -609,7 +611,7 @@ class Message extends Base {
 
         const stream = new Readable({
             read() {
-                cdp.send('IO.read', { handle: ioHandle, size: 65536 })
+                cdp.send('IO.read', { handle: ioHandle, size: chunkSize })
                     .then(({ data, base64Encoded, eof }) => {
                         this.push(
                             Buffer.from(

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -564,82 +564,49 @@ class Message extends Base {
     async downloadMediaStream({ chunkSize = 10 * 1024 * 1024 } = {}) {
         if (!this.hasMedia) return undefined;
 
-        const page = this.client.pupPage;
-        const resultHandle = await page.evaluateHandle(
+        const resultHandle = await this.client.pupPage.evaluateHandle(
             (msgId) => window.WWebJS.resolveMediaBlob(msgId),
             this.id._serialized,
         );
 
-        const metadata = await resultHandle.evaluate((r) =>
+        const info = await resultHandle.evaluate((r) =>
             r
                 ? {
                       mimetype: r.mimetype,
                       filename: r.filename,
                       filesize: r.filesize,
+                      blobSize: r.blob.size,
                   }
                 : null,
         );
-        if (!metadata) {
+        if (!info) {
             await resultHandle.dispose();
             return undefined;
         }
 
         const blobHandle = await resultHandle.evaluateHandle((r) => r.blob);
         await resultHandle.dispose();
+        const { blobSize, ...metadata } = info;
 
-        let cdp, ioHandle;
-        try {
-            cdp = await page.createCDPSession();
-            const { uuid } = await cdp.send('IO.resolveBlob', {
-                objectId: blobHandle.remoteObject().objectId,
-            });
-            ioHandle = `blob:${uuid}`;
-        } catch (err) {
-            await Promise.all([
-                cdp?.detach().catch(() => {}),
-                blobHandle.dispose(),
-            ]);
-            throw err;
+        async function* readChunks() {
+            try {
+                for (let offset = 0; offset < blobSize; offset += chunkSize) {
+                    const base64 = await blobHandle.evaluate(
+                        async (blob, s, e) =>
+                            window.WWebJS.arrayBufferToBase64Async(
+                                await blob.slice(s, e).arrayBuffer(),
+                            ),
+                        offset,
+                        offset + chunkSize,
+                    );
+                    yield Buffer.from(base64, 'base64');
+                }
+            } finally {
+                await blobHandle.dispose();
+            }
         }
 
-        const cleanup = () =>
-            Promise.all([
-                cdp.send('IO.close', { handle: ioHandle }).catch(() => {}),
-                cdp.detach().catch(() => {}),
-                blobHandle.dispose(),
-            ]);
-
-        const stream = new Readable({
-            read() {
-                cdp.send('IO.read', { handle: ioHandle, size: chunkSize })
-                    .then(({ data, base64Encoded, eof }) => {
-                        this.push(
-                            Buffer.from(
-                                data,
-                                base64Encoded ? 'base64' : 'utf8',
-                            ),
-                        );
-                        if (eof) {
-                            this.push(null);
-                            cleanup();
-                        }
-                    })
-                    .catch((err) => {
-                        cleanup().then(
-                            () => this.destroy(err),
-                            () => this.destroy(err),
-                        );
-                    });
-            },
-            destroy(err, callback) {
-                cleanup().then(
-                    () => callback(err),
-                    () => callback(err),
-                );
-            },
-        });
-
-        return { stream, ...metadata };
+        return { stream: Readable.from(readChunks()), ...metadata };
     }
 
     /**

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1111,6 +1111,66 @@ exports.LoadUtils = () => {
         });
     };
 
+    /**
+     * Resolves the media blob and metadata for a message.
+     * Shared by downloadMedia and downloadMediaStream.
+     * @param {string} msgId
+     * @returns {Promise<{blob: Blob, mimetype: string, filename: string, filesize: number}|null>}
+     */
+    window.WWebJS.resolveMediaBlob = async (msgId) => {
+        const { Msg } = window.require('WAWebCollections');
+        const msg =
+            Msg.get(msgId) ||
+            (await Msg.getMessagesById([msgId]))?.messages?.[0];
+
+        if (
+            !msg ||
+            !msg.mediaData ||
+            msg.mediaData.mediaStage === 'REUPLOADING'
+        ) {
+            return null;
+        }
+
+        // Always call internal downloadMedia - never skip based on
+        // mediaStage, because cache eviction can leave stage=RESOLVED
+        // with empty InMemoryMediaBlobCache.
+        await msg.downloadMedia({
+            downloadEvenIfExpensive: true,
+            rmrReason: 1,
+            isUserInitiated: true,
+        });
+
+        if (
+            msg.mediaData.mediaStage.includes('ERROR') ||
+            msg.mediaData.mediaStage === 'FETCHING'
+        ) {
+            return null;
+        }
+
+        const cached = window
+            .require('WAWebMediaInMemoryBlobCache')
+            .InMemoryMediaBlobCache.get(msg.mediaObject?.filehash);
+
+        let blob;
+        if (cached) {
+            blob = cached;
+        } else if (msg.mediaObject?.mediaBlob) {
+            const ab = await window
+                .require('WAWebMediaDataUtils')
+                .opaqueDataToArrayBuffer(msg.mediaObject.mediaBlob);
+            blob = new Blob([ab]);
+        }
+
+        if (!blob) return null;
+
+        return {
+            blob,
+            mimetype: msg.mimetype,
+            filename: msg.filename,
+            filesize: msg.size,
+        };
+    };
+
     window.WWebJS.arrayBufferToBase64 = (arrayBuffer) => {
         let binary = '';
         const bytes = new Uint8Array(arrayBuffer);

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1155,10 +1155,7 @@ exports.LoadUtils = () => {
         if (cached) {
             blob = cached;
         } else if (msg.mediaObject?.mediaBlob) {
-            const ab = await window
-                .require('WAWebMediaDataUtils')
-                .opaqueDataToArrayBuffer(msg.mediaObject.mediaBlob);
-            blob = new Blob([ab]);
+            blob = msg.mediaObject.mediaBlob.forceToBlob();
         }
 
         if (!blob) return null;


### PR DESCRIPTION
## TL;DR

Read media from WhatsApp's own in-memory caches instead of re-downloading from CDN. Add `downloadMediaStream()` that streams data in configurable chunks (default 10MB) for big files without loading the entire file into memory.

---

## The problem

`downloadMedia` calls `downloadAndMaybeDecrypt` which re-downloads and decrypts media from WhatsApp's CDN on every call. This is unnecessary because the data is already sitting decrypted in the browser's memory after WhatsApp Web resolved the message.

It also means the entire file gets loaded into a single base64 string. A 25MB PDF turns into ~33MB of memory in one string with no way to process it in chunks.

Additionally, `downloadAndMaybeDecrypt` caches results through `LruMediaStore`, which has a hardcoded 30MB per-file limit (the constant `30000000` in WhatsApp's source). Files above that size can't be cached in the LRU store, forcing a CDN re-download every time.

## The fix

### Read from WhatsApp's own caches instead of re-downloading

When WhatsApp Web resolves a media message, it downloads, decrypts, and stores the result in two in-memory locations:

- `InMemoryMediaBlobCache` - LRU cache with a 250MB total pool and no per-file size limit
- `mediaObject.mediaBlob` - OpaqueData blob stored directly on the message's media object

This PR makes `downloadMedia` read directly from these caches. No CDN round-trip, no re-decryption, no LruMediaStore involvement at all.

For the `mediaBlob` path, `OpaqueData.forceToBlob()` returns the internal Blob directly without copying. The previous approach (`opaqueDataToArrayBuffer` + `new Blob`) created two full copies of the file in browser memory. For a 924MB file, that's ~1.8GB of unnecessary allocations eliminated.

### Add `downloadMediaStream()` for big files

Even with the cache fix, `downloadMedia` still loads everything into a base64 string. For large files that's a lot of memory.

`downloadMediaStream()` returns a Node.js `Readable` stream instead. It reads the Blob in chunks via `evaluateHandle` + `blob.slice()`, so the full file never sits in Node.js memory at once. Chunk size defaults to 10MB and is configurable:

```js
const result = await msg.downloadMediaStream();
// or with custom chunk size:
const result = await msg.downloadMediaStream({ chunkSize: 1024 * 1024 });
if (result) {
    result.stream.pipe(fs.createWriteStream(result.filename));
}
```

The implementation uses an async generator with `Readable.from()`, and `try/finally` ensures the browser-side Blob handle is disposed even if the consumer aborts mid-stream.

### Shared `resolveMediaBlob` utility

The cache-reading logic is extracted into `window.WWebJS.resolveMediaBlob(msgId)` so both `downloadMedia` and `downloadMediaStream` use the same resolution path. Returns `{ blob, mimetype, filename, filesize }` or `null`.

### Other changes

- `.eslintignore`: added `*.d.ts` so ESLint doesn't fail on the TypeScript declaration file
- `index.d.ts`: added `MessageMediaMetadata`, `MessageMediaStream`, `MediaStreamOptions` interfaces, `downloadMediaStream` method, fixed `downloadMedia` return type to include `| undefined`
- `example.js`: added `!streamdownload` example command

## Before vs after

**Before:** `msg.downloadMedia()` -> re-download from CDN -> decrypt -> base64 string in memory

**After:** `msg.downloadMedia()` -> read from browser cache (zero-copy via forceToBlob) -> base64 string in memory

**After (streaming):** `msg.downloadMediaStream()` -> read from browser cache -> 10MB chunks via Readable stream (only 1-2 chunks in memory at a time)