### PR TITLE
fix(revoke): use protocolMessageKey for original message ID

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -664,35 +664,28 @@ class Client extends EventEmitter {
             },
         );
 
-        let last_message;
-
         await exposeFunctionIfAbsent(
             this.pupPage,
             'onChangeMessageTypeEvent',
             (msg) => {
-                if (msg.type === 'revoked') {
-                    const message = new Message(this, msg);
-                    let revoked_msg;
-                    if (last_message && msg.id.id === last_message.id.id) {
-                        revoked_msg = new Message(this, last_message);
+                const originalKey = msg.protocolMessageKey;
+                const message = new Message(this, { ...msg, id: originalKey });
+                const revoked_msg = originalKey
+                    ? new Message(this, { id: originalKey })
+                    : undefined;
 
-                        if (message.protocolMessageKey)
-                            revoked_msg.id = { ...message.protocolMessageKey };
-                    }
-
-                    /**
-                     * Emitted when a message is deleted for everyone in the chat.
-                     * @event Client#message_revoke_everyone
-                     * @param {Message} message The message that was revoked, in its current state. It will not contain the original message's data.
-                     * @param {?Message} revoked_msg The message that was revoked, before it was revoked. It will contain the message's original data.
-                     * Note that due to the way this data is captured, it may be possible that this param will be undefined.
-                     */
-                    this.emit(
-                        Events.MESSAGE_REVOKED_EVERYONE,
-                        message,
-                        revoked_msg,
-                    );
-                }
+                /**
+                 * Emitted when a message is deleted for everyone in the chat.
+                 * @event Client#message_revoke_everyone
+                 * @param {Message} message The message that was revoked, in its current state. It will not contain the original message's data.
+                 * @param {?Message} revoked_msg The message that was revoked, before it was revoked. It will contain the message's original data.
+                 * Note that due to the way this data is captured, it may be possible that this param will be undefined.
+                 */
+                this.emit(
+                    Events.MESSAGE_REVOKED_EVERYONE,
+                    message,
+                    revoked_msg,
+                );
             },
         );
 
@@ -700,10 +693,6 @@ class Client extends EventEmitter {
             this.pupPage,
             'onChangeMessageEvent',
             (msg) => {
-                if (msg.type !== 'revoked') {
-                    last_message = msg;
-                }
-
                 /**
                  * The event notification that is received when one of
                  * the group participants changes their phone number.
@@ -1032,6 +1021,7 @@ class Client extends EventEmitter {
                 window.onChangeMessageEvent(window.WWebJS.getMessageModel(msg));
             });
             Msg.on('change:type', (msg) => {
+                if (msg.type !== 'revoked') return;
                 window.onChangeMessageTypeEvent(
                     window.WWebJS.getMessageModel(msg),
                 );


### PR DESCRIPTION
## TL;DR

When someone deletes a message for everyone, WWJS reports the wrong message ID. This fix reads the original ID directly from the message model instead of relying on a broken cache.

## The problem

When a message is revoked, WhatsApp replaces its ID with a new one. The `message_revoke_everyone` event should report the original ID so consumers can match it to the message they already stored, but WWJS was reporting the new (post-revoke) ID instead.

The old code tried to work around this with a `last_message` variable that saved the most recent message and compared it when a revoke arrived. This was unreliable because the IDs don't match after revoke, and a single variable can only track one message at a time.

## The fix

WhatsApp stores the original message key on the revoked model as `protocolMessageKey`. This PR reads it directly instead of guessing from a cache.

- Reads `msg.protocolMessageKey` to get the original ID
- Creates the message object with the original ID: `new Message(this, { ...msg, id: originalKey })`
- Removes the `last_message` cache
- Skips serialization for non-revoke type changes in the browser listener

## Why this is safe

Verified from WhatsApp's bundle source code: every revoke goes through a single code path that always sets `protocolMessageKey` to the original key. It's stored as a persistent property on the model, so it survives serialization.

## Testing

- Verified all assumptions from WhatsApp's bundle source code
- Ran a version with verification logs in production across multiple accounts for 3 weeks
- 500 revoke events analyzed: `protocolMessageKey` was present and correct in 100% of cases
- No edge cases or failures observed