### PR TITLE
feat(client): move `sendReaction` method to the Client

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -210,6 +210,12 @@ declare namespace WAWebJS {
             options?: MessageSendOptions,
         ): Promise<Message>;
 
+        /** Send a reaction to a specific messageId */
+        sendReaction(
+            messageId: string,
+            reaction: string,
+        ): Promise<void>;
+
         /** Sends a channel admin invitation to a user, allowing them to become an admin of the channel */
         sendChannelAdminInvite(
             chatId: string,

--- a/src/Client.js
+++ b/src/Client.js
@@ -1541,6 +1541,33 @@ class Client extends EventEmitter {
     }
 
     /**
+     * Send an emoji reaction to a specific message
+     * @param {string} messageId - Id of the message to add the reaction.
+     * @param {string} reaction  - Emoji to react with. Send an empty string to remove the reaction.
+     * @return {Promise}
+     */
+    async sendReaction(messageId, reaction) {
+        await this.pupPage.evaluate(
+            async (messageId, reaction) => {
+                if (!messageId) return null;
+                const msg =
+                    window.require('WAWebCollections').Msg.get(messageId) ||
+                    (
+                        await window
+                            .require('WAWebCollections')
+                            .Msg.getMessagesById([messageId])
+                    )?.messages?.[0];
+                if (!msg) return null;
+                await window
+                    .require('WAWebSendReactionMsgAction')
+                    .sendReactionToMsg(msg, reaction);
+            },
+            messageId,
+            reaction,
+        );
+    }
+
+    /**
      * @typedef {Object} SendChannelAdminInviteOptions
      * @property {?string} comment The comment to be added to an invitation
      */

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -477,24 +477,7 @@ class Message extends Base {
      * @return {Promise}
      */
     async react(reaction) {
-        await this.client.pupPage.evaluate(
-            async (messageId, reaction) => {
-                if (!messageId) return null;
-                const msg =
-                    window.require('WAWebCollections').Msg.get(messageId) ||
-                    (
-                        await window
-                            .require('WAWebCollections')
-                            .Msg.getMessagesById([messageId])
-                    )?.messages?.[0];
-                if (!msg) return null;
-                await window
-                    .require('WAWebSendReactionMsgAction')
-                    .sendReactionToMsg(msg, reaction);
-            },
-            this.id._serialized,
-            reaction,
-        );
+        return this.client.sendReaction(this.id._serialized, reaction);
     }
 
     /**


### PR DESCRIPTION
# PR Details

`Message.react` moved to `Client.sendReaction` (and the old `Message.react` now calls
`this.client.sendReaction)

## Description

The new method created from `Message.react`, and the original method now calls the new one. 

## Motivation and Context

With this method it is possible to send reactions to any message, not only to the just received message, or fetched by "load/fetch messages"

## How Has This Been Tested

Basically, the code were just moved, so I called both: 

- msg.react
- client.sendReaction

and both worked in private/group messages.

### Environment

I've tested with `whatsapp-web.js@1.34.6` inside a `node:24.12.0-alpine3.23` (linux) docker image.

webVersion: "2.3000.1036705643"

## Types of changes

- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] All new and existing tests pass (`npm test`).
- [x] Typings (e.g. `index.d.ts`) have been updated if necessary.
- [x] Usage examples (e.g. `example.js`) / documentation have been updated if applicable.

## Related PRs

- replaces #4004 