### PR TITLE
ci: add PR body validation against template

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -47,3 +47,68 @@ jobs:
                     echo "❌ PR title does not match the required format!"
                     exit 1
                   fi
+
+    validate-body:
+        name: Validate body
+        runs-on: ubuntu-latest
+        steps:
+            - name: Validate pull request body
+              env:
+                  BODY: ${{ github.event.pull_request.body }}
+              run: |
+                  errors=()
+
+                  # Strip HTML comments
+                  clean=$(echo "$BODY" | sed 's/<!--.*-->//g')
+
+                  # Check required sections
+                  for section in "## Description" "## Testing Summary" "## Type of Change" "## Checklist"; do
+                    if ! echo "$BODY" | grep -q "$section"; then
+                      errors+=("Missing section: $section")
+                    fi
+                  done
+
+                  # Check Description has content
+                  desc=$(echo "$clean" | sed -n '/^## Description/,/^## /p' | sed '1d;$d' | xargs)
+                  if [ -z "$desc" ]; then
+                    errors+=("Description section is empty")
+                  fi
+
+                  # Check Test Details has content
+                  test_details=$(echo "$clean" | sed -n '/^### Test Details/,/^##\|^###/p' | sed '1d;$d' | xargs)
+                  if [ -z "$test_details" ]; then
+                    errors+=("Test Details section is empty")
+                  fi
+
+                  # Check Environment fields are filled
+                  for field in "Machine OS" "Phone OS" "Library Version" "WhatsApp Web Version" "Browser Type and Version" "Node Version"; do
+                    line=$(echo "$clean" | grep -E "^- ${field}:" || true)
+                    value=$(echo "$line" | sed "s/^- ${field}://" | xargs)
+                    if [ -z "$value" ]; then
+                      errors+=("Environment field not filled: $field")
+                    fi
+                  done
+
+                  # Check at least one checkbox is checked in Type of Change
+                  type_section=$(echo "$BODY" | sed -n '/^## Type of Change/,/^## /p')
+                  if ! echo "$type_section" | grep -q "\[x\]"; then
+                    errors+=("No type of change selected")
+                  fi
+
+                  # Check at least one checkbox is checked in Checklist
+                  checklist_section=$(echo "$BODY" | sed -n '/^## Checklist/,/^## \|$/p')
+                  if ! echo "$checklist_section" | grep -q "\[x\]"; then
+                    errors+=("No checklist item checked")
+                  fi
+
+                  if [ ${#errors[@]} -gt 0 ]; then
+                    echo "❌ PR body does not match the required template:"
+                    for err in "${errors[@]}"; do
+                      echo "  - $err"
+                    done
+                    echo ""
+                    echo "Please follow the PR template: .github/pull_request_template.md"
+                    exit 1
+                  fi
+
+                  echo "✅ PR body matches the template"


### PR DESCRIPTION
## Description

Adds a `validate-body` job to the PR triage workflow that checks PR descriptions against the PR template. The check verifies:

- Required sections exist (Description, Testing Summary, Type of Change, Checklist)
- Description and Test Details have actual content (not just HTML comment placeholders)
- All Environment fields are filled in (Machine OS, Phone OS, Library Version, WhatsApp Web Version, Browser Type and Version, Node Version)
- At least one Type of Change checkbox is checked
- At least one Checklist checkbox is checked

This helps maintainers by catching incomplete PRs automatically instead of having to review and close them manually.

## Testing Summary

### Test Details

Ran the validation script locally against multiple PR bodies:
- Raw unfilled template: correctly fails with all fields missing
- Valid fully-filled body: passes
- Body without template structure: correctly fails with missing sections
- Body with HTML comments but no real content: correctly fails

### Environment

- Machine OS: Windows 11
- Phone OS: Android 14
- Library Version: 1.34.6
- WhatsApp Web Version: 2.3000.1036713926
- Browser Type and Version: Chromium 138.0.7204.251
- Node Version: 22.20.0

## Type of Change

- [ ] **Dependency change** _(package changes such as removals, upgrades, or additions)_
- [ ] **Bug fix** _(non-breaking change that fixes an issue)_
- [ ] **New feature** _(non-breaking change that adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to change)_
- [x] **Non-code change** _(documentation, README, etc.)_

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] All new and existing tests pass (`npm test`).
- [ ] Typings (e.g. `index.d.ts`) have been updated if necessary.
- [ ] Usage examples (e.g. `example.js`) / documentation have been updated if applicable.