### PR TITLE
ci: add PR body validation against template

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -47,3 +47,53 @@ jobs:
                     echo "❌ PR title does not match the required format!"
                     exit 1
                   fi
+
+    validate-body:
+        name: Validate body
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/github-script@v7
+              with:
+                  script: |
+                      const tmpl = require('fs').readFileSync('.github/pull_request_template.md', 'utf8');
+                      const body = context.payload.pull_request.body || '';
+                      const stripComments = s => s.replace(/<!--[\s\S]*?-->/g, '');
+                      const cleanTmpl = stripComments(tmpl);
+                      const cleanBody = stripComments(body);
+
+                      function findMissingSections() {
+                        return [...cleanTmpl.matchAll(/^(#{2,3} .+)$/gm)]
+                          .filter(([, h]) => !body.includes(h))
+                          .map(([, h]) => `Missing: ${h}`);
+                      }
+
+                      function findEmptySubsections() {
+                        return [...cleanBody.matchAll(/^(### .+)\n([\s\S]*?)(?=\n##|$(?![\s\S]))/gm)]
+                          .filter(([, , content]) => !content.trim())
+                          .map(([, heading]) => `Empty: ${heading}`);
+                      }
+
+                      function findUnfilledFields() {
+                        const bodyLines = cleanBody.split('\n');
+                        return [...cleanTmpl.matchAll(/^- (.+):\s*$/gm)]
+                          .filter(([, field]) => {
+                            const line = bodyLines.find(l => l.startsWith(`- ${field}:`));
+                            return !line || !line.slice(field.length + 3).trim();
+                          })
+                          .map(([, field]) => `Unfilled: - ${field}`);
+                      }
+
+                      function findUncheckedSections() {
+                        return [...body.matchAll(/^(## .+)\n([\s\S]*?)(?=\n## |$(?![\s\S]))/gm)]
+                          .filter(([, , content]) => /\[ \]/.test(content) && !/\[x\]/i.test(content))
+                          .map(([, heading]) => `Unchecked: ${heading}`);
+                      }
+
+                      const errors = [
+                        ...findMissingSections(),
+                        ...findEmptySubsections(),
+                        ...findUnfilledFields(),
+                        ...findUncheckedSections(),
+                      ];
+                      if (errors.length) core.setFailed(errors.join('\n'));


### PR DESCRIPTION
## Description

I had a PR closed because I didn't follow the template, and I noticed this happens a lot to other contributors too. Instead of maintainers having to check each PR manually and close the ones that don't comply, this adds an automated CI check that catches it right away.

It reads the template file at runtime, so if you ever change the template the check just works - nothing hardcoded.

It catches:
- Missing sections
- Subsections left empty (just the HTML comment placeholder, nothing else)
- Environment fields not filled in
- Checkbox sections where nothing was selected

Zero dependencies, just a few lines of JS inside actions/github-script.

## Testing Summary

### Test Details

Tested on my fork with both valid and invalid PR descriptions. Also ran 14 edge cases locally - empty body, raw template copy-pasted without changes, CRLF line endings, uppercase [X], fields with colons in the value, sections in a different order, multiline HTML comments, etc. All good.

### Environment

- Machine OS: Windows 11
- Phone OS: Android 14
- Library Version: 1.34.6
- WhatsApp Web Version: 2.3000.1036713926
- Browser Type and Version: Chromium 138.0.7204.251
- Node Version: 22.20.0

## Type of Change

- [ ] **Dependency change** _(package changes such as removals, upgrades, or additions)_
- [ ] **Bug fix** _(non-breaking change that fixes an issue)_
- [x] **New feature** _(non-breaking change that adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to change)_
- [ ] **Non-code change** _(documentation, README, etc.)_

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] All new and existing tests pass (`npm test`).
- [ ] Typings (e.g. `index.d.ts`) have been updated if necessary.
- [ ] Usage examples (e.g. `example.js`) / documentation have been updated if applicable.