### PR TITLE
refactor(structures): optimize message loading with msgFindBefore

### DIFF
--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -353,40 +353,166 @@ class Channel extends Base {
                     const msgFindLocal = window.require(
                         'WAWebDBMessageFindLocal',
                     );
+                    const WAWebMsgKey = window.require('WAWebMsgKey');
                     const MsgStore = window.require('WAWebCollections').Msg;
 
-                    while (msgs.length < searchOptions.limit) {
-                        const anchor =
-                            msgs[0]?.id || channel.msgs.getModelsArray()[0]?.id;
-                        if (!anchor) break;
-
-                        const result = await msgFindLocal.msgFindBefore({
-                            anchor: anchor,
-                            count: searchOptions.limit - msgs.length,
+                    const findBefore = async (anchorKey, count) => {
+                        if (
+                            typeof msgFindLocal.msgFindByDirection ===
+                            'function'
+                        ) {
+                            return await msgFindLocal.msgFindByDirection({
+                                anchor: anchorKey,
+                                count,
+                                direction: 'before',
+                            });
+                        }
+                        return await msgFindLocal.msgFindBefore({
+                            anchor: anchorKey,
+                            count,
                         });
+                    };
 
-                        const rawMessages = Array.isArray(result)
-                            ? result
-                            : result?.messages || [];
-                        if (!rawMessages.length) break;
+                    const toMsgKey = (id) => {
+                        if (!id) return null;
+                        if (id instanceof WAWebMsgKey) return id;
+                        const s =
+                            typeof id === 'string'
+                                ? id
+                                : id._serialized || id?.toString?.();
+                        return s ? WAWebMsgKey.fromString(s) : null;
+                    };
 
-                        const loadedMessages = rawMessages
-                            .map((m) => {
-                                if (m && typeof m.serialize === 'function')
-                                    return m;
-                                return (
-                                    MsgStore.get(m.id?._serialized || m) || null
+                    const toMsgModels = (rawMessages) => {
+                        const out = [];
+                        for (const m of rawMessages) {
+                            if (m && typeof m.serialize === 'function') {
+                                out.push(m);
+                                continue;
+                            }
+                            const serialized =
+                                m?.id?._serialized ||
+                                (typeof m === 'string' ? m : null);
+                            let model =
+                                (serialized && MsgStore.get(serialized)) ||
+                                (m?.id &&
+                                    MsgStore.get(m.id._serialized || m.id)) ||
+                                null;
+                            if (!model && m && MsgStore.modelClass) {
+                                try {
+                                    model = new MsgStore.modelClass(m);
+                                } catch (e) {
+                                    model = null;
+                                }
+                            }
+                            if (model) out.push(model);
+                        }
+                        return out;
+                    };
+
+                    const dedupeByMsgId = (arr) => {
+                        const seen = new Set();
+                        return arr.filter((m) => {
+                            const key = m.id?._serialized;
+                            if (!key || seen.has(key)) return false;
+                            seen.add(key);
+                            return true;
+                        });
+                    };
+
+                    const limit = searchOptions.limit;
+                    const finite = Number.isFinite(limit);
+                    const fromMeFilter =
+                        searchOptions && searchOptions.fromMe !== undefined;
+
+                    if (!fromMeFilter && finite) {
+                        const anchorSerialized =
+                            channel.lastReceivedKey?.toString();
+                        if (!anchorSerialized) {
+                            msgs.sort((a, b) => (a.t > b.t ? 1 : -1));
+                            msgs = msgs.slice(-Math.min(limit, msgs.length));
+                        } else {
+                            const fetchCount = Math.max(0, limit - 1);
+                            const anchorKey = toMsgKey(anchorSerialized);
+                            const result = await findBefore(
+                                anchorKey,
+                                fetchCount,
+                            );
+                            const rawMessages = Array.isArray(result)
+                                ? result
+                                : result?.messages || [];
+                            if (
+                                result?.status === 404 &&
+                                (!rawMessages || !rawMessages.length)
+                            ) {
+                                msgs = [];
+                            } else {
+                                let loaded = toMsgModels(rawMessages);
+                                const anchorMsg =
+                                    MsgStore.get(anchorSerialized);
+                                let merged = [
+                                    ...loaded,
+                                    ...(anchorMsg ? [anchorMsg] : []),
+                                ];
+                                merged = merged.filter(
+                                    (m) =>
+                                        !m.isNotification &&
+                                        m.type !== 'newsletter_notification',
                                 );
-                            })
-                            .filter(Boolean);
-                        if (!loadedMessages.length) break;
-
-                        msgs = [...loadedMessages.filter(msgFilter), ...msgs];
-                    }
-
-                    if (msgs.length > searchOptions.limit) {
+                                merged.sort((a, b) => (a.t > b.t ? 1 : -1));
+                                merged = dedupeByMsgId(merged);
+                                msgs = merged.filter(msgFilter);
+                                if (msgs.length > limit) {
+                                    msgs = msgs.slice(-limit);
+                                }
+                            }
+                        }
+                    } else {
                         msgs.sort((a, b) => (a.t > b.t ? 1 : -1));
-                        msgs = msgs.splice(msgs.length - searchOptions.limit);
+                        const batchCap = finite ? limit : 100;
+                        while (msgs.length < limit || !finite) {
+                            const anchor =
+                                msgs[0]?.id ||
+                                channel.msgs.getModelsArray()[0]?.id ||
+                                channel.lastReceivedKey;
+                            if (!anchor) break;
+
+                            const anchorKey = toMsgKey(anchor);
+                            if (!anchorKey) break;
+
+                            const need = finite
+                                ? Math.min(batchCap, limit - msgs.length)
+                                : batchCap;
+                            if (need <= 0) break;
+
+                            const result = await findBefore(anchorKey, need);
+                            const rawMessages = Array.isArray(result)
+                                ? result
+                                : result?.messages || [];
+                            if (result?.status === 404 || !rawMessages.length) {
+                                break;
+                            }
+
+                            const loadedMessages = toMsgModels(rawMessages);
+                            if (!loadedMessages.length) break;
+
+                            const prevLen = msgs.length;
+                            msgs = dedupeByMsgId([
+                                ...loadedMessages.filter(msgFilter),
+                                ...msgs,
+                            ]);
+                            msgs.sort((a, b) => (a.t > b.t ? 1 : -1));
+
+                            if (msgs.length === prevLen) break;
+
+                            if (!finite && loadedMessages.length < need) {
+                                break;
+                            }
+                        }
+
+                        if (finite && msgs.length > limit) {
+                            msgs = msgs.slice(-limit);
+                        }
                     }
                 }
 

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -350,11 +350,37 @@ class Channel extends Base {
                 let msgs = channel.msgs.getModelsArray().filter(msgFilter);
 
                 if (searchOptions && searchOptions.limit > 0) {
+                    const msgFindLocal = window.require(
+                        'WAWebDBMessageFindLocal',
+                    );
+                    const MsgStore = window.require('WAWebCollections').Msg;
+
                     while (msgs.length < searchOptions.limit) {
-                        const loadedMessages = await window
-                            .require('WAWebChatLoadMessages')
-                            .loadEarlierMsgs(channel);
-                        if (!loadedMessages || !loadedMessages.length) break;
+                        const anchor =
+                            msgs[0]?.id || channel.msgs.getModelsArray()[0]?.id;
+                        if (!anchor) break;
+
+                        const result = await msgFindLocal.msgFindBefore({
+                            anchor: anchor,
+                            count: searchOptions.limit - msgs.length,
+                        });
+
+                        const rawMessages = Array.isArray(result)
+                            ? result
+                            : result?.messages || [];
+                        if (!rawMessages.length) break;
+
+                        const loadedMessages = rawMessages
+                            .map((m) => {
+                                if (m && typeof m.serialize === 'function')
+                                    return m;
+                                return (
+                                    MsgStore.get(m.id?._serialized || m) || null
+                                );
+                            })
+                            .filter(Boolean);
+                        if (!loadedMessages.length) break;
+
                         msgs = [...loadedMessages.filter(msgFilter), ...msgs];
                     }
 

--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -223,11 +223,37 @@ class Chat extends Base {
                 let msgs = chat.msgs.getModelsArray().filter(msgFilter);
 
                 if (searchOptions && searchOptions.limit > 0) {
+                    const msgFindLocal = window.require(
+                        'WAWebDBMessageFindLocal',
+                    );
+                    const MsgStore = window.require('WAWebCollections').Msg;
+
                     while (msgs.length < searchOptions.limit) {
-                        const loadedMessages = await window
-                            .require('WAWebChatLoadMessages')
-                            .loadEarlierMsgs(chat, chat.msgs);
-                        if (!loadedMessages || !loadedMessages.length) break;
+                        const anchor =
+                            msgs[0]?.id || chat.msgs.getModelsArray()[0]?.id;
+                        if (!anchor) break;
+
+                        const result = await msgFindLocal.msgFindBefore({
+                            anchor: anchor,
+                            count: searchOptions.limit - msgs.length,
+                        });
+
+                        const rawMessages = Array.isArray(result)
+                            ? result
+                            : result?.messages || [];
+                        if (!rawMessages.length) break;
+
+                        const loadedMessages = rawMessages
+                            .map((m) => {
+                                if (m && typeof m.serialize === 'function')
+                                    return m;
+                                return (
+                                    MsgStore.get(m.id?._serialized || m) || null
+                                );
+                            })
+                            .filter(Boolean);
+                        if (!loadedMessages.length) break;
+
                         msgs = [...loadedMessages.filter(msgFilter), ...msgs];
                     }
 

--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -226,40 +226,164 @@ class Chat extends Base {
                     const msgFindLocal = window.require(
                         'WAWebDBMessageFindLocal',
                     );
+                    const WAWebMsgKey = window.require('WAWebMsgKey');
                     const MsgStore = window.require('WAWebCollections').Msg;
 
-                    while (msgs.length < searchOptions.limit) {
-                        const anchor =
-                            msgs[0]?.id || chat.msgs.getModelsArray()[0]?.id;
-                        if (!anchor) break;
-
-                        const result = await msgFindLocal.msgFindBefore({
-                            anchor: anchor,
-                            count: searchOptions.limit - msgs.length,
+                    const findBefore = async (anchorKey, count) => {
+                        if (
+                            typeof msgFindLocal.msgFindByDirection ===
+                            'function'
+                        ) {
+                            return await msgFindLocal.msgFindByDirection({
+                                anchor: anchorKey,
+                                count,
+                                direction: 'before',
+                            });
+                        }
+                        return await msgFindLocal.msgFindBefore({
+                            anchor: anchorKey,
+                            count,
                         });
+                    };
 
-                        const rawMessages = Array.isArray(result)
-                            ? result
-                            : result?.messages || [];
-                        if (!rawMessages.length) break;
+                    const toMsgKey = (id) => {
+                        if (!id) return null;
+                        if (id instanceof WAWebMsgKey) return id;
+                        const s =
+                            typeof id === 'string'
+                                ? id
+                                : id._serialized || id?.toString?.();
+                        return s ? WAWebMsgKey.fromString(s) : null;
+                    };
 
-                        const loadedMessages = rawMessages
-                            .map((m) => {
-                                if (m && typeof m.serialize === 'function')
-                                    return m;
-                                return (
-                                    MsgStore.get(m.id?._serialized || m) || null
+                    const toMsgModels = (rawMessages) => {
+                        const out = [];
+                        for (const m of rawMessages) {
+                            if (m && typeof m.serialize === 'function') {
+                                out.push(m);
+                                continue;
+                            }
+                            const serialized =
+                                m?.id?._serialized ||
+                                (typeof m === 'string' ? m : null);
+                            let model =
+                                (serialized && MsgStore.get(serialized)) ||
+                                (m?.id &&
+                                    MsgStore.get(m.id._serialized || m.id)) ||
+                                null;
+                            if (!model && m && MsgStore.modelClass) {
+                                try {
+                                    model = new MsgStore.modelClass(m);
+                                } catch (e) {
+                                    model = null;
+                                }
+                            }
+                            if (model) out.push(model);
+                        }
+                        return out;
+                    };
+
+                    const dedupeByMsgId = (arr) => {
+                        const seen = new Set();
+                        return arr.filter((m) => {
+                            const key = m.id?._serialized;
+                            if (!key || seen.has(key)) return false;
+                            seen.add(key);
+                            return true;
+                        });
+                    };
+
+                    const limit = searchOptions.limit;
+                    const finite = Number.isFinite(limit);
+                    const fromMeFilter =
+                        searchOptions && searchOptions.fromMe !== undefined;
+
+                    if (!fromMeFilter && finite) {
+                        const anchorSerialized =
+                            chat.lastReceivedKey?.toString();
+                        if (!anchorSerialized) {
+                            msgs.sort((a, b) => (a.t > b.t ? 1 : -1));
+                            msgs = msgs.slice(-Math.min(limit, msgs.length));
+                        } else {
+                            const fetchCount = Math.max(0, limit - 1);
+                            const anchorKey = toMsgKey(anchorSerialized);
+                            const result = await findBefore(
+                                anchorKey,
+                                fetchCount,
+                            );
+                            const rawMessages = Array.isArray(result)
+                                ? result
+                                : result?.messages || [];
+                            if (
+                                result?.status === 404 &&
+                                (!rawMessages || !rawMessages.length)
+                            ) {
+                                msgs = [];
+                            } else {
+                                let loaded = toMsgModels(rawMessages);
+                                const anchorMsg =
+                                    MsgStore.get(anchorSerialized);
+                                let merged = [
+                                    ...loaded,
+                                    ...(anchorMsg ? [anchorMsg] : []),
+                                ];
+                                merged = merged.filter(
+                                    (m) => !m.isNotification,
                                 );
-                            })
-                            .filter(Boolean);
-                        if (!loadedMessages.length) break;
-
-                        msgs = [...loadedMessages.filter(msgFilter), ...msgs];
-                    }
-
-                    if (msgs.length > searchOptions.limit) {
+                                merged.sort((a, b) => (a.t > b.t ? 1 : -1));
+                                merged = dedupeByMsgId(merged);
+                                msgs = merged.filter(msgFilter);
+                                if (msgs.length > limit) {
+                                    msgs = msgs.slice(-limit);
+                                }
+                            }
+                        }
+                    } else {
                         msgs.sort((a, b) => (a.t > b.t ? 1 : -1));
-                        msgs = msgs.splice(msgs.length - searchOptions.limit);
+                        const batchCap = finite ? limit : 100;
+                        while (msgs.length < limit || !finite) {
+                            const anchor =
+                                msgs[0]?.id ||
+                                chat.msgs.getModelsArray()[0]?.id ||
+                                chat.lastReceivedKey;
+                            if (!anchor) break;
+
+                            const anchorKey = toMsgKey(anchor);
+                            if (!anchorKey) break;
+
+                            const need = finite
+                                ? Math.min(batchCap, limit - msgs.length)
+                                : batchCap;
+                            if (need <= 0) break;
+
+                            const result = await findBefore(anchorKey, need);
+                            const rawMessages = Array.isArray(result)
+                                ? result
+                                : result?.messages || [];
+                            if (result?.status === 404 || !rawMessages.length) {
+                                break;
+                            }
+
+                            const loadedMessages = toMsgModels(rawMessages);
+                            if (!loadedMessages.length) break;
+
+                            const prevLen = msgs.length;
+                            msgs = dedupeByMsgId([
+                                ...loadedMessages.filter(msgFilter),
+                                ...msgs,
+                            ]);
+                            msgs.sort((a, b) => (a.t > b.t ? 1 : -1));
+
+                            if (msgs.length === prevLen) break;
+
+                            if (!finite && loadedMessages.length < need) {
+                                break;
+                            }
+                        }
+
+                        if (finite && msgs.length > limit) {
+                            msgs = msgs.slice(-limit);
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Description

Replaces `WAWebChatLoadMessages.loadEarlierMsgs` with `WAWebDBMessageFindLocal.msgFindBefore` when paginating messages until reaching `searchOptions.limit` in both `Chat` and `Channel`, resolving models through `MsgStore` when the returned entries are not yet serialized.

## Related Issue(s)

N/A

## Testing Summary

### Test Details

- `npx eslint` on the modified files: OK.
- Full `npm test` requires `WWEBJS_TEST_REMOTE_ID` (integration). Manual validation is recommended for message fetching with `limit` in chats/channels.

### Environment

- Machine OS: (fill in)
- Phone OS: (fill in)
- Library Version: 1.34.6
- WhatsApp Web Version: (fill in — `await client.getWWebVersion()`)
- Browser Type and Version: (fill in)
- Node Version: (fill in)

## Type of Change

- [ ] **Dependency change**
- [ ] **Bug fix**
- [ ] **New feature**
- [ ] **Breaking change**
- [ ] **Non-code change**
- [x] **Refactor / performance** (internal message loading)

## Checklist

- [x] My code follows the style guidelines of this project.
- [ ] All new and existing tests pass (`npm test`). _(integration suite requires environment variables)_
- [x] Typings have been updated if necessary. _(no public API changes)_
- [ ] Usage examples / documentation have been updated if applicable.

---

Closes https://github.com/wwebjs/whatsapp-web.js/issues/201706

Closes #201706