### PR TITLE
fix(structures): fix fetchMessages pagination and dropped in-memory msgs

### DIFF
--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -356,6 +356,7 @@ class Channel extends Base {
                     const WAWebMsgKey = window.require('WAWebMsgKey');
                     const MsgStore = window.require('WAWebCollections').Msg;
 
+                    // msgFindByDirection is the newer API; fall back to msgFindBefore on older WA Web versions
                     const findBefore = async (anchorKey, count) => {
                         if (
                             typeof msgFindLocal.msgFindByDirection ===
@@ -445,7 +446,11 @@ class Channel extends Base {
                                 result?.status === 404 &&
                                 (!rawMessages || !rawMessages.length)
                             ) {
-                                msgs = [];
+                                // anchor not in local DB — fall back to in-memory msgs (same as the !anchorSerialized branch above)
+                                msgs.sort((a, b) => (a.t > b.t ? 1 : -1));
+                                msgs = msgs.slice(
+                                    -Math.min(limit, msgs.length),
+                                );
                             } else {
                                 let loaded = toMsgModels(rawMessages);
                                 const anchorMsg =
@@ -453,6 +458,7 @@ class Channel extends Base {
                                 let merged = [
                                     ...loaded,
                                     ...(anchorMsg ? [anchorMsg] : []),
+                                    // include in-memory msgs so recent (not-yet-persisted) messages aren't dropped
                                     ...msgs,
                                 ];
                                 merged = merged.filter(

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -350,17 +350,170 @@ class Channel extends Base {
                 let msgs = channel.msgs.getModelsArray().filter(msgFilter);
 
                 if (searchOptions && searchOptions.limit > 0) {
-                    while (msgs.length < searchOptions.limit) {
-                        const loadedMessages = await window
-                            .require('WAWebChatLoadMessages')
-                            .loadEarlierMsgs(channel);
-                        if (!loadedMessages || !loadedMessages.length) break;
-                        msgs = [...loadedMessages.filter(msgFilter), ...msgs];
-                    }
+                    const msgFindLocal = window.require(
+                        'WAWebDBMessageFindLocal',
+                    );
+                    const WAWebMsgKey = window.require('WAWebMsgKey');
+                    const MsgStore = window.require('WAWebCollections').Msg;
 
-                    if (msgs.length > searchOptions.limit) {
+                    const findBefore = async (anchorKey, count) => {
+                        if (
+                            typeof msgFindLocal.msgFindByDirection ===
+                            'function'
+                        ) {
+                            return await msgFindLocal.msgFindByDirection({
+                                anchor: anchorKey,
+                                count,
+                                direction: 'before',
+                            });
+                        }
+                        return await msgFindLocal.msgFindBefore({
+                            anchor: anchorKey,
+                            count,
+                        });
+                    };
+
+                    const toMsgKey = (id) => {
+                        if (!id) return null;
+                        if (id instanceof WAWebMsgKey) return id;
+                        const s =
+                            typeof id === 'string'
+                                ? id
+                                : id._serialized || id?.toString?.();
+                        return s ? WAWebMsgKey.fromString(s) : null;
+                    };
+
+                    const toMsgModels = (rawMessages) => {
+                        const out = [];
+                        for (const m of rawMessages) {
+                            if (m && typeof m.serialize === 'function') {
+                                out.push(m);
+                                continue;
+                            }
+                            const serialized =
+                                m?.id?._serialized ||
+                                (typeof m === 'string' ? m : null);
+                            let model =
+                                (serialized && MsgStore.get(serialized)) ||
+                                (m?.id &&
+                                    MsgStore.get(m.id._serialized || m.id)) ||
+                                null;
+                            if (!model && m && MsgStore.modelClass) {
+                                try {
+                                    model = new MsgStore.modelClass(m);
+                                } catch (e) {
+                                    model = null;
+                                }
+                            }
+                            if (model) out.push(model);
+                        }
+                        return out;
+                    };
+
+                    const dedupeByMsgId = (arr) => {
+                        const seen = new Set();
+                        return arr.filter((m) => {
+                            const key = m.id?._serialized;
+                            if (!key || seen.has(key)) return false;
+                            seen.add(key);
+                            return true;
+                        });
+                    };
+
+                    const limit = searchOptions.limit;
+                    const finite = Number.isFinite(limit);
+                    const fromMeFilter =
+                        searchOptions && searchOptions.fromMe !== undefined;
+
+                    if (!fromMeFilter && finite) {
+                        const anchorSerialized =
+                            channel.lastReceivedKey?.toString();
+                        if (!anchorSerialized) {
+                            msgs.sort((a, b) => (a.t > b.t ? 1 : -1));
+                            msgs = msgs.slice(-Math.min(limit, msgs.length));
+                        } else {
+                            const fetchCount = Math.max(0, limit - 1);
+                            const anchorKey = toMsgKey(anchorSerialized);
+                            const result = await findBefore(
+                                anchorKey,
+                                fetchCount,
+                            );
+                            const rawMessages = Array.isArray(result)
+                                ? result
+                                : result?.messages || [];
+                            if (
+                                result?.status === 404 &&
+                                (!rawMessages || !rawMessages.length)
+                            ) {
+                                msgs = [];
+                            } else {
+                                let loaded = toMsgModels(rawMessages);
+                                const anchorMsg =
+                                    MsgStore.get(anchorSerialized);
+                                let merged = [
+                                    ...loaded,
+                                    ...(anchorMsg ? [anchorMsg] : []),
+                                    ...msgs,
+                                ];
+                                merged = merged.filter(
+                                    (m) =>
+                                        !m.isNotification &&
+                                        m.type !== 'newsletter_notification',
+                                );
+                                merged.sort((a, b) => (a.t > b.t ? 1 : -1));
+                                merged = dedupeByMsgId(merged);
+                                msgs = merged.filter(msgFilter);
+                                if (msgs.length > limit) {
+                                    msgs = msgs.slice(-limit);
+                                }
+                            }
+                        }
+                    } else {
                         msgs.sort((a, b) => (a.t > b.t ? 1 : -1));
-                        msgs = msgs.splice(msgs.length - searchOptions.limit);
+                        const batchCap = finite ? limit : 100;
+                        while (msgs.length < limit || !finite) {
+                            const anchor =
+                                msgs[0]?.id ||
+                                channel.msgs.getModelsArray()[0]?.id ||
+                                channel.lastReceivedKey;
+                            if (!anchor) break;
+
+                            const anchorKey = toMsgKey(anchor);
+                            if (!anchorKey) break;
+
+                            const need = finite
+                                ? Math.min(batchCap, limit - msgs.length)
+                                : batchCap;
+                            if (need <= 0) break;
+
+                            const result = await findBefore(anchorKey, need);
+                            const rawMessages = Array.isArray(result)
+                                ? result
+                                : result?.messages || [];
+                            if (result?.status === 404 || !rawMessages.length) {
+                                break;
+                            }
+
+                            const loadedMessages = toMsgModels(rawMessages);
+                            if (!loadedMessages.length) break;
+
+                            const prevLen = msgs.length;
+                            msgs = dedupeByMsgId([
+                                ...loadedMessages.filter(msgFilter),
+                                ...msgs,
+                            ]);
+                            msgs.sort((a, b) => (a.t > b.t ? 1 : -1));
+
+                            if (msgs.length === prevLen) break;
+
+                            if (!finite && loadedMessages.length < need) {
+                                break;
+                            }
+                        }
+
+                        if (finite && msgs.length > limit) {
+                            msgs = msgs.slice(-limit);
+                        }
                     }
                 }
 

--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -223,17 +223,168 @@ class Chat extends Base {
                 let msgs = chat.msgs.getModelsArray().filter(msgFilter);
 
                 if (searchOptions && searchOptions.limit > 0) {
-                    while (msgs.length < searchOptions.limit) {
-                        const loadedMessages = await window
-                            .require('WAWebChatLoadMessages')
-                            .loadEarlierMsgs(chat, chat.msgs);
-                        if (!loadedMessages || !loadedMessages.length) break;
-                        msgs = [...loadedMessages.filter(msgFilter), ...msgs];
-                    }
+                    const msgFindLocal = window.require(
+                        'WAWebDBMessageFindLocal',
+                    );
+                    const WAWebMsgKey = window.require('WAWebMsgKey');
+                    const MsgStore = window.require('WAWebCollections').Msg;
 
-                    if (msgs.length > searchOptions.limit) {
+                    const findBefore = async (anchorKey, count) => {
+                        if (
+                            typeof msgFindLocal.msgFindByDirection ===
+                            'function'
+                        ) {
+                            return await msgFindLocal.msgFindByDirection({
+                                anchor: anchorKey,
+                                count,
+                                direction: 'before',
+                            });
+                        }
+                        return await msgFindLocal.msgFindBefore({
+                            anchor: anchorKey,
+                            count,
+                        });
+                    };
+
+                    const toMsgKey = (id) => {
+                        if (!id) return null;
+                        if (id instanceof WAWebMsgKey) return id;
+                        const s =
+                            typeof id === 'string'
+                                ? id
+                                : id._serialized || id?.toString?.();
+                        return s ? WAWebMsgKey.fromString(s) : null;
+                    };
+
+                    const toMsgModels = (rawMessages) => {
+                        const out = [];
+                        for (const m of rawMessages) {
+                            if (m && typeof m.serialize === 'function') {
+                                out.push(m);
+                                continue;
+                            }
+                            const serialized =
+                                m?.id?._serialized ||
+                                (typeof m === 'string' ? m : null);
+                            let model =
+                                (serialized && MsgStore.get(serialized)) ||
+                                (m?.id &&
+                                    MsgStore.get(m.id._serialized || m.id)) ||
+                                null;
+                            if (!model && m && MsgStore.modelClass) {
+                                try {
+                                    model = new MsgStore.modelClass(m);
+                                } catch (e) {
+                                    model = null;
+                                }
+                            }
+                            if (model) out.push(model);
+                        }
+                        return out;
+                    };
+
+                    const dedupeByMsgId = (arr) => {
+                        const seen = new Set();
+                        return arr.filter((m) => {
+                            const key = m.id?._serialized;
+                            if (!key || seen.has(key)) return false;
+                            seen.add(key);
+                            return true;
+                        });
+                    };
+
+                    const limit = searchOptions.limit;
+                    const finite = Number.isFinite(limit);
+                    const fromMeFilter =
+                        searchOptions && searchOptions.fromMe !== undefined;
+
+                    if (!fromMeFilter && finite) {
+                        const anchorSerialized =
+                            chat.lastReceivedKey?.toString();
+                        if (!anchorSerialized) {
+                            msgs.sort((a, b) => (a.t > b.t ? 1 : -1));
+                            msgs = msgs.slice(-Math.min(limit, msgs.length));
+                        } else {
+                            const fetchCount = Math.max(0, limit - 1);
+                            const anchorKey = toMsgKey(anchorSerialized);
+                            const result = await findBefore(
+                                anchorKey,
+                                fetchCount,
+                            );
+                            const rawMessages = Array.isArray(result)
+                                ? result
+                                : result?.messages || [];
+                            if (
+                                result?.status === 404 &&
+                                (!rawMessages || !rawMessages.length)
+                            ) {
+                                msgs = [];
+                            } else {
+                                let loaded = toMsgModels(rawMessages);
+                                const anchorMsg =
+                                    MsgStore.get(anchorSerialized);
+                                let merged = [
+                                    ...loaded,
+                                    ...(anchorMsg ? [anchorMsg] : []),
+                                    ...msgs,
+                                ];
+                                merged = merged.filter(
+                                    (m) => !m.isNotification,
+                                );
+                                merged.sort((a, b) => (a.t > b.t ? 1 : -1));
+                                merged = dedupeByMsgId(merged);
+                                msgs = merged.filter(msgFilter);
+                                if (msgs.length > limit) {
+                                    msgs = msgs.slice(-limit);
+                                }
+                            }
+                        }
+                    } else {
                         msgs.sort((a, b) => (a.t > b.t ? 1 : -1));
-                        msgs = msgs.splice(msgs.length - searchOptions.limit);
+                        const batchCap = finite ? limit : 100;
+                        while (msgs.length < limit || !finite) {
+                            const anchor =
+                                msgs[0]?.id ||
+                                chat.msgs.getModelsArray()[0]?.id ||
+                                chat.lastReceivedKey;
+                            if (!anchor) break;
+
+                            const anchorKey = toMsgKey(anchor);
+                            if (!anchorKey) break;
+
+                            const need = finite
+                                ? Math.min(batchCap, limit - msgs.length)
+                                : batchCap;
+                            if (need <= 0) break;
+
+                            const result = await findBefore(anchorKey, need);
+                            const rawMessages = Array.isArray(result)
+                                ? result
+                                : result?.messages || [];
+                            if (result?.status === 404 || !rawMessages.length) {
+                                break;
+                            }
+
+                            const loadedMessages = toMsgModels(rawMessages);
+                            if (!loadedMessages.length) break;
+
+                            const prevLen = msgs.length;
+                            msgs = dedupeByMsgId([
+                                ...loadedMessages.filter(msgFilter),
+                                ...msgs,
+                            ]);
+                            msgs.sort((a, b) => (a.t > b.t ? 1 : -1));
+
+                            if (msgs.length === prevLen) break;
+
+                            if (!finite && loadedMessages.length < need) {
+                                break;
+                            }
+                        }
+
+                        if (finite && msgs.length > limit) {
+                            msgs = msgs.slice(-limit);
+                        }
                     }
                 }
 

--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -229,6 +229,7 @@ class Chat extends Base {
                     const WAWebMsgKey = window.require('WAWebMsgKey');
                     const MsgStore = window.require('WAWebCollections').Msg;
 
+                    // msgFindByDirection is the newer API; fall back to msgFindBefore on older WA Web versions
                     const findBefore = async (anchorKey, count) => {
                         if (
                             typeof msgFindLocal.msgFindByDirection ===
@@ -318,7 +319,11 @@ class Chat extends Base {
                                 result?.status === 404 &&
                                 (!rawMessages || !rawMessages.length)
                             ) {
-                                msgs = [];
+                                // anchor not in local DB — fall back to in-memory msgs (same as the !anchorSerialized branch above)
+                                msgs.sort((a, b) => (a.t > b.t ? 1 : -1));
+                                msgs = msgs.slice(
+                                    -Math.min(limit, msgs.length),
+                                );
                             } else {
                                 let loaded = toMsgModels(rawMessages);
                                 const anchorMsg =
@@ -326,6 +331,7 @@ class Chat extends Base {
                                 let merged = [
                                     ...loaded,
                                     ...(anchorMsg ? [anchorMsg] : []),
+                                    // include in-memory msgs so recent (not-yet-persisted) messages aren't dropped
                                     ...msgs,
                                 ];
                                 merged = merged.filter(


### PR DESCRIPTION
## Description

Follow-up to #201705. Builds on that refactor and fixes two cases where `Chat.fetchMessages` / `Channel.fetchMessages` could return fewer messages than requested — in particular, an empty array or a single anchor message where the caller expected up to `limit` messages.

Changes (both `src/structures/Chat.js` and `src/structures/Channel.js`, in the `!fromMeFilter && finite` fast-path introduced by #201705):

1. **Include in-memory `msgs` when building `merged`.**
   `loaded` only contains what `msgFindBefore` returned from the local IndexedDB message table. Messages that are in the in-memory `MsgCollection` but not yet persisted (or not returned by the range query) were being dropped. Appending `...msgs` into `merged` preserves them; the existing `dedupeByMsgId` step guarantees no duplicates.

   Symptom before the fix: chats whose requested window consisted mostly of recent in-memory messages (with nothing older resolvable via `msgFindBefore`) returned only the anchor message — reproduced and confirmed in the #201705 discussion thread.

2. **Preserve `msgs` on `msgFindBefore` `status: 404`.**
   When the anchor is not present in the local DB (`NoAnchorMessageError` → `status: 404`), the fast-path previously set `msgs = []`, throwing away the already-filtered in-memory messages. It now mirrors the `!anchorSerialized` fallback immediately above: sort by `t` and slice to `limit`. Rare in practice (`lastReceivedKey` is almost always present in the DB), but consistent with how the "cannot run the DB query" case is handled a few lines above.

No public API or type changes.

## Related Issue(s)

Builds on #201705.

## Testing Summary

### Test Details

- `npx eslint src/structures/Chat.js src/structures/Channel.js` — clean.
- Manual verification against a live WhatsApp Web session for both `Chat` and `Channel`:
  - `chat.fetchMessages({ limit: 50 })` on a chat with a large stored history → returns ~50 messages (regression guard for the single-message bug).
  - `chat.fetchMessages({ limit: 50 })` on a chat whose history mostly lives in the in-memory collection → now returns the in-memory messages instead of one or zero.
  - Same two scenarios on a channel via `channel.fetchMessages({ limit: 50 })`.

## Type of Change

- [ ] **Dependency change**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Breaking change**
- [ ] **Non-code change**

## Checklist

- [x] My code follows the style guidelines of this project.
- [ ] All new and existing tests pass (`npm test`). _(integration suite requires `WWEBJS_TEST_REMOTE_ID`; eslint on the touched files is clean)_
- [x] Typings (e.g. `index.d.ts`) have been updated if necessary. _(no public API changes)_
- [ ] Usage examples (e.g. `example.js`) / documentation have been updated if applicable. _(not applicable)_