### PR TITLE
fix(structures): use updated loadEarlierMsgs options signature in fetchMessages

### DIFF
--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -353,7 +353,7 @@ class Channel extends Base {
                     while (msgs.length < searchOptions.limit) {
                         const loadedMessages = await window
                             .require('WAWebChatLoadMessages')
-                            .loadEarlierMsgs(channel);
+                            .loadEarlierMsgs({ chat: channel });
                         if (!loadedMessages || !loadedMessages.length) break;
                         msgs = [...loadedMessages.filter(msgFilter), ...msgs];
                     }

--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -226,7 +226,7 @@ class Chat extends Base {
                     while (msgs.length < searchOptions.limit) {
                         const loadedMessages = await window
                             .require('WAWebChatLoadMessages')
-                            .loadEarlierMsgs(chat, chat.msgs);
+                            .loadEarlierMsgs({ chat });
                         if (!loadedMessages || !loadedMessages.length) break;
                         msgs = [...loadedMessages.filter(msgFilter), ...msgs];
                     }


### PR DESCRIPTION
WhatsApp Web changed the signature of `WAWebChatLoadMessages.loadEarlierMsgs` from positional `(chat, msgCollection)` to an options object `{ chat, msgCollection, signal, threadId, trigger }`.

Calling the old positional form crashes with `Cannot read properties of undefined (reading 'waitForChatLoading')` because the destructure reads `e.chat` on the first positional argument instead of treating the first argument as the chat.

Updates both `Chat.fetchMessages` and `Channel.fetchMessages` to pass the options object. No other behaviour change.

`msgCollection` is intentionally omitted — the `loadEarlierMsgs` implementation already falls back to `chat.msgs` when it is not provided, so passing it explicitly would be redundant.

## Related Issue(s)

Fixes https://github.com/wwebjs/whatsapp-web.js/issues/201706 

## Testing Summary

### Test Details

1. Before the fix, `chat.fetchMessages({ limit: 100 })` crashed inside the injected `loadEarlierMsgs` call with `Cannot read properties of undefined (reading 'waitForChatLoading')` as soon as the loop attempted to page earlier messages.
2. After the fix, `chat.fetchMessages({ limit: 100 })` returns without error and paginates backwards via `loadEarlierMsgs` until the requested limit is reached or WhatsApp Web reports no earlier messages available.
3. `channel.fetchMessages({ limit: 50 })` on a newsletter/channel returns the same corrected behaviour — no crash, correct pagination.

### Environment

- WhatsApp Web Version: 2.3000.103718033
- Node Version: 22.14.0

## Type of Change

- [ ] **Dependency change** _(package changes such as removals, upgrades, or additions)_
- [x] **Bug fix** _(non-breaking change that fixes an issue)_
- [ ] **New feature** _(non-breaking change that adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to change)_
- [ ] **Non-code change** _(documentation, README, etc.)_

## Checklist

- [x] My code follows the style guidelines of this project.
- [] All new and existing tests pass (`npm test`).
- [x] Typings (e.g. `index.d.ts`) have been updated if necessary. _(no public API change — the method signature of `fetchMessages` is unchanged, only its internal call to a WA Web module was corrected)_
- [] Usage examples (e.g. `example.js`) / documentation have been updated if applicable. _(no API surface change)_