### PR TITLE
fix: Error asUserWidOrThrow calling client.getContacts()

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -433,13 +433,13 @@ exports.LoadUtils = () => {
                     : meUser;
             participant = window
                 .require('WAWebWidFactory')
-                .asUserWidOrThrow(from);
+                .createWidFromWidLike(from);
         }
 
         if (typeof chat.id?.isStatus === 'function' && chat.id.isStatus()) {
             participant = window
                 .require('WAWebWidFactory')
-                .asUserWidOrThrow(from);
+                .createWidFromWidLike(from);
         }
 
         const newMsgKey = new (window.require('WAWebMsgKey'))({


### PR DESCRIPTION
Calling client.getContacts() fails with an uncaught error: asUserWidOrThrow: wid is not a user wid. 

## Description

Calling client.getContacts() fails with an uncaught error: asUserWidOrThrow: wid is not a user wid. This seems to happen when the contact list contains non-user WIDs (like group JIDs) or new Linked ID (@lid) identifiers that the internal WhatsApp asUserWidOrThrow function does not validate as standard users.


## Related Issue(s)

#201717


