### PR TITLE
fix(types): make Client constructor options optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ import InterfaceController from './src/util/InterfaceController';
 
 declare namespace WAWebJS {
     export class Client extends EventEmitter {
-        constructor(options: ClientOptions);
+        constructor(options?: ClientOptions);
 
         /** Current connection information */
         public info: ClientInfo;


### PR DESCRIPTION
## Fix: Client constructor options should be optional

The current type definition requires an argument:

```ts
constructor(options: ClientOptions)
```

However, the runtime allows instantiating without arguments:

```ts
new Client()
```

This results in a TypeScript error:

> Expected 1 arguments, but got 0. [2554]

## Proposed change

Make the options parameter optional:

```ts
constructor(options?: ClientOptions)
```

## Impact

- Aligns type definitions with runtime behavior
- Fixes incorrect TypeScript error
- Improves developer experience