### PR TITLE
fix(RemoteAuth): correct auth zip directory based on writable of cwd

### DIFF
--- a/src/authStrategies/RemoteAuth.js
+++ b/src/authStrategies/RemoteAuth.js
@@ -59,6 +59,9 @@ class RemoteAuth extends BaseAuthStrategy {
             fs.accessSync(process.cwd(), fs.constants.W_OK);
             this.zipDir = process.cwd();
         } catch {
+            console.warn(
+                `[RemoteAuth] (${process.cwd()}) is not writable. Falling back to dataPath (${this.dataPath}) for session zips.`,
+            );
             this.zipDir = this.dataPath;
         }
         this.tempDir = `${this.dataPath}/wwebjs_temp_session_${this.clientId}`;

--- a/src/authStrategies/RemoteAuth.js
+++ b/src/authStrategies/RemoteAuth.js
@@ -55,6 +55,12 @@ class RemoteAuth extends BaseAuthStrategy {
         this.clientId = clientId;
         this.backupSyncIntervalMs = backupSyncIntervalMs;
         this.dataPath = path.resolve(dataPath || './.wwebjs_auth/');
+        try {
+            fs.accessSync(process.cwd(), fs.constants.W_OK);
+            this.zipDir = process.cwd();
+        } catch {
+            this.zipDir = this.dataPath;
+        }
         this.tempDir = `${this.dataPath}/wwebjs_temp_session_${this.clientId}`;
         this.requiredDirs = [
             'Default',
@@ -163,7 +169,7 @@ class RemoteAuth extends BaseAuthStrategy {
     async extractRemoteSession() {
         const pathExists = await this.isValidPath(this.userDataDir);
         const compressedSessionPath = path.join(
-            this.dataPath,
+            this.zipDir,
             `${this.sessionName}.zip`,
         );
         const sessionExists = await this.store.sessionExists({
@@ -205,7 +211,7 @@ class RemoteAuth extends BaseAuthStrategy {
         await this.copyByRequiredDirs(userDataDefaultPath, stageDefaultPath);
 
         const archive = archiver('zip');
-        const outPath = path.join(this.dataPath, `${this.sessionName}.zip`);
+        const outPath = path.join(this.zipDir, `${this.sessionName}.zip`);
         const out = fs.createWriteStream(outPath);
 
         await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Description

Fixes `ENOENT` failures when RemoteAuth is paired with remote stores like `wwebjs-aws-s3` or `wwebjs-mongo`.

Since #3375, the session zip is written to `this.dataPath`. However, store adapters (S3, GridFS) open the zip by its **relative filename** (e.g. `RemoteAuth-<sessionId>.zip`), which Node resolves against `process.cwd()`. When `dataPath` and `cwd` differ, the upload step can't find the file and crashes:

```
node:internal/process/promises:394
  triggerUncaughtException(err, true /* fromPromise */);
[Error: ENOENT: no such file or directory, open 'RemoteAuth-XXXXXXXXXX.zip'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'RemoteAuth-XXXXXXXXXX.zip'
}
Node.js v24.15.0
ELIFECYCLE  Command failed with exit code 1.
```
This PR resolves a single `zipDir` at construction time so the zip lives where store adapters expect it, while preserving #3375 Lambda support:

- If `process.cwd()` is writable => use it. The zip lands at the path store adapters resolve relative filenames against, so S3 / GridFS uploads succeed.
- Otherwise => fall back to `this.dataPath` (Lambda's read-only root filesystem, only `/tmp` writable — #3375).

Both the archiver output path (backup => upload to S3 / Mongo) and the extract path (download => restore) use `this.zipDir`, so the write and read locations stay consistent.
## Related Issue(s)

closes #5781 

## Testing Summary

### Test Details

- PNPM: 
```
pnpm add github:huynhtuandat05december/whatsapp-web.js#fix/remote-auth-zip-directory
```

- YARN: 
```
yarn add github:huynhtuandat05december/whatsapp-web.js#fix/remote-auth-zip-directory
```

- NPM: 
```
npm install github:huynhtuandat05december/whatsapp-web.js#fix/remote-auth-zip-directory
```

### Environment

- Machine OS: macOS 15
- Phone OS: iOS 26.0
- Library Version: 1.34.6 - main branch with latest commit hash is `211205363c06b0a4d35f0047adce07da937ffc19`
- WhatsApp Web Version: 2.3000.1017054665
- Browser Type and Version: Chromium 120
- Node Version: 24.15.0

## Type of Change

<!-- Select all that apply: -->

- [ ] **Dependency change** _(package changes such as removals, upgrades, or additions)_
- [x] **Bug fix** _(non-breaking change that fixes an issue)_
- [ ] **New feature** _(non-breaking change that adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to change)_
- [ ] **Non-code change** _(documentation, README, etc.)_

## Checklist

<!-- Please confirm that all relevant items below have been completed. -->

- [x] My code follows the style guidelines of this project.
- [x] All new and existing tests pass (`npm test`).
- [ ] Typings (e.g. `index.d.ts`) have been updated if necessary.
- [ ] Usage examples (e.g. `example.js`) / documentation have been updated if applicable.
