### PR TITLE
fix: typeerror in wwebjs.sendMessage

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -546,9 +546,7 @@ exports.LoadUtils = () => {
                     messageSecret: window.crypto.getRandomValues(
                         new Uint8Array(32),
                     ),
-                    cannotBeRanked: window
-                        .require('WAWebStatusGatingUtils')
-                        .canCheckStatusRankingPosterGating(),
+                    cannotBeRanked: window.require('WAWebStatusGatingUtils')?.canCheckStatusRankingPosterGating ? window.require('WAWebStatusGatingUtils').canCheckStatusRankingPosterGating() : false,
                 },
             );
 


### PR DESCRIPTION
## Description

this is to fix a typeerror on window.wwebjs.sendMessage method that intermittently happens when the app is running

## Related Issue(s)

fixes #201761 

## Testing Summary

### Test Details

just run the app and wait several hours after finishing authentication

### Environment

- Machine OS: macOS 26
- Phone OS: Android 12
- Library Version: 1.34.7
- WhatsApp Web Version: 2.3000.1017054665
- Browser Type and Version: 146.0.7680.31
- Node Version: 18.19

## Type of Change

- [ ] **Dependency change** _(package changes such as removals, upgrades, or additions)_
- [x] **Bug fix** _(non-breaking change that fixes an issue)_
- [ ] **New feature** _(non-breaking change that adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to change)_
- [ ] **Non-code change** _(documentation, README, etc.)_

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] All new and existing tests pass (`npm test`).
- [x] Typings (e.g. `index.d.ts`) have been updated if necessary.
- [x] Usage examples (e.g. `example.js`) / documentation have been updated if applicable.
