### PR TITLE
fix(Contact): update block/unblock implementation for latest WhatsApp Web

### DIFF
--- a/src/structures/Contact.js
+++ b/src/structures/Contact.js
@@ -154,27 +154,27 @@ class Contact extends Base {
     async block() {
         if (this.isGroup) return false;
 
+        const mapping = await this.client.getContactLidAndPhone([
+            this.id._serialized,
+        ]);
+
+        const phoneWid = mapping[0]?.pn || this.id._serialized;
+
         await this.client.pupPage.evaluate(async (contactId) => {
-            const contact = await window
-                .require('WAWebCollections')
-                .Contact.find(contactId);
-            const lid = contact.id.isLid()
-                ? contact.id
-                : window
-                      .require('WAWebApiContact')
-                      .getAlternateUserWid(contact.id);
-            const ContactToBlock = {
-                id: lid,
-                isContactBlocked: false,
-                phoneNumber: null,
-            };
+            const wid = window.require('WAWebWidFactory').createWid(contactId);
+
+            const chat = window
+                .require('WAWebChatCollection')
+                .ChatCollection.getLatestChatForWid(wid);
+
             await window.require('WAWebBlockContactAction').blockContact({
-                contact: ContactToBlock,
+                contact: chat.contact,
                 blockEntryPoint: 'ChatListBlock',
             });
-        }, this.id._serialized);
+        }, phoneWid);
 
         this.isBlocked = true;
+
         return true;
     }
 
@@ -185,25 +185,26 @@ class Contact extends Base {
     async unblock() {
         if (this.isGroup) return false;
 
-        await this.client.pupPage.evaluate(async (contactId) => {
-            let contact = await window
-                .require('WAWebCollections')
-                .Contact.find(contactId);
-            if (!contact.id.isLid()) {
-                const lid = window
-                    .require('WAWebApiContact')
-                    .getAlternateUserWid(contact.id);
+        const mapping = await this.client.getContactLidAndPhone([
+            this.id._serialized,
+        ]);
 
-                contact = await window
-                    .require('WAWebCollections')
-                    .Contact.find(lid._serialized);
-            }
+        const phoneWid = mapping[0]?.pn || this.id._serialized;
+
+        await this.client.pupPage.evaluate(async (contactId) => {
+            const wid = window.require('WAWebWidFactory').createWid(contactId);
+
+            const chat = window
+                .require('WAWebChatCollection')
+                .ChatCollection.getLatestChatForWid(wid);
+
             await window
                 .require('WAWebBlockContactAction')
-                .unblockContact(contact, 'ChatListBlock');
-        }, this.id._serialized);
+                .unblockContact(chat.contact);
+        }, phoneWid);
 
         this.isBlocked = false;
+
         return true;
     }
 


### PR DESCRIPTION
## Description

Fixes ```contact.block()``` and ```contact.unblock()``` for latest WhatsApp Web versions.

Recent WhatsApp Web internal API changes removed:

```WAWebBlockContactUtils.getContactToBlockOnlyUseIfNoAssociatedChat```

which caused blocking and unblocking contacts to fail with:

```TypeError: window.require(...).getContactToBlockOnlyUseIfNoAssociatedChat is not a function```

This PR updates the implementation to use the newer chat flow by:

- resolving LID/phone mappings when necessary
- creating WIDs using WAWebWidFactory
- retrieving chats using WAWebChatCollection
- directly calling WAWebBlockContactAction.blockContact() and unblockContact()

## Related Issue(s)

fixes #201776

<!--
If this pull request relates to one or more GitHub issues, link them using GitHub's closing keywords to automatically close the issues upon merging.

Examples:
  closes #123
  fixes #456
  resolves #789

For more details, see:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Testing Summary

### Test Details

Tested the following scenarios successfully:

- Blocking normal contacts
- Blocking @lid contacts
- Unblocking contacts
- Multi-device enabled accounts
- Incoming message triggered blocking flow

### Environment

- Machine OS: Windows 10
- Phone OS: Android 16
- Library Version: 1.34.7
- WhatsApp Web Version: 2.3000.1040549582
- Browser Type and Version: Google Chrome 148.0.7778.216
- Node Version: 20.20.1

## Type of Change

- [x] **Bug fix** _(non-breaking change that fixes an issue)_

## Checklist

- [x] My code follows the style guidelines of this project.