### PR TITLE
fix: use WWebJS.getChat for inviteV4 fallback in addParticipants

### DIFF
--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -209,13 +209,10 @@ class GroupChat extends Chat {
                         if (
                             rpcResult.name ===
                                 'ParticipantRequestCodeCanBeSent' &&
-                            (userChat =
-                                window
-                                    .require('WAWebCollections')
-                                    .Chat.get(pWid) ||
-                                (await window
-                                    .require('WAWebCollections')
-                                    .Chat.find(pWid)))
+                            (userChat = await window.WWebJS.getChat(
+                                pWid._serialized,
+                                { getAsModel: false },
+                            ))
                         ) {
                             const groupName =
                                 group.formattedTitle || group.name;


### PR DESCRIPTION
## Description

`GroupChat.addParticipants` crashes with `TypeError: this.findImpl is not a function` when a participant can't be added directly and the inviteV4 fallback kicks in (RPC code 403, `ParticipantRequestCodeCanBeSent`).

The fallback looked up the participant's 1:1 chat via the legacy collection API:

```js
window.require('WAWebCollections').Chat.get(pWid) ||
    (await window.require('WAWebCollections').Chat.find(pWid));
```

Current WhatsApp Web builds no longer implement `findImpl` on the Chat collection, so whenever the participant has **no existing private chat** — which is precisely the scenario where the invite fallback is needed — `Chat.get` misses and `Chat.find` throws.

This PR replaces that lookup with the library's own `window.WWebJS.getChat()` helper, which was already migrated to WhatsApp's supported `WAWebFindChatAction.findOrCreateLatestChat` API (#3703) and also creates the chat when it doesn't exist, handling LID/PN resolution. This mirrors how `removeParticipants` in the same file already resolves chats.

Note: this call site is the only remaining legacy `Chat.find` usage that structurally targets a user with no loaded chat, which is why it's the one crashing in the wild. Migrating the other (practically unreachable) legacy call sites could be a follow-up.

## Related Issue(s)

fixes #201789

## Testing Summary

### Test Details

Fix is based on analysis of the stack trace in #201789: the crash originates at the legacy `Chat.find` call, and the replacement (`window.WWebJS.getChat`) is the same code path already exercised on current WhatsApp Web by `getChatById` and `removeParticipants`.

I could not yet reproduce the full scenario end-to-end (it requires a second account with group-add privacy set to "My contacts" and no prior chat with the account). Verification from the issue reporter, who has a reliable repro, would be appreciated.

`eslint` and `prettier --check` pass on the changed file.

Unrelated note: `.husky/commit-msg` uses the GNU-sed-only `\L` extension, which on macOS (BSD sed) prepends a literal `L` to the commit type, making every commit fail commitlint. Can open a separate PR for that.

### Environment

- Machine OS: macOS 15
- Phone OS: Android
- Library Version: main (1.34.7)
- WhatsApp Web Version: 2.3000.x (current)
- Browser Type and Version: Chromium (Puppeteer 24.38.0 bundled)
- Node Version: 18+

## Type of Change

- [ ] **Dependency change** _(package changes such as removals, upgrades, or additions)_
- [x] **Bug fix** _(non-breaking change that fixes an issue)_
- [ ] **New feature** _(non-breaking change that adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to change)_
- [ ] **Non-code change** _(documentation, README, etc.)_

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] All new and existing tests pass (`npm test`).
- [x] Typings (e.g. `index.d.ts`) have been updated if necessary. _(no signature change, not needed)_
- [x] Usage examples (e.g. `example.js`) / documentation have been updated if applicable. _(not applicable)_