### PR TITLE
chore: remove node-fetch in favor of Node.js 18+ built-in fetch

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -198,7 +198,7 @@ declare namespace WAWebJS {
         ): Promise<string>;
 
         /** Cancels an active pairing code session and returns to QR code mode */
-        cancelPairingCode(): Promise<void>
+        cancelPairingCode(): Promise<void>;
 
         /** Force reset of connection state for the client */
         resetState(): Promise<void>;
@@ -211,10 +211,7 @@ declare namespace WAWebJS {
         ): Promise<Message>;
 
         /** Send a reaction to a specific messageId */
-        sendReaction(
-            messageId: string,
-            reaction: string,
-        ): Promise<void>;
+        sendReaction(messageId: string, reaction: string): Promise<void>;
 
         /** Sends a channel admin invitation to a user, allowing them to become an admin of the channel */
         sendChannelAdminInvite(

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from 'events';
-import { RequestInit } from 'node-fetch';
 import * as puppeteer from 'puppeteer';
 import InterfaceController from './src/util/InterfaceController';
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "dependencies": {
         "fluent-ffmpeg": "2.1.3",
         "mime": "3.0.0",
-        "node-fetch": "2.7.0",
         "node-webpmux": "3.2.1",
         "puppeteer": "24.38.0"
     },
@@ -45,7 +44,6 @@
         "@commitlint/cli": "^20.4.3",
         "@commitlint/config-conventional": "^20.4.3",
         "@eslint/js": "^9.39.4",
-        "@types/node-fetch": "^2.6.13",
         "chai": "^4.5.0",
         "chai-as-promised": "^7.1.2",
         "dotenv": "^16.6.1",

--- a/src/structures/MessageMedia.js
+++ b/src/structures/MessageMedia.js
@@ -3,7 +3,6 @@
 const fs = require('fs');
 const path = require('path');
 const mime = require('mime');
-const fetch = require('node-fetch');
 const { URL } = require('url');
 
 /**

--- a/src/webCache/RemoteWebCache.js
+++ b/src/webCache/RemoteWebCache.js
@@ -1,4 +1,3 @@
-const fetch = require('node-fetch');
 const { WebCache, VersionResolveError } = require('./WebCache');
 
 /**


### PR DESCRIPTION
Node.js 18+ provides a built-in fetch API, and since this project requires Node.js >=18.0.0, the node-fetch dependency is no longer necessary.

## Changes

- Removed node-fetch from dependencies
- Removed @types/node-fetch from devDependencies
- Removed node-fetch import from MessageMedia.js and RemoteWebCache.js
- Removed RequestInit import from index.d.ts (now uses global fetch types)

## Notes

The existing code in MessageMedia.js already handles native fetch via the arrayBuffer() fallback when response.buffer is unavailable.