### PR TITLE
fix: compatibility with WhatsApp Web 2.3000.1043xxx ($1 vs _serialized, window.Store migration)

### DIFF
--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -64,12 +64,6 @@ class Chat extends Base {
         this.pinned = !!data.pin;
 
         /**
-         * Indicates if the Chat is locked
-         * @type {boolean}
-         */
-        this.isLocked = data.isLocked;
-
-        /**
          * Indicates if the chat is muted or not
          * @type {boolean}
          */
@@ -85,17 +79,15 @@ class Chat extends Base {
          * Last message fo chat
          * @type {Message}
          */
-        this.lastMessage = data.lastMessage
-            ? new Message(this.client, data.lastMessage)
-            : undefined;
-
+        this.lastMessage = data.lastMessage ? new Message(this.client, data.lastMessage) : undefined;
+        
         return super._patch(data);
     }
 
     /**
      * Send a message to this chat
      * @param {string|MessageMedia|Location} content
-     * @param {MessageSendOptions} [options]
+     * @param {MessageSendOptions} [options] 
      * @returns {Promise<Message>} Message that was just sent
      */
     async sendMessage(content, options) {
@@ -115,7 +107,7 @@ class Chat extends Base {
      * @returns {Promise<boolean>} result
      */
     async clearMessages() {
-        return this.client.pupPage.evaluate((chatId) => {
+        return this.client.pupPage.evaluate(chatId => {
             return window.WWebJS.sendClearChat(chatId);
         }, this.id._serialized);
     }
@@ -125,7 +117,7 @@ class Chat extends Base {
      * @returns {Promise<Boolean>} result
      */
     async delete() {
-        return this.client.pupPage.evaluate((chatId) => {
+        return this.client.pupPage.evaluate(chatId => {
             return window.WWebJS.sendDeleteChat(chatId);
         }, this.id._serialized);
     }
@@ -166,10 +158,7 @@ class Chat extends Base {
      * @returns {Promise<{isMuted: boolean, muteExpiration: number}>}
      */
     async mute(unmuteDate) {
-        const result = await this.client.muteChat(
-            this.id._serialized,
-            unmuteDate,
-        );
+        const result = await this.client.muteChat(this.id._serialized, unmuteDate);
         this.isMuted = result.isMuted;
         this.muteExpiration = result.muteExpiration;
         return result;
@@ -189,7 +178,7 @@ class Chat extends Base {
     /**
      * Mark this chat as unread
      */
-    async markUnread() {
+    async markUnread(){
         return this.client.markChatUnread(this.id._serialized);
     }
 
@@ -201,56 +190,209 @@ class Chat extends Base {
      * @returns {Promise<Array<Message>>}
      */
     async fetchMessages(searchOptions) {
-        let messages = await this.client.pupPage.evaluate(
-            async (chatId, searchOptions) => {
-                const msgFilter = (m) => {
-                    if (m.isNotification) {
-                        return false; // dont include notification messages
-                    }
-                    if (
-                        searchOptions &&
-                        searchOptions.fromMe !== undefined &&
-                        m.id.fromMe !== searchOptions.fromMe
-                    ) {
-                        return false;
-                    }
-                    return true;
-                };
-
-                const chat = await window.WWebJS.getChat(chatId, {
-                    getAsModel: false,
-                });
-                let msgs = chat.msgs.getModelsArray().filter(msgFilter);
-
-                if (searchOptions && searchOptions.limit > 0) {
-                    while (msgs.length < searchOptions.limit) {
-                        const loadedMessages = await window
-                            .require('WAWebChatLoadMessages')
-                            .loadEarlierMsgs({ chat });
-                        if (!loadedMessages || !loadedMessages.length) break;
-                        msgs = [...loadedMessages.filter(msgFilter), ...msgs];
-                    }
-
-                    if (msgs.length > searchOptions.limit) {
-                        msgs.sort((a, b) => (a.t > b.t ? 1 : -1));
-                        msgs = msgs.splice(msgs.length - searchOptions.limit);
-                    }
+        let messages = await this.client.pupPage.evaluate(async (chatId, searchOptions) => {
+            const msgFilter = (m) => {
+                if (m.isNotification) {
+                    return false; // dont include notification messages
                 }
+                if (searchOptions && searchOptions.fromMe !== undefined && m.id.fromMe !== searchOptions.fromMe) {
+                    return false;
+                }
+                return true;
+            };
 
-                return msgs.map((m) => window.WWebJS.getMessageModel(m));
-            },
-            this.id._serialized,
-            searchOptions,
-        );
+            const chat = await window.WWebJS.getChat(chatId, { getAsModel: false });
+            let msgs = chat.msgs.getModelsArray().filter(msgFilter);
 
-        return messages.map((m) => new Message(this.client, m));
+            if (searchOptions && searchOptions.limit > 0) {
+                    const msgFindLocal = window.require(
+                        'WAWebDBMessageFindLocal',
+                    );
+                    const WAWebMsgKey = window.require('WAWebMsgKey');
+                    const MsgStore = window.require('WAWebCollections').Msg;
+
+                    const findBefore = async (anchorKey, count) => {
+                        if (
+                            typeof msgFindLocal.msgFindByDirection ===
+                            'function'
+                        ) {
+                            return await msgFindLocal.msgFindByDirection({
+                                anchor: anchorKey,
+                                count,
+                                direction: 'before',
+                            });
+                        }
+                        return await msgFindLocal.msgFindBefore({
+                            anchor: anchorKey,
+                            count,
+                        });
+                    };
+
+                    const toMsgKey = (id) => {
+                        if (!id) return null;
+                        if (id instanceof WAWebMsgKey) return id;
+                        const s =
+                            typeof id === 'string'
+                                ? id
+                                : id._serialized || id.$1 || id?.toString?.();
+                        return s ? WAWebMsgKey.fromString(s) : null;
+                    };
+
+                    const toMsgModels = (rawMessages) => {
+                        const out = [];
+                        for (const m of rawMessages) {
+                            if (m && typeof m.serialize === 'function') {
+                                out.push(m);
+                                continue;
+                            }
+                            const serialized =
+                                m?.id?._serialized ||
+                                m?.id?.$1 ||
+                                (typeof m === 'string' ? m : null);
+                            let model =
+                                (serialized && MsgStore.get(serialized)) ||
+                                (m?.id &&
+                                    MsgStore.get(
+                                        m.id._serialized || m.id.$1 || m.id,
+                                    )) ||
+                                null;
+                            if (!model && m && MsgStore.modelClass) {
+                                try {
+                                    model = new MsgStore.modelClass(m);
+                                } catch (e) {
+                                    model = null;
+                                }
+                            }
+                            if (model) out.push(model);
+                        }
+                        return out;
+                    };
+
+                    const dedupeByMsgId = (arr) => {
+                        const seen = new Set();
+                        const msgKeyOf = (m) => {
+                            const id = m.id;
+                            if (!id) return null;
+                            if (id._serialized) return id._serialized;
+                            if (id.$1) return id.$1;
+                            const s = id.toString?.();
+                            return s && s !== '[object Object]' ? s : null;
+                        };
+                        return arr.filter((m) => {
+                            const key = msgKeyOf(m);
+                            if (!key) return true;
+                            if (seen.has(key)) return false;
+                            seen.add(key);
+                            return true;
+                        });
+                    };
+
+                    const limit = searchOptions.limit;
+                    const finite = Number.isFinite(limit);
+                    const fromMeFilter =
+                        searchOptions && searchOptions.fromMe !== undefined;
+
+                    if (!fromMeFilter && finite) {
+                        const anchorSerialized =
+                            chat.lastReceivedKey?.toString();
+                        if (!anchorSerialized) {
+                            msgs.sort((a, b) => (a.t > b.t ? 1 : -1));
+                            msgs = msgs.slice(-Math.min(limit, msgs.length));
+                        } else {
+                            const fetchCount = Math.max(0, limit - 1);
+                            const anchorKey = toMsgKey(anchorSerialized);
+                            const result = await findBefore(
+                                anchorKey,
+                                fetchCount,
+                            );
+                            const rawMessages = Array.isArray(result)
+                                ? result
+                                : result?.messages || [];
+                            if (
+                                result?.status === 404 &&
+                                (!rawMessages || !rawMessages.length)
+                            ) {
+                                msgs = [];
+                            } else {
+                                let loaded = toMsgModels(rawMessages);
+                                const anchorMsg =
+                                    MsgStore.get(anchorSerialized);
+                                let merged = [
+                                    ...loaded,
+                                    ...(anchorMsg ? [anchorMsg] : []),
+                                ];
+                                merged = merged.filter(
+                                    (m) => !m.isNotification,
+                                );
+                                merged.sort((a, b) => (a.t > b.t ? 1 : -1));
+                                merged = dedupeByMsgId(merged);
+                                msgs = merged.filter(msgFilter);
+                                if (msgs.length > limit) {
+                                    msgs = msgs.slice(-limit);
+                                }
+                            }
+                        }
+                    } else {
+                        msgs.sort((a, b) => (a.t > b.t ? 1 : -1));
+                        const batchCap = finite ? limit : 100;
+                        while (msgs.length < limit || !finite) {
+                            const anchor =
+                                msgs[0]?.id ||
+                                chat.msgs.getModelsArray()[0]?.id ||
+                                chat.lastReceivedKey;
+                            if (!anchor) break;
+
+                            const anchorKey = toMsgKey(anchor);
+                            if (!anchorKey) break;
+
+                            const need = finite
+                                ? Math.min(batchCap, limit - msgs.length)
+                                : batchCap;
+                            if (need <= 0) break;
+
+                            const result = await findBefore(anchorKey, need);
+                            const rawMessages = Array.isArray(result)
+                                ? result
+                                : result?.messages || [];
+                            if (result?.status === 404 || !rawMessages.length) {
+                                break;
+                            }
+
+                            const loadedMessages = toMsgModels(rawMessages);
+                            if (!loadedMessages.length) break;
+
+                            const prevLen = msgs.length;
+                            msgs = dedupeByMsgId([
+                                ...loadedMessages.filter(msgFilter),
+                                ...msgs,
+                            ]);
+                            msgs.sort((a, b) => (a.t > b.t ? 1 : -1));
+
+                            if (msgs.length === prevLen) break;
+
+                            if (!finite && loadedMessages.length < need) {
+                                break;
+                            }
+                        }
+
+                        if (finite && msgs.length > limit) {
+                            msgs = msgs.slice(-limit);
+                        }
+                    }
+            }
+
+            return msgs.map(m => window.WWebJS.getMessageModel(m));
+
+        }, this.id._serialized, searchOptions);
+
+        return messages.map(m => new Message(this.client, m));
     }
 
     /**
      * Simulate typing in chat. This will last for 25 seconds.
      */
     async sendStateTyping() {
-        return this.client.pupPage.evaluate((chatId) => {
+        return this.client.pupPage.evaluate(chatId => {
             window.WWebJS.sendChatstate('typing', chatId);
             return true;
         }, this.id._serialized);
@@ -260,7 +402,7 @@ class Chat extends Base {
      * Simulate recording audio in chat. This will last for 25 seconds.
      */
     async sendStateRecording() {
-        return this.client.pupPage.evaluate((chatId) => {
+        return this.client.pupPage.evaluate(chatId => {
             window.WWebJS.sendChatstate('recording', chatId);
             return true;
         }, this.id._serialized);
@@ -270,7 +412,7 @@ class Chat extends Base {
      * Stops typing or recording in chat immediately.
      */
     async clearState() {
-        return this.client.pupPage.evaluate((chatId) => {
+        return this.client.pupPage.evaluate(chatId => {
             window.WWebJS.sendChatstate('stop', chatId);
             return true;
         }, this.id._serialized);
@@ -308,7 +450,7 @@ class Chat extends Base {
     async getPinnedMessages() {
         return this.client.getPinnedMessages(this.id._serialized);
     }
-
+    
     /**
      * Sync chat history conversation
      * @return {Promise<boolean>} True if operation completed successfully, false otherwise.
@@ -343,7 +485,7 @@ class Chat extends Base {
      */
     async getCustomerNote() {
         if (this.isGroup || this.isChannel) return null;
-
+        
         return this.client.getCustomerNote(this.id._serialized);
     }
 }

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -3,171 +3,73 @@
 exports.LoadUtils = () => {
     window.WWebJS = {};
 
-    /**
-     * Helper function that compares between two WWeb versions. Its purpose is to help the developer to choose the correct code implementation depending on the comparison value and the WWeb version.
-     * @param {string} lOperand The left operand for the WWeb version string to compare with
-     * @param {string} operator The comparison operator
-     * @param {string} rOperand The right operand for the WWeb version string to compare with
-     * @returns {boolean} Boolean value that indicates the result of the comparison
-     */
-    window.WWebJS.compareWwebVersions = (lOperand, operator, rOperand) => {
-        if (!['>', '>=', '<', '<=', '='].includes(operator)) {
-            throw new (class _ extends Error {
-                constructor(m) {
-                    super(m);
-                    this.name = 'CompareWwebVersionsError';
-                }
-            })('Invalid comparison operator is provided');
-        }
-        if (typeof lOperand !== 'string' || typeof rOperand !== 'string') {
-            throw new (class _ extends Error {
-                constructor(m) {
-                    super(m);
-                    this.name = 'CompareWwebVersionsError';
-                }
-            })('A non-string WWeb version type is provided');
-        }
-
-        lOperand = lOperand.replace(/-beta$/, '');
-        rOperand = rOperand.replace(/-beta$/, '');
-
-        while (lOperand.length !== rOperand.length) {
-            lOperand.length > rOperand.length
-                ? (rOperand = rOperand.concat('0'))
-                : (lOperand = lOperand.concat('0'));
-        }
-
-        lOperand = Number(lOperand.replace(/\./g, ''));
-        rOperand = Number(rOperand.replace(/\./g, ''));
-
-        return operator === '>'
-            ? lOperand > rOperand
-            : operator === '>='
-              ? lOperand >= rOperand
-              : operator === '<'
-                ? lOperand < rOperand
-                : operator === '<='
-                  ? lOperand <= rOperand
-                  : operator === '='
-                    ? lOperand === rOperand
-                    : false;
+    // Compatibility shim: newer WhatsApp Web builds (2.3000.1043xxx, July 2026)
+    // expose the serialized wid/msg-key as `$1` instead of `_serialized`.
+    // See https://github.com/wwebjs/whatsapp-web.js/issues/201831
+    window.WWebJS.widSerialized = (wid) => {
+        if (!wid || typeof wid === 'string') return wid;
+        return wid._serialized
+            ?? wid.$1
+            ?? (typeof wid.toString === 'function' ? wid.toString() : undefined);
     };
 
-    /**
-     * Target options object description
-     * @typedef {Object} TargetOptions
-     * @property {string|number} module The target module
-     * @property {string} function The function name to get from a module
-     */
-    /**
-     * Function to modify functions
-     * @param {TargetOptions} target Options specifying the target function to search for modifying
-     * @param {Function} callback Modified function
-     */
-    window.WWebJS.injectToFunction = (target, callback) => {
-        try {
-            let module = window.require(target.module);
-            if (!module) return;
-
-            const path = target.function.split('.');
-            const funcName = path.pop();
-
-            for (const key of path) {
-                if (!module[key]) return;
-                module = module[key];
-            }
-
-            const originalFunction = module[funcName];
-            if (typeof originalFunction !== 'function') return;
-
-            module[funcName] = ((...args) => {
-                try {
-                    return callback(module, originalFunction, ...args);
-                } catch {
-                    return originalFunction.apply(module, args);
-                }
-            }).bind(module);
-        } catch {
-            return;
+    // Recursively mirror `$1` back onto `_serialized` in serialized models so
+    // node-side code (and user code) keeps reading `id._serialized` as before.
+    window.WWebJS.normalizeSerialized = (obj, depth = 0) => {
+        if (!obj || typeof obj !== 'object' || depth > 8) return obj;
+        if (Array.isArray(obj)) {
+            for (const item of obj) window.WWebJS.normalizeSerialized(item, depth + 1);
+            return obj;
         }
+        if (obj.$1 !== undefined && obj._serialized === undefined) {
+            obj._serialized = obj.$1;
+        }
+        for (const key of Object.keys(obj)) {
+            const value = obj[key];
+            if (value && typeof value === 'object') window.WWebJS.normalizeSerialized(value, depth + 1);
+        }
+        return obj;
     };
-
-    window.WWebJS.injectToFunction(
-        { module: 'WAWebBackendJobsCommon', function: 'mediaTypeFromProtobuf' },
-        (module, func, ...args) => {
-            const [proto] = args;
-            return proto.locationMessage ? null : func(...args);
-        },
-    );
-
-    window.WWebJS.injectToFunction(
-        { module: 'WAWebE2EProtoUtils', function: 'typeAttributeFromProtobuf' },
-        (module, func, ...args) => {
-            const [proto] = args;
-            return proto.locationMessage || proto.groupInviteMessage
-                ? 'text'
-                : func(...args);
-        },
-    );
 
     window.WWebJS.forwardMessage = async (chatId, msgId) => {
-        const msg =
-            window.require('WAWebCollections').Msg.get(msgId) ||
-            (
-                await window
-                    .require('WAWebCollections')
-                    .Msg.getMessagesById([msgId])
-            )?.messages?.[0];
+        const msg = window.Store.Msg.get(msgId) || (await window.Store.Msg.getMessagesById([msgId]))?.messages?.[0];
         const chat = await window.WWebJS.getChat(chatId, { getAsModel: false });
-        return await window.require('WAWebChatForwardMessage').forwardMessages({
-            chat: chat,
-            msgs: [msg],
-            multicast: true,
-            includeCaption: true,
-            appendedText: undefined,
-        });
+        return await window.Store.ForwardUtils.forwardMessages({ 'chat': chat, 'msgs': [msg], 'multicast': true, 'includeCaption': true, 'appendedText': undefined });
     };
 
     window.WWebJS.sendSeen = async (chatId) => {
         const chat = await window.WWebJS.getChat(chatId, { getAsModel: false });
         if (chat) {
-            window.require('WAWebStreamModel').Stream.markAvailable();
-            await window.require('WAWebUpdateUnreadChatAction').sendSeen({
+            window.Store.WAWebStreamModel.Stream.markAvailable();
+            await window.Store.SendSeen.sendSeen({
                 chat: chat,
-                threadId: undefined,
+                threadId: undefined
             });
-            window.require('WAWebStreamModel').Stream.markUnavailable();
+            window.Store.WAWebStreamModel.Stream.markUnavailable();
             return true;
         }
         return false;
     };
 
     window.WWebJS.sendMessage = async (chat, content, options = {}) => {
-        const { getIsNewsletter, getIsBroadcast } =
-            window.require('WAWebChatGetters');
-        const isChannel = getIsNewsletter(chat);
-        const isStatus = getIsBroadcast(chat);
-
-        const { findLink } = window.require('WALinkify');
+        const isChannel = window.Store.ChatGetters.getIsNewsletter(chat);
+        const isStatus = window.Store.ChatGetters.getIsBroadcast(chat);
 
         let mediaOptions = {};
         if (options.media) {
-            mediaOptions =
-                options.sendMediaAsSticker && !isChannel && !isStatus
-                    ? await window.WWebJS.processStickerData(options.media)
-                    : await window.WWebJS.processMediaData(options.media, {
-                          forceSticker: options.sendMediaAsSticker,
-                          forceGif: options.sendVideoAsGif,
-                          forceVoice: options.sendAudioAsVoice,
-                          forceDocument: options.sendMediaAsDocument,
-                          forceMediaHd: options.sendMediaAsHd,
-                          sendToChannel: isChannel,
-                          sendToStatus: isStatus,
-                      });
+            mediaOptions = options.sendMediaAsSticker && !isChannel && !isStatus
+                ? await window.WWebJS.processStickerData(options.media)
+                : await window.WWebJS.processMediaData(options.media, {
+                    forceSticker: options.sendMediaAsSticker,
+                    forceGif: options.sendVideoAsGif,
+                    forceVoice: options.sendAudioAsVoice,
+                    forceDocument: options.sendMediaAsDocument,
+                    forceMediaHd: options.sendMediaAsHd,
+                    sendToChannel: isChannel,
+                    sendToStatus: isStatus
+                });
             mediaOptions.caption = options.caption;
-            content = options.sendMediaAsSticker
-                ? undefined
-                : mediaOptions.preview;
+            content = options.sendMediaAsSticker ? undefined : mediaOptions.preview;
             mediaOptions.isViewOnce = options.isViewOnce;
             delete options.media;
             delete options.sendMediaAsSticker;
@@ -175,19 +77,12 @@ exports.LoadUtils = () => {
 
         let quotedMsgOptions = {};
         if (options.quotedMessageId) {
-            let quotedMessage = window
-                .require('WAWebCollections')
-                .Msg.get(options.quotedMessageId);
-            !quotedMessage &&
-                (quotedMessage = (
-                    await window
-                        .require('WAWebCollections')
-                        .Msg.getMessagesById([options.quotedMessageId])
-                )?.messages?.[0]);
+            let quotedMessage = window.Store.Msg.get(options.quotedMessageId);
+            !quotedMessage && (quotedMessage = (await window.Store.Msg.getMessagesById([options.quotedMessageId]))?.messages?.[0]);
             if (quotedMessage) {
-                const ReplyUtils = window.require('WAWebMsgReply');
-                const canReply = ReplyUtils
-                    ? ReplyUtils.canReplyMsg(quotedMessage.unsafe())
+
+                const canReply = window.Store.ReplyUtils
+                    ? window.Store.ReplyUtils.canReplyMsg(quotedMessage.unsafe())
                     : quotedMessage.canReply();
 
                 if (canReply) {
@@ -204,30 +99,28 @@ exports.LoadUtils = () => {
         }
 
         if (options.mentionedJidList) {
-            options.mentionedJidList = options.mentionedJidList.map((id) =>
-                window.require('WAWebWidFactory').createWid(id),
-            );
+            options.mentionedJidList = options.mentionedJidList.map((id) => window.Store.WidFactory.createWid(id));
             options.mentionedJidList = options.mentionedJidList.filter(Boolean);
         }
 
         if (options.groupMentions) {
             options.groupMentions = options.groupMentions.map((e) => ({
                 groupSubject: e.subject,
-                groupJid: window.require('WAWebWidFactory').createWid(e.id),
+                groupJid: window.Store.WidFactory.createWid(e.id)
             }));
         }
 
         let locationOptions = {};
         if (options.location) {
             let { latitude, longitude, description, url } = options.location;
-            url = findLink(url)?.href;
+            url = window.Store.Validators.findLink(url)?.href;
             url && !description && (description = url);
             locationOptions = {
                 type: 'location',
                 loc: description,
                 lat: latitude,
                 lng: longitude,
-                clientUrl: url,
+                clientUrl: url
             };
             delete options.location;
         }
@@ -235,8 +128,7 @@ exports.LoadUtils = () => {
         let pollOptions = {};
         if (options.poll) {
             const { pollName, pollOptions: _pollOptions } = options.poll;
-            const { allowMultipleAnswers, messageSecret } =
-                options.poll.options;
+            const { allowMultipleAnswers, messageSecret } = options.poll.options;
             pollOptions = {
                 kind: 'pollCreation',
                 type: 'poll_creation',
@@ -246,7 +138,7 @@ exports.LoadUtils = () => {
                 messageSecret:
                     Array.isArray(messageSecret) && messageSecret.length === 32
                         ? new Uint8Array(messageSecret)
-                        : window.crypto.getRandomValues(new Uint8Array(32)),
+                        : window.crypto.getRandomValues(new Uint8Array(32))
             };
             delete options.poll;
         }
@@ -264,17 +156,12 @@ exports.LoadUtils = () => {
                 eventLocation: eventSendOptions.location && {
                     degreesLatitude: 0,
                     degreesLongitude: 0,
-                    name: eventSendOptions.location,
+                    name: eventSendOptions.location
                 },
-                eventJoinLink:
-                    eventSendOptions.callType === 'none'
-                        ? null
-                        : await window
-                              .require('WAWebGenerateEventCallLink')
-                              .createEventCallLink(
-                                  startTimeTs,
-                                  eventSendOptions.callType,
-                              ),
+                eventJoinLink: eventSendOptions.callType === 'none' ? null : await window.Store.ScheduledEventMsgUtils.createEventCallLink(
+                    startTimeTs,
+                    eventSendOptions.callType
+                ),
                 isEventCanceled: eventSendOptions.isEventCanceled,
                 messageSecret:
                     Array.isArray(messageSecret) && messageSecret.length === 32
@@ -286,65 +173,43 @@ exports.LoadUtils = () => {
 
         let vcardOptions = {};
         if (options.contactCard) {
-            let contact = await window
-                .require('WAWebCollections')
-                .Contact.find(options.contactCard);
+            let contact = window.Store.Contact.get(options.contactCard);
             vcardOptions = {
-                body: window
-                    .require('WAWebFrontendVcardUtils')
-                    .vcardFromContactModel(contact).vcard,
+                body: window.Store.VCard.vcardFromContactModel(contact).vcard,
                 type: 'vcard',
-                vcardFormattedName: contact.formattedName,
+                vcardFormattedName: contact.formattedName
             };
             delete options.contactCard;
         } else if (options.contactCardList) {
-            let contacts = await Promise.all(
-                options.contactCardList.map((c) =>
-                    window.require('WAWebCollections').Contact.find(c),
-                ),
-            );
-            let vcards = contacts.map((c) =>
-                window
-                    .require('WAWebFrontendVcardUtils')
-                    .vcardFromContactModel(c),
-            );
+            let contacts = options.contactCardList.map(c => window.Store.Contact.get(c));
+            let vcards = contacts.map(c => window.Store.VCard.vcardFromContactModel(c));
             vcardOptions = {
                 type: 'multi_vcard',
                 vcardList: vcards,
-                body: null,
+                body: null
             };
             delete options.contactCardList;
-        } else if (
-            options.parseVCards &&
-            typeof content === 'string' &&
-            content.startsWith('BEGIN:VCARD')
-        ) {
+        } else if (options.parseVCards && typeof (content) === 'string' && content.startsWith('BEGIN:VCARD')) {
             delete options.parseVCards;
             delete options.linkPreview;
             try {
-                const parsed = window
-                    .require('WAWebVcardParsingUtils')
-                    .parseVcard(content);
+                const parsed = window.Store.VCard.parseVcard(content);
                 if (parsed) {
                     vcardOptions = {
                         type: 'vcard',
-                        vcardFormattedName: window
-                            .require('WAWebVcardGetNameFromParsed')
-                            .vcardGetNameFromParsed(parsed),
+                        vcardFormattedName: window.Store.VCard.vcardGetNameFromParsed(parsed)
                     };
                 }
-            } catch (ignoredError) {
+            } catch (_) {
                 // not a vcard
             }
         }
 
         if (options.linkPreview) {
             delete options.linkPreview;
-            const link = findLink(content);
+            const link = window.Store.Validators.findLink(content);
             if (link) {
-                let preview = await window
-                    .require('WAWebLinkPreviewChatAction')
-                    .getLinkPreview(link);
+                let preview = await window.Store.LinkPreview.getLinkPreview(link);
                 if (preview && preview.data) {
                     preview = preview.data;
                     preview.preview = true;
@@ -361,41 +226,34 @@ exports.LoadUtils = () => {
                 content = options.buttons.body;
                 caption = content;
             } else {
-                caption = options.caption ? options.caption : ' '; // Caption can't be empty
+                caption = options.caption ? options.caption : ' '; //Caption can't be empty
             }
             buttonOptions = {
                 productHeaderImageRejected: false,
                 isFromTemplate: false,
                 isDynamicReplyButtonsMsg: true,
-                title: options.buttons.title
-                    ? options.buttons.title
-                    : undefined,
-                footer: options.buttons.footer
-                    ? options.buttons.footer
-                    : undefined,
+                title: options.buttons.title ? options.buttons.title : undefined,
+                footer: options.buttons.footer ? options.buttons.footer : undefined,
                 dynamicReplyButtons: options.buttons.buttons,
                 replyButtons: options.buttons.buttons,
-                caption: caption,
+                caption: caption
             };
             delete options.buttons;
         }
 
         let listOptions = {};
         if (options.list) {
-            if (
-                window.require('WAWebConnModel').Conn.platform === 'smba' ||
-                window.require('WAWebConnModel').Conn.platform === 'smbi'
-            ) {
-                throw "[LT01] Whatsapp business can't send this yet";
+            if (window.Store.Conn.platform === 'smba' || window.Store.Conn.platform === 'smbi') {
+                throw '[LT01] Whatsapp business can\'t send this yet';
             }
             listOptions = {
                 type: 'list',
                 footer: options.list.footer,
                 list: {
                     ...options.list,
-                    listType: 1,
+                    listType: 1
                 },
-                body: options.list.description,
+                body: options.list.description
             };
             delete options.list;
             delete listOptions.list.footer;
@@ -403,46 +261,29 @@ exports.LoadUtils = () => {
 
         const botOptions = {};
         if (options.invokedBotWid) {
-            botOptions.messageSecret = window.crypto.getRandomValues(
-                new Uint8Array(32),
-            );
-            botOptions.botMessageSecret = await window
-                .require('WAWebBotMessageSecret')
-                .genBotMsgSecretFromMsgSecret(botOptions.messageSecret);
-            botOptions.invokedBotWid = window
-                .require('WAWebWidFactory')
-                .createWid(options.invokedBotWid);
-            botOptions.botPersonaId = window
-                .require('WAWebBotProfileCollection')
-                .BotProfileCollection.get(options.invokedBotWid).personaId;
+            botOptions.messageSecret = window.crypto.getRandomValues(new Uint8Array(32));
+            botOptions.botMessageSecret = await window.Store.BotSecret.genBotMsgSecretFromMsgSecret(botOptions.messageSecret);
+            botOptions.invokedBotWid = window.Store.WidFactory.createWid(options.invokedBotWid);
+            botOptions.botPersonaId = window.Store.BotProfiles.BotProfileCollection.get(options.invokedBotWid).personaId;
             delete options.invokedBotWid;
         }
-        const { getMaybeMeLidUser, getMaybeMePnUser } = window.require(
-            'WAWebUserPrefsMeUser',
-        );
-        const lidUser = getMaybeMeLidUser();
-        const meUser = getMaybeMePnUser();
-        const newId = await window.require('WAWebMsgKey').newId();
+
+        const lidUser = window.Store.User.getMaybeMeLidUser();
+        const meUser = window.Store.User.getMaybeMePnUser();
+        const newId = await window.Store.MsgKey.newId();
         let from = chat.id.isLid() ? lidUser : meUser;
         let participant;
 
         if (typeof chat.id?.isGroup === 'function' && chat.id.isGroup()) {
-            from =
-                chat.groupMetadata && chat.groupMetadata.isLidAddressingMode
-                    ? lidUser
-                    : meUser;
-            participant = window
-                .require('WAWebWidFactory')
-                .asUserWidOrThrow(from);
+            from = chat.groupMetadata && chat.groupMetadata.isLidAddressingMode ? lidUser : meUser;
+            participant = window.Store.WidFactory.asUserWidOrThrow(from);
         }
 
         if (typeof chat.id?.isStatus === 'function' && chat.id.isStatus()) {
-            participant = window
-                .require('WAWebWidFactory')
-                .asUserWidOrThrow(from);
+            participant = window.Store.WidFactory.asUserWidOrThrow(from);
         }
 
-        const newMsgKey = new (window.require('WAWebMsgKey'))({
+        const newMsgKey = new window.Store.MsgKey({
             from: from,
             to: chat.id,
             id: newId,
@@ -453,9 +294,7 @@ exports.LoadUtils = () => {
         const extraOptions = options.extraOptions || {};
         delete options.extraOptions;
 
-        const ephemeralFields = window
-            .require('WAWebGetEphemeralFieldsMsgActionsUtils')
-            .getEphemeralFields(chat);
+        const ephemeralFields = window.Store.EphemeralFields.getEphemeralFields(chat);
 
         const message = {
             ...options,
@@ -480,7 +319,7 @@ exports.LoadUtils = () => {
             ...buttonOptions,
             ...listOptions,
             ...botOptions,
-            ...extraOptions,
+            ...extraOptions
         };
 
         // Bot's won't reply if canonicalUrl is set (linking)
@@ -489,100 +328,72 @@ exports.LoadUtils = () => {
         }
 
         if (isChannel) {
-            const msg = new (window.require('WAWebCollections').Msg.modelClass)(
-                message,
-            );
-            const msgDataFromMsgModel = window
-                .require('WAWebMsgDataFromModel')
-                .msgDataFromMsgModel(msg);
+            const msg = new window.Store.Msg.modelClass(message);
+            const msgDataFromMsgModel = window.Store.SendChannelMessage.msgDataFromMsgModel(msg);
             const isMedia = Object.keys(mediaOptions).length > 0;
-            await window
-                .require('WAWebNewsletterUpdateMsgsRecordsJob')
-                .addNewsletterMsgsRecords([msgDataFromMsgModel]);
+            await window.Store.SendChannelMessage.addNewsletterMsgsRecords([msgDataFromMsgModel]);
             chat.msgs.add(msg);
             chat.t = msg.t;
 
-            const sendChannelMsgResponse = await window
-                .require('WAWebNewsletterSendMessageJob')
-                .sendNewsletterMessageJob({
-                    msg: msg,
-                    type:
-                        message.type === 'chat'
-                            ? 'text'
-                            : isMedia
-                              ? 'media'
-                              : 'pollCreation',
-                    newsletterJid: chat.id.toJid(),
-                    ...(isMedia
-                        ? {
-                              mediaMetadata: msg.avParams(),
-                              mediaHandle: isMedia
-                                  ? mediaOptions.mediaHandle
-                                  : null,
-                          }
-                        : {}),
-                });
+            const sendChannelMsgResponse = await window.Store.SendChannelMessage.sendNewsletterMessageJob({
+                msg: msg,
+                type: message.type === 'chat' ? 'text' : isMedia ? 'media' : 'pollCreation',
+                newsletterJid: chat.id.toJid(),
+                ...(isMedia
+                    ? {
+                        mediaMetadata: msg.avParams(),
+                        mediaHandle: isMedia ? mediaOptions.mediaHandle : null,
+                    }
+                    : {}
+                )
+            });
 
             if (sendChannelMsgResponse.success) {
                 msg.t = sendChannelMsgResponse.ack.t;
                 msg.serverId = sendChannelMsgResponse.serverId;
             }
             msg.updateAck(1, true);
-            await window
-                .require('WAWebNewsletterUpdateMsgsRecordsJob')
-                .updateNewsletterMsgRecord(msg);
+            await window.Store.SendChannelMessage.updateNewsletterMsgRecord(msg);
             return msg;
         }
 
         if (isStatus) {
             const { backgroundColor, fontStyle } = extraOptions;
             const isMedia = Object.keys(mediaOptions).length > 0;
-            const mediaUpdate = (data) =>
-                window.require('WAWebMediaUpdateMsg')(data, mediaOptions);
-            const msg = new (window.require('WAWebCollections').Msg.modelClass)(
-                {
-                    ...message,
-                    author: participant ? participant : null,
-                    messageSecret: window.crypto.getRandomValues(
-                        new Uint8Array(32),
-                    ),
-                    cannotBeRanked: window
-                        .require('WAWebStatusGatingUtils')
-                        .canCheckStatusRankingPosterGating(),
-                },
-            );
+            const mediaUpdate = data => window.Store.MediaUpdate(data, mediaOptions);
+            const msg = new window.Store.Msg.modelClass({
+                ...message,
+                author: participant ? participant : null,
+                messageSecret: window.crypto.getRandomValues(new Uint8Array(32)),
+                cannotBeRanked: window.Store.StatusUtils.canCheckStatusRankingPosterGating()
+            });
 
             // for text only
             const statusOptions = {
-                color:
-                    (backgroundColor &&
-                        window.WWebJS.assertColor(backgroundColor)) ||
-                    0xff7acca5,
-                font: (fontStyle >= 0 && fontStyle <= 7 && fontStyle) || 0,
-                text: msg.body,
+                color: backgroundColor && window.WWebJS.assertColor(backgroundColor) || 0xff7acca5,
+                font: fontStyle >= 0 && fontStyle <= 7 && fontStyle || 0,
+                text: msg.body
             };
 
-            await window
-                .require('WAWebSendStatusMsgAction')
-                [
-                    isMedia
-                        ? 'sendStatusMediaMsgAction'
-                        : 'sendStatusTextMsgAction'
-                ](...(isMedia ? [msg, mediaUpdate] : [statusOptions]));
+            await window.Store.StatusUtils[
+                isMedia ?
+                    'sendStatusMediaMsgAction' : 'sendStatusTextMsgAction'
+            ](
+                ...(
+                    isMedia ?
+                        [msg, mediaUpdate] : [statusOptions]
+                )
+            );
 
             return msg;
         }
 
-        const [msgPromise, sendMsgResultPromise] = window
-            .require('WAWebSendMsgChatAction')
-            .addAndSendMsgToChat(chat, message);
+        const [msgPromise, sendMsgResultPromise] = window.Store.SendMessage.addAndSendMsgToChat(chat, message);
         await msgPromise;
 
         if (options.waitUntilMsgSent) await sendMsgResultPromise;
 
-        return window
-            .require('WAWebCollections')
-            .Msg.get(newMsgKey._serialized);
+        return window.Store.Msg.get(newMsgKey._serialized);
     };
 
     window.WWebJS.editMessage = async (msg, content, options = {}) => {
@@ -590,82 +401,69 @@ exports.LoadUtils = () => {
         delete options.extraOptions;
 
         if (options.mentionedJidList) {
-            options.mentionedJidList = options.mentionedJidList.map((id) =>
-                window.require('WAWebWidFactory').createWid(id),
-            );
+            options.mentionedJidList = options.mentionedJidList.map((id) => window.Store.WidFactory.createWid(id));
             options.mentionedJidList = options.mentionedJidList.filter(Boolean);
         }
 
         if (options.groupMentions) {
             options.groupMentions = options.groupMentions.map((e) => ({
                 groupSubject: e.subject,
-                groupJid: window.require('WAWebWidFactory').createWid(e.id),
+                groupJid: window.Store.WidFactory.createWid(e.id)
             }));
         }
 
         if (options.linkPreview) {
-            const { findLink } = window.require('WALinkify');
             delete options.linkPreview;
-            const link = findLink(content);
+            const link = window.Store.Validators.findLink(content);
             if (link) {
-                const preview = await window
-                    .require('WAWebLinkPreviewChatAction')
-                    .getLinkPreview(link);
+                const preview = await window.Store.LinkPreview.getLinkPreview(link);
                 preview.preview = true;
                 preview.subtype = 'url';
                 options = { ...options, ...preview };
             }
         }
 
+
         const internalOptions = {
             ...options,
-            ...extraOptions,
+            ...extraOptions
         };
 
-        await window
-            .require('WAWebSendMessageEditAction')
-            .sendMessageEdit(msg, content, internalOptions);
-        return window.require('WAWebCollections').Msg.get(msg.id._serialized);
+        await window.Store.EditMessage.sendMessageEdit(msg, content, internalOptions);
+        return window.Store.Msg.get(msg.id._serialized);
     };
 
     window.WWebJS.toStickerData = async (mediaInfo) => {
         if (mediaInfo.mimetype == 'image/webp') return mediaInfo;
 
         const file = window.WWebJS.mediaInfoToFile(mediaInfo);
-        const webpSticker = await window
-            .require('WAWebImageUtils')
-            .toWebpSticker(file);
+        const webpSticker = await window.Store.StickerTools.toWebpSticker(file);
         const webpBuffer = await webpSticker.arrayBuffer();
         const data = window.WWebJS.arrayBufferToBase64(webpBuffer);
 
         return {
             mimetype: 'image/webp',
-            data,
+            data
         };
     };
 
     window.WWebJS.processStickerData = async (mediaInfo) => {
-        if (mediaInfo.mimetype !== 'image/webp')
-            throw new Error('Invalid media type');
+        if (mediaInfo.mimetype !== 'image/webp') throw new Error('Invalid media type');
 
         const file = window.WWebJS.mediaInfoToFile(mediaInfo);
         let filehash = await window.WWebJS.getFileHash(file);
         let mediaKey = await window.WWebJS.generateHash(32);
 
         const controller = new AbortController();
-        const uploadedInfo = await window
-            .require('WAWebUploadManager')
-            .encryptAndUpload({
-                blob: file,
-                type: 'sticker',
-                signal: controller.signal,
-                mediaKey,
-                uploadQpl: window
-                    .require('WAWebStartMediaUploadQpl')
-                    .startMediaUploadQpl({
-                        entryPoint: 'MediaUpload',
-                    }),
-            });
+        const uploadedInfo = await window.Store.UploadUtils.encryptAndUpload({
+            blob: file,
+            type: 'sticker',
+            signal: controller.signal,
+            mediaKey,
+            uploadQpl: window.Store.MediaUpload.startMediaUploadQpl({
+                entryPoint: "MediaUpload"
+            }),
+        });
 
         const stickerInfo = {
             ...uploadedInfo,
@@ -674,49 +472,30 @@ exports.LoadUtils = () => {
             uploadhash: uploadedInfo.encFilehash,
             size: file.size,
             type: 'sticker',
-            filehash,
+            filehash
         };
 
         return stickerInfo;
     };
 
-    window.WWebJS.processMediaData = async (
-        mediaInfo,
-        {
-            forceSticker,
-            forceGif,
-            forceVoice,
-            forceDocument,
-            forceMediaHd,
-            sendToChannel,
-            sendToStatus,
-        },
-    ) => {
+    window.WWebJS.processMediaData = async (mediaInfo, { forceSticker, forceGif, forceVoice, forceDocument, forceMediaHd, sendToChannel, sendToStatus }) => {
         const file = window.WWebJS.mediaInfoToFile(mediaInfo);
-        const OpaqueData = window.require('WAWebMediaOpaqueData');
-        const opaqueData = await OpaqueData.createFromData(
-            file,
-            mediaInfo.mimetype,
-        );
+        const opaqueData = await window.Store.OpaqueData.createFromData(file, file.type);
         const mediaParams = {
             asSticker: forceSticker,
             asGif: forceGif,
             isPtt: forceVoice,
-            asDocument: forceDocument,
+            asDocument: forceDocument
         };
 
         if (forceMediaHd && file.type.indexOf('image/') === 0) {
             mediaParams.maxDimension = 2560;
         }
 
-        const mediaPrep = window
-            .require('WAWebPrepRawMedia')
-            .prepRawMedia(opaqueData, mediaParams);
+        const mediaPrep = window.Store.MediaPrep.prepRawMedia(opaqueData, mediaParams);
         const mediaData = await mediaPrep.waitForPrep();
-        const mediaObject = window
-            .require('WAWebMediaStorage')
-            .getOrCreateMediaObject(mediaData.filehash);
-        const mediaType = window.require('WAWebMmsMediaTypes').msgToMediaType({
+        const mediaObject = window.Store.MediaObject.getOrCreateMediaObject(mediaData.filehash);
+        const mediaType = window.Store.MediaTypes.msgToMediaType({
             type: mediaData.type,
             isGif: mediaData.isGif,
             isNewsletter: sendToChannel,
@@ -726,19 +505,16 @@ exports.LoadUtils = () => {
             throw new Error('media-fault: sendToChat filehash undefined');
         }
 
-        if (
-            (forceVoice && mediaData.type === 'ptt') ||
-            (sendToStatus && mediaData.type === 'audio')
-        ) {
+        if ((forceVoice && mediaData.type === 'ptt') || (sendToStatus && mediaData.type === 'audio')) {
             const waveform = mediaObject.contentInfo.waveform;
             mediaData.waveform =
-                waveform || (await window.WWebJS.generateWaveform(file));
+                waveform || await window.WWebJS.generateWaveform(file);
         }
 
-        if (!(mediaData.mediaBlob instanceof OpaqueData)) {
-            mediaData.mediaBlob = await OpaqueData.createFromData(
+        if (!(mediaData.mediaBlob instanceof window.Store.OpaqueData)) {
+            mediaData.mediaBlob = await window.Store.OpaqueData.createFromData(
                 mediaData.mediaBlob,
-                mediaData.mediaBlob.type,
+                mediaData.mediaBlob.type
             );
         }
 
@@ -746,36 +522,24 @@ exports.LoadUtils = () => {
         mediaObject.consolidate(mediaData.toJSON());
 
         mediaData.mediaBlob.autorelease();
-        const shouldUseMediaCache = window
-            .require('WAWebMediaDataUtils')
-            .shouldUseMediaCache(
-                window.require('WAWebMmsMediaTypes').castToV4(mediaObject.type),
-            );
-        if (shouldUseMediaCache && mediaData.mediaBlob instanceof OpaqueData) {
+        const shouldUseMediaCache = window.Store.MediaDataUtils.shouldUseMediaCache(
+            window.Store.MediaTypes.castToV4(mediaObject.type)
+        );
+        if (shouldUseMediaCache && mediaData.mediaBlob instanceof window.Store.OpaqueData) {
             const formData = mediaData.mediaBlob.formData();
-            window
-                .require('WAWebMediaInMemoryBlobCache')
-                .InMemoryMediaBlobCache.put(mediaObject.filehash, formData);
+            window.Store.BlobCache.InMemoryMediaBlobCache.put(mediaObject.filehash, formData);
         }
 
         const dataToUpload = {
             mimetype: mediaData.mimetype,
             mediaObject,
             mediaType,
-            ...(sendToChannel
-                ? {
-                      calculateToken: window.require('WAMediaCalculateFilehash')
-                          .getRandomFilehash,
-                  }
-                : {}),
+            ...(sendToChannel ? { calculateToken: window.Store.SendChannelMessage.getRandomFilehash() } : {})
         };
 
-        const { uploadMedia, uploadUnencryptedMedia } = window.require(
-            'WAWebMediaMmsV4Upload',
-        );
         const uploadedMedia = !sendToChannel
-            ? await uploadMedia(dataToUpload)
-            : await uploadUnencryptedMedia(dataToUpload);
+            ? await window.Store.MediaUpload.uploadMedia(dataToUpload)
+            : await window.Store.MediaUpload.uploadUnencryptedMedia(dataToUpload);
 
         const mediaEntry = uploadedMedia.mediaEntry;
         if (!mediaEntry) {
@@ -803,71 +567,49 @@ exports.LoadUtils = () => {
     window.WWebJS.getMessageModel = (message) => {
         const msg = message.serialize();
 
-        const { findLinks } = window.require('WALinkify');
-
         msg.isEphemeral = message.isEphemeral;
         msg.isStatusV3 = message.isStatusV3;
-        msg.links = findLinks(
-            message.mediaObject ? message.caption : message.body,
-        ).map((link) => ({
+        msg.links = (window.Store.Validators.findLinks(message.mediaObject ? message.caption : message.body)).map((link) => ({
             link: link.href,
-            isSuspicious: Boolean(
-                link.suspiciousCharacters && link.suspiciousCharacters.size,
-            ),
+            isSuspicious: Boolean(link.suspiciousCharacters && link.suspiciousCharacters.size)
         }));
 
         if (msg.buttons) {
             msg.buttons = msg.buttons.serialize();
         }
         if (msg.dynamicReplyButtons) {
-            msg.dynamicReplyButtons = JSON.parse(
-                JSON.stringify(msg.dynamicReplyButtons),
-            );
+            msg.dynamicReplyButtons = JSON.parse(JSON.stringify(msg.dynamicReplyButtons));
         }
         if (msg.replyButtons) {
             msg.replyButtons = JSON.parse(JSON.stringify(msg.replyButtons));
         }
 
         if (typeof msg.id.remote === 'object') {
-            msg.id = Object.assign({}, msg.id, {
-                remote: msg.id.remote._serialized,
-            });
+            msg.id = Object.assign({}, msg.id, { remote: window.WWebJS.widSerialized(msg.id.remote) });
         }
 
         delete msg.pendingAckUpdate;
 
-        return msg;
+        return window.WWebJS.normalizeSerialized(msg);
     };
 
     window.WWebJS.getChat = async (chatId, { getAsModel = true } = {}) => {
         const isChannel = /@\w*newsletter\b/.test(chatId);
-        const chatWid = window.require('WAWebWidFactory').createWid(chatId);
+        const chatWid = window.Store.WidFactory.createWid(chatId);
         let chat;
 
         if (isChannel) {
             try {
-                chat = window
-                    .require('WAWebCollections')
-                    .WAWebNewsletterCollection.get(chatId);
+                chat = window.Store.NewsletterCollection.get(chatId);
                 if (!chat) {
-                    await window
-                        .require('WAWebLoadNewsletterPreviewChatAction')
-                        .loadNewsletterPreviewChat(chatId);
-                    chat = await window
-                        .require('WAWebCollections')
-                        .WAWebNewsletterCollection.find(chatWid);
+                    await window.Store.ChannelUtils.loadNewsletterPreviewChat(chatId);
+                    chat = await window.Store.NewsletterCollection.find(chatWid);
                 }
-            } catch (ignoredError) {
+            } catch (err) {
                 chat = null;
             }
         } else {
-            chat =
-                window.require('WAWebCollections').Chat.get(chatWid) ||
-                (
-                    await window
-                        .require('WAWebFindChatAction')
-                        .findOrCreateLatestChat(chatWid)
-                )?.chat;
+            chat = window.Store.Chat.get(chatWid) || (await window.Store.FindOrCreateChat.findOrCreateLatestChat(chatWid))?.chat;
         }
 
         return getAsModel && chat
@@ -876,62 +618,43 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.getChannelMetadata = async (inviteCode) => {
-        const role = window
-            .require('WAWebNewsletterModelUtils')
-            .getRoleByIdentifier(inviteCode);
-        const response = await window
-            .require('WAWebNewsletterMetadataQueryJob')
-            .queryNewsletterMetadataByInviteCode(inviteCode, role);
+        const response =
+            await window.Store.ChannelUtils.queryNewsletterMetadataByInviteCode(
+                inviteCode,
+                window.Store.ChannelUtils.getRoleByIdentifier(inviteCode)
+            );
 
-        const picUrl =
-            response.newsletterPictureMetadataMixin?.picture[0]
-                ?.queryPictureDirectPathOrEmptyResponseMixinGroup.value
-                .directPath;
+        const picUrl = response.newsletterPictureMetadataMixin?.picture[0]?.queryPictureDirectPathOrEmptyResponseMixinGroup.value.directPath;
 
         return {
             id: response.idJid,
-            createdAtTs:
-                response.newsletterCreationTimeMetadataMixin.creationTimeValue,
+            createdAtTs: response.newsletterCreationTimeMetadataMixin.creationTimeValue,
             titleMetadata: {
                 title: response.newsletterNameMetadataMixin.nameElementValue,
-                updatedAtTs:
-                    response.newsletterNameMetadataMixin.nameUpdateTime,
+                updatedAtTs: response.newsletterNameMetadataMixin.nameUpdateTime
             },
             descriptionMetadata: {
-                description:
-                    response.newsletterDescriptionMetadataMixin
-                        .descriptionQueryDescriptionResponseMixin.elementValue,
-                updatedAtTs:
-                    response.newsletterDescriptionMetadataMixin
-                        .descriptionQueryDescriptionResponseMixin.updateTime,
+                description: response.newsletterDescriptionMetadataMixin.descriptionQueryDescriptionResponseMixin.elementValue,
+                updatedAtTs: response.newsletterDescriptionMetadataMixin.descriptionQueryDescriptionResponseMixin.updateTime
             },
             inviteLink: `https://whatsapp.com/channel/${response.newsletterInviteLinkMetadataMixin.inviteCode}`,
-            membershipType: role,
+            membershipType: window.Store.ChannelUtils.getRoleByIdentifier(inviteCode),
             stateType: response.newsletterStateMetadataMixin.stateType,
             pictureUrl: picUrl ? `https://pps.whatsapp.net${picUrl}` : null,
-            subscribersCount:
-                response.newsletterSubscribersMetadataMixin.subscribersCount,
-            isVerified:
-                response.newsletterVerificationMetadataMixin
-                    .verificationState === 'verified',
+            subscribersCount: response.newsletterSubscribersMetadataMixin.subscribersCount,
+            isVerified: response.newsletterVerificationMetadataMixin.verificationState === 'verified'
         };
     };
 
     window.WWebJS.getChats = async () => {
-        const chats = window.require('WAWebCollections').Chat.getModelsArray();
-        const chatPromises = chats.map((chat) =>
-            window.WWebJS.getChatModel(chat),
-        );
+        const chats = window.Store.Chat.getModelsArray();
+        const chatPromises = chats.map(chat => window.WWebJS.getChatModel(chat));
         return await Promise.all(chatPromises);
     };
 
     window.WWebJS.getChannels = async () => {
-        const channels = window
-            .require('WAWebCollections')
-            .WAWebNewsletterCollection.getModelsArray();
-        const channelPromises = channels?.map((channel) =>
-            window.WWebJS.getChatModel(channel, { isChannel: true }),
-        );
+        const channels = window.Store.NewsletterCollection.getModelsArray();
+        const channelPromises = channels?.map((channel) => window.WWebJS.getChatModel(channel, { isChannel: true }));
         return await Promise.all(channelPromises);
     };
 
@@ -942,151 +665,96 @@ exports.LoadUtils = () => {
         model.isGroup = false;
         model.isMuted = chat.mute?.expiration !== 0;
         if (isChannel) {
-            model.isChannel = window
-                .require('WAWebChatGetters')
-                .getIsNewsletter(chat);
+            model.isChannel = window.Store.ChatGetters.getIsNewsletter(chat);
         } else {
             model.formattedTitle = chat.formattedTitle;
         }
 
         if (chat.groupMetadata) {
             model.isGroup = true;
-            const chatWid = window
-                .require('WAWebWidFactory')
-                .createWid(chat.id._serialized);
-            const groupMetadata =
-                window.require('WAWebCollections').GroupMetadata ||
-                window.require('WAWebCollections').WAWebGroupMetadataCollection;
-            await groupMetadata.update(chatWid);
-            const { toPn } = window.require('WAWebLidMigrationUtils');
-            const serializedMetadata = chat.groupMetadata.serialize();
-            for (const p of serializedMetadata.participants || []) {
-                p.id = toPn(p.id) ?? p.id;
+            const chatWid = window.Store.WidFactory.createWid(window.WWebJS.widSerialized(chat.id));
+            if (window.Store.GroupMetadata && typeof window.Store.GroupMetadata.update === 'function') {
+                await window.Store.GroupMetadata.update(chatWid);
             }
-            model.groupMetadata = serializedMetadata;
+            const participantModels = chat.groupMetadata.participants.getModelsArray?.()
+                || chat.groupMetadata.participants._models
+                || [];
+            participantModels
+                .filter(x => window.WWebJS.widSerialized(x.id)?.endsWith('@lid'))
+                .forEach(x => x.contact?.phoneNumber && (x.id = x.contact.phoneNumber));
+            model.groupMetadata = chat.groupMetadata.serialize();
             model.isReadOnly = chat.groupMetadata.announce;
         }
 
         if (chat.newsletterMetadata) {
-            const newsletterMetadata =
-                window.require('WAWebCollections')
-                    .NewsletterMetadataCollection ||
-                window.require('WAWebCollections')
-                    .WAWebNewsletterMetadataCollection;
-            await newsletterMetadata.update(chat.id);
+            if (window.Store.NewsletterMetadataCollection && typeof window.Store.NewsletterMetadataCollection.update === 'function') {
+                await window.Store.NewsletterMetadataCollection.update(chat.id);
+            }
             model.channelMetadata = chat.newsletterMetadata.serialize();
-            model.channelMetadata.createdAtTs =
-                chat.newsletterMetadata.creationTime;
+            model.channelMetadata.createdAtTs = chat.newsletterMetadata.creationTime;
         }
 
         model.lastMessage = null;
         if (model.msgs && model.msgs.length) {
-            const lastMessage = chat.lastReceivedKey
-                ? window
-                      .require('WAWebCollections')
-                      .Msg.get(chat.lastReceivedKey._serialized) ||
-                  (
-                      await window
-                          .require('WAWebCollections')
-                          .Msg.getMessagesById([
-                              chat.lastReceivedKey._serialized,
-                          ])
-                  )?.messages?.[0]
-                : null;
-            lastMessage &&
-                (model.lastMessage =
-                    window.WWebJS.getMessageModel(lastMessage));
+            try {
+                const lastReceivedKey = window.WWebJS.widSerialized(chat.lastReceivedKey);
+                const lastMessage = lastReceivedKey
+                    ? window.Store.Msg.get(lastReceivedKey) || (await window.Store.Msg.getMessagesById([lastReceivedKey]))?.messages?.[0]
+                    : null;
+                lastMessage && (model.lastMessage = window.WWebJS.getMessageModel(lastMessage));
+            } catch (e) {
+                // lastMessage resolution is best-effort; a key-format change
+                // in WhatsApp Web must not break the whole chat model
+            }
         }
 
         delete model.msgs;
         delete model.msgUnsyncedButtonReplyMsgs;
         delete model.unsyncedButtonReplies;
 
-        return model;
+        return window.WWebJS.normalizeSerialized(model);
     };
 
-    window.WWebJS.getContactModel = (contact) => {
+    window.WWebJS.getContactModel = contact => {
         let res = contact.serialize();
-
-        const wid = window
-            .require('WAWebWidFactory')
-            .createWidFromWidLike(contact.id);
-        if (wid.isLid() && contact.phoneNumber) {
-            res.id = contact.phoneNumber;
-        }
-
-        res.isBusiness =
-            contact.isBusiness === undefined ? false : contact.isBusiness;
+        res.isBusiness = contact.isBusiness === undefined ? false : contact.isBusiness;
 
         if (contact.businessProfile) {
             res.businessProfile = contact.businessProfile.serialize();
         }
 
+        res.isMe = window.Store.ContactMethods.getIsMe(contact);
+        res.isUser = window.Store.ContactMethods.getIsUser(contact);
+        res.isGroup = window.Store.ContactMethods.getIsGroup(contact);
+        res.isWAContact = window.Store.ContactMethods.getIsWAContact(contact);
+        res.isMyContact = window.Store.ContactMethods.getIsMyContact(contact);
         res.isBlocked = contact.isContactBlocked;
-        if (!res.isBlocked) {
-            const alt = window
-                .require('WAWebApiContact')
-                .getAlternateUserWid(wid);
-            if (alt) {
-                res.isBlocked = !!window
-                    .require('WAWebCollections')
-                    .Blocklist.get(alt);
-            }
-        }
-
-        const ContactMethods = window.require('WAWebContactGetters');
-        res.isMe = ContactMethods.getIsMe(contact);
-        res.isUser = ContactMethods.getIsUser(contact);
-        res.isGroup = ContactMethods.getIsGroup(contact);
-        res.isWAContact = ContactMethods.getIsWAContact(contact);
-        res.userid = ContactMethods.getUserid(contact);
-        res.verifiedName = ContactMethods.getVerifiedName(contact);
-        res.verifiedLevel = ContactMethods.getVerifiedLevel(contact);
-        res.statusMute = ContactMethods.getStatusMute(contact);
-        res.name = ContactMethods.getName(contact);
-        res.shortName = ContactMethods.getShortName(contact);
-        res.pushname = ContactMethods.getPushname(contact);
-
-        const { getIsMyContact } = window.require(
-            'WAWebFrontendContactGetters',
-        );
-        res.isMyContact = getIsMyContact(contact);
-        res.isEnterprise = ContactMethods.getIsEnterprise(contact);
+        res.userid = window.Store.ContactMethods.getUserid(contact);
+        res.isEnterprise = window.Store.ContactMethods.getIsEnterprise(contact);
+        res.verifiedName = window.Store.ContactMethods.getVerifiedName(contact);
+        res.verifiedLevel = window.Store.ContactMethods.getVerifiedLevel(contact);
+        res.statusMute = window.Store.ContactMethods.getStatusMute(contact);
+        res.name = window.Store.ContactMethods.getName(contact);
+        res.shortName = window.Store.ContactMethods.getShortName(contact);
+        res.pushname = window.Store.ContactMethods.getPushname(contact);
 
         return res;
     };
 
-    window.WWebJS.getContact = async (contactId) => {
-        const contactWid = window
-            .require('WAWebWidFactory')
-            .createWid(contactId);
-        const contact = await window
-            .require('WAWebCollections')
-            .Contact.find(contactWid);
-        if (contact.isBusiness || contact.isEnterprise) {
-            const bizProfile = await window
-                .require('WAWebCollections')
-                .BusinessProfile.find(contactWid);
-            bizProfile.profileOptions && (contact.businessProfile = bizProfile);
+    window.WWebJS.getContact = async contactId => {
+        const wid = window.Store.WidFactory.createWid(contactId);
+        let contact = await window.Store.Contact.find(wid);
+        if (contact.id._serialized.endsWith('@lid')) {
+            contact.id = contact.phoneNumber;
         }
+        const bizProfile = await window.Store.BusinessProfile.fetchBizProfile(wid);
+        bizProfile.profileOptions && (contact.businessProfile = bizProfile);
         return window.WWebJS.getContactModel(contact);
     };
 
     window.WWebJS.getContacts = () => {
-        const contacts = window
-            .require('WAWebCollections')
-            .Contact.getModelsArray();
-        return Promise.all(
-            contacts.map(async (contact) => {
-                if (contact.isBusiness || contact.isEnterprise) {
-                    await window
-                        .require('WAWebCollections')
-                        .BusinessProfile.find(contact.id)
-                        .catch(() => {});
-                }
-                return window.WWebJS.getContactModel(contact);
-            }),
-        );
+        const contacts = window.Store.Contact.getModelsArray();
+        return contacts.map(contact => window.WWebJS.getContactModel(contact));
     };
 
     window.WWebJS.mediaInfoToFile = ({ data, mimetype, filename }) => {
@@ -1101,65 +769,8 @@ exports.LoadUtils = () => {
         const blob = new Blob([buffer], { type: mimetype });
         return new File([blob], filename, {
             type: mimetype,
-            lastModified: Date.now(),
+            lastModified: Date.now()
         });
-    };
-
-    /**
-     * Resolves the media blob and metadata for a message.
-     * Shared by downloadMedia and downloadMediaStream.
-     * @param {string} msgId
-     * @returns {Promise<{blob: Blob, mimetype: string, filename: string, filesize: number}|null>}
-     */
-    window.WWebJS.resolveMediaBlob = async (msgId) => {
-        const { Msg } = window.require('WAWebCollections');
-        const msg =
-            Msg.get(msgId) ||
-            (await Msg.getMessagesById([msgId]))?.messages?.[0];
-
-        if (
-            !msg ||
-            !msg.mediaData ||
-            msg.mediaData.mediaStage === 'REUPLOADING'
-        ) {
-            return null;
-        }
-
-        // Always call internal downloadMedia - never skip based on
-        // mediaStage, because cache eviction can leave stage=RESOLVED
-        // with empty InMemoryMediaBlobCache.
-        await msg.downloadMedia({
-            downloadEvenIfExpensive: true,
-            rmrReason: 1,
-            isUserInitiated: true,
-        });
-
-        if (
-            msg.mediaData.mediaStage.includes('ERROR') ||
-            msg.mediaData.mediaStage === 'FETCHING'
-        ) {
-            return null;
-        }
-
-        const cached = window
-            .require('WAWebMediaInMemoryBlobCache')
-            .InMemoryMediaBlobCache.get(msg.mediaObject?.filehash);
-
-        let blob;
-        if (cached) {
-            blob = cached;
-        } else if (msg.mediaObject?.mediaBlob) {
-            blob = msg.mediaObject.mediaBlob.forceToBlob();
-        }
-
-        if (!blob) return null;
-
-        return {
-            blob,
-            mimetype: msg.mimetype,
-            filename: msg.filename,
-            filesize: msg.size,
-        };
     };
 
     window.WWebJS.arrayBufferToBase64 = (arrayBuffer) => {
@@ -1194,13 +805,10 @@ exports.LoadUtils = () => {
 
     window.WWebJS.generateHash = async (length) => {
         var result = '';
-        var characters =
-            'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+        var characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
         var charactersLength = characters.length;
         for (var i = 0; i < length; i++) {
-            result += characters.charAt(
-                Math.floor(Math.random() * charactersLength),
-            );
+            result += characters.charAt(Math.floor(Math.random() * charactersLength));
         }
         return result;
     };
@@ -1228,11 +836,11 @@ exports.LoadUtils = () => {
             const normalizedData = filteredData.map((n) => n * multiplier);
 
             const waveform = new Uint8Array(
-                normalizedData.map((n) => Math.floor(100 * n)),
+                normalizedData.map((n) => Math.floor(100 * n))
             );
 
             return waveform;
-        } catch (ignoredError) {
+        } catch (e) {
             return undefined;
         }
     };
@@ -1240,7 +848,7 @@ exports.LoadUtils = () => {
     window.WWebJS.sendClearChat = async (chatId) => {
         let chat = await window.WWebJS.getChat(chatId, { getAsModel: false });
         if (chat !== undefined) {
-            await window.require('WAWebChatClearBridge').sendClear(chat, false);
+            await window.Store.SendClear.sendClear(chat, false);
             return true;
         }
         return false;
@@ -1249,25 +857,24 @@ exports.LoadUtils = () => {
     window.WWebJS.sendDeleteChat = async (chatId) => {
         let chat = await window.WWebJS.getChat(chatId, { getAsModel: false });
         if (chat !== undefined) {
-            await window.require('WAWebDeleteChatAction').sendDelete(chat);
+            await window.Store.SendDelete.sendDelete(chat);
             return true;
         }
         return false;
     };
 
     window.WWebJS.sendChatstate = async (state, chatId) => {
-        chatId = window.require('WAWebWidFactory').createWid(chatId);
+        chatId = window.Store.WidFactory.createWid(chatId);
 
-        const ChatState = window.require('WAWebChatStateBridge');
         switch (state) {
             case 'typing':
-                await ChatState.sendChatStateComposing(chatId);
+                await window.Store.ChatState.sendChatStateComposing(chatId);
                 break;
             case 'recording':
-                await ChatState.sendChatStateRecording(chatId);
+                await window.Store.ChatState.sendChatStateRecording(chatId);
                 break;
             case 'stop':
-                await ChatState.sendChatStatePaused(chatId);
+                await window.Store.ChatState.sendChatStatePaused(chatId);
                 break;
             default:
                 throw 'Invalid chatstate';
@@ -1276,7 +883,7 @@ exports.LoadUtils = () => {
         return true;
     };
 
-    window.WWebJS.getLabelModel = (label) => {
+    window.WWebJS.getLabelModel = label => {
         let res = label.serialize();
         res.hexColor = label.hexColor;
 
@@ -1284,34 +891,28 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.getLabels = () => {
-        const labels = window
-            .require('WAWebCollections')
-            .Label.getModelsArray();
-        return labels.map((label) => window.WWebJS.getLabelModel(label));
+        const labels = window.Store.Label.getModelsArray();
+        return labels.map(label => window.WWebJS.getLabelModel(label));
     };
 
     window.WWebJS.getLabel = (labelId) => {
-        const label = window.require('WAWebCollections').Label.get(labelId);
+        const label = window.Store.Label.get(labelId);
         return window.WWebJS.getLabelModel(label);
     };
 
     window.WWebJS.getChatLabels = async (chatId) => {
         const chat = await window.WWebJS.getChat(chatId);
-        return (chat.labels || []).map((id) => window.WWebJS.getLabel(id));
+        return (chat.labels || []).map(id => window.WWebJS.getLabel(id));
     };
 
     window.WWebJS.getOrderDetail = async (orderId, token, chatId) => {
-        const chatWid = window.require('WAWebWidFactory').createWid(chatId);
-        return window
-            .require('WAWebBizOrderBridge')
-            .queryOrder(chatWid, orderId, 80, 80, token);
+        const chatWid = window.Store.WidFactory.createWid(chatId);
+        return window.Store.QueryOrder.queryOrder(chatWid, orderId, 80, 80, token);
     };
 
     window.WWebJS.getProductMetadata = async (productId) => {
-        let sellerId = window.require('WAWebConnModel').Conn.wid;
-        let product = await window
-            .require('WAWebBizProductCatalogBridge')
-            .queryProduct(sellerId, productId);
+        let sellerId = window.Store.Conn.wid;
+        let product = await window.Store.QueryProduct.queryProduct(sellerId, productId);
         if (product && product.data) {
             return product.data;
         }
@@ -1320,26 +921,20 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.rejectCall = async (peerJid, id) => {
-        let userId = window
-            .require('WAWebUserPrefsMeUser')
-            .getMaybeMePnUser()._serialized;
+        let userId = window.Store.User.getMaybeMePnUser()._serialized;
 
-        const stanza = window.require('WAWap').wap(
-            'call',
-            {
-                id: window.require('WAWap').generateId(),
-                from: userId,
-                to: peerJid,
-            },
-            [
-                window.require('WAWap').wap('reject', {
-                    'call-id': id,
-                    'call-creator': peerJid,
-                    count: '0',
-                }),
-            ],
-        );
-        await window.require('WADeprecatedSendIq').deprecatedCastStanza(stanza);
+        const stanza = window.Store.SocketWap.wap('call', {
+            id: window.Store.SocketWap.generateId(),
+            from: userId,
+            to: peerJid,
+        }, [
+            window.Store.SocketWap.wap('reject', {
+                'call-id': id,
+                'call-creator': peerJid,
+                count: '0',
+            })
+        ]);
+        await window.Store.Socket.deprecatedCastStanza(stanza);
     };
 
     window.WWebJS.cropAndResizeImage = async (media, options = {}) => {
@@ -1349,15 +944,7 @@ exports.LoadUtils = () => {
         if (options.mimetype && !options.mimetype.includes('image'))
             delete options.mimetype;
 
-        options = Object.assign(
-            {
-                size: 640,
-                mimetype: media.mimetype,
-                quality: 0.75,
-                asDataUrl: false,
-            },
-            options,
-        );
+        options = Object.assign({ size: 640, mimetype: media.mimetype, quality: .75, asDataUrl: false }, options);
 
         const img = await new Promise((resolve, reject) => {
             const img = new Image();
@@ -1379,40 +966,25 @@ exports.LoadUtils = () => {
 
         const dataUrl = canvas.toDataURL(options.mimetype, options.quality);
 
-        if (options.asDataUrl) return dataUrl;
+        if (options.asDataUrl)
+            return dataUrl;
 
         return Object.assign(media, {
             mimetype: options.mimetype,
-            data: dataUrl.replace(`data:${options.mimetype};base64,`, ''),
+            data: dataUrl.replace(`data:${options.mimetype};base64,`, '')
         });
     };
 
     window.WWebJS.setPicture = async (chatId, media) => {
-        const thumbnail = await window.WWebJS.cropAndResizeImage(media, {
-            asDataUrl: true,
-            mimetype: 'image/jpeg',
-            size: 96,
-        });
-        const profilePic = await window.WWebJS.cropAndResizeImage(media, {
-            asDataUrl: true,
-            mimetype: 'image/jpeg',
-            size: 640,
-        });
+        const thumbnail = await window.WWebJS.cropAndResizeImage(media, { asDataUrl: true, mimetype: 'image/jpeg', size: 96 });
+        const profilePic = await window.WWebJS.cropAndResizeImage(media, { asDataUrl: true, mimetype: 'image/jpeg', size: 640 });
 
-        const chatWid = window.require('WAWebWidFactory').createWid(chatId);
+        const chatWid = window.Store.WidFactory.createWid(chatId);
         try {
-            const collection =
-                window
-                    .require('WAWebCollections')
-                    .ProfilePicThumb.get(chatId) ||
-                (await window
-                    .require('WAWebCollections')
-                    .ProfilePicThumb.find(chatId));
+            const collection = window.Store.ProfilePicThumb.get(chatId) || await window.Store.ProfilePicThumb.find(chatId);
             if (!collection?.canSet()) return false;
 
-            const res = await window
-                .require('WAWebContactProfilePicThumbBridge')
-                .sendSetPicture(chatWid, thumbnail, profilePic);
+            const res = await window.Store.GroupUtils.sendSetPicture(chatWid, thumbnail, profilePic);
             return res ? res.status === 200 : false;
         } catch (err) {
             if (err.name === 'ServerStatusCodeError') return false;
@@ -1421,16 +993,12 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.deletePicture = async (chatid) => {
-        const chatWid = window.require('WAWebWidFactory').createWid(chatid);
+        const chatWid = window.Store.WidFactory.createWid(chatid);
         try {
-            const collection = window
-                .require('WAWebCollections')
-                .ProfilePicThumb.get(chatid);
+            const collection = window.Store.ProfilePicThumb.get(chatid);
             if (!collection.canDelete()) return;
 
-            const res = await window
-                .require('WAWebContactProfilePicThumbBridge')
-                .requestDeletePicture(chatWid);
+            const res = await window.Store.GroupUtils.requestDeletePicture(chatWid);
             return res ? res.status === 200 : false;
         } catch (err) {
             if (err.name === 'ServerStatusCodeError') return false;
@@ -1439,9 +1007,7 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.getProfilePicThumbToBase64 = async (chatWid) => {
-        const profilePicCollection = await window
-            .require('WAWebCollections')
-            .ProfilePicThumb.find(chatWid);
+        const profilePicCollection = await window.Store.ProfilePicThumb.find(chatWid);
 
         const _readImageAsBase64 = (imageBlob) => {
             return new Promise((resolve) => {
@@ -1469,44 +1035,33 @@ exports.LoadUtils = () => {
                         return base64Image;
                     }
                 }
-            } catch (ignoredError) {
-                /* empty */
-            }
+            } catch (error) { /* empty */ }
         }
         return undefined;
     };
 
-    window.WWebJS.getAddParticipantsRpcResult = async (
-        groupWid,
-        participantWid,
-    ) => {
-        const iqTo = window.require('WAWebWidToJid').widToGroupJid(groupWid);
+    window.WWebJS.getAddParticipantsRpcResult = async (groupWid, participantWid) => {
+        const iqTo = window.Store.WidToJid.widToGroupJid(groupWid);
 
-        const participantArgs = [
-            {
-                participantJid: window
-                    .require('WAWebWidToJid')
-                    .widToUserJid(participantWid),
-            },
-        ];
+        const participantArgs = [{
+            participantJid: window.Store.WidToJid.widToUserJid(participantWid)
+        }];
 
         let rpcResult, resultArgs;
         const data = {
             name: undefined,
             code: undefined,
             inviteV4Code: undefined,
-            inviteV4CodeExp: undefined,
+            inviteV4CodeExp: undefined
         };
 
         try {
-            rpcResult = await window
-                .require('WASmaxGroupsAddParticipantsRPC')
-                .sendAddParticipantsRPC({ participantArgs, iqTo });
-            resultArgs =
-                rpcResult.value.addParticipant[0]
-                    .addParticipantsParticipantAddedOrNonRegisteredWaUserParticipantErrorLidResponseMixinGroup
-                    .value.addParticipantsParticipantMixins;
-        } catch (ignoredError) {
+            rpcResult = await window.Store.GroupParticipants.sendAddParticipantsRPC({ participantArgs, iqTo });
+            resultArgs = rpcResult.value.addParticipant[0]
+                .addParticipantsParticipantAddedOrNonRegisteredWaUserParticipantErrorLidResponseMixinGroup
+                .value
+                .addParticipantsParticipantMixins;
+        } catch (err) {
             data.code = 400;
             return data;
         }
@@ -1516,13 +1071,15 @@ exports.LoadUtils = () => {
             data.name = resultArgs?.name;
             data.code = +code;
             data.inviteV4Code = resultArgs?.value.addRequestCode;
-            data.inviteV4CodeExp =
-                resultArgs?.value.addRequestExpiration?.toString();
-        } else if (rpcResult.name === 'AddParticipantsResponseClientError') {
-            const { code: code } =
-                rpcResult.value.errorAddParticipantsClientErrors.value;
+            data.inviteV4CodeExp = resultArgs?.value.addRequestExpiration?.toString();
+        }
+
+        else if (rpcResult.name === 'AddParticipantsResponseClientError') {
+            const { code: code } = rpcResult.value.errorAddParticipantsClientErrors.value;
             data.code = +code;
-        } else if (rpcResult.name === 'AddParticipantsResponseServerError') {
+        }
+
+        else if (rpcResult.name === 'AddParticipantsResponseServerError') {
             const { code: code } = rpcResult.value.errorServerErrors.value;
             data.code = +code;
         }
@@ -1530,69 +1087,44 @@ exports.LoadUtils = () => {
         return data;
     };
 
-    window.WWebJS.membershipRequestAction = async (
-        groupId,
-        action,
-        requesterIds,
-        sleep,
-    ) => {
-        const groupWid = window.require('WAWebWidFactory').createWid(groupId);
-        const group = await window
-            .require('WAWebCollections')
-            .Chat.find(groupWid);
+    window.WWebJS.membershipRequestAction = async (groupId, action, requesterIds, sleep) => {
+        const groupWid = window.Store.WidFactory.createWid(groupId);
+        const group = await window.Store.Chat.find(groupWid);
         const toApprove = action === 'Approve';
         let membershipRequests;
         let response;
         let result = [];
 
-        await window
-            .require('WAWebGroupQueryJob')
-            .queryAndUpdateGroupMetadataById({ id: groupId });
+        await window.Store.GroupQueryAndUpdate({ id: groupId });
 
         if (!requesterIds?.length) {
-            membershipRequests =
-                group.groupMetadata.membershipApprovalRequests._models.map(
-                    ({ id }) => id,
-                );
+            membershipRequests = group.groupMetadata.membershipApprovalRequests._models.map(({ id }) => id);
         } else {
             !Array.isArray(requesterIds) && (requesterIds = [requesterIds]);
-            membershipRequests = requesterIds.map((r) =>
-                window.require('WAWebWidFactory').createWid(r),
-            );
+            membershipRequests = requesterIds.map(r => window.Store.WidFactory.createWid(r));
         }
 
         if (!membershipRequests.length) return [];
 
-        const participantArgs = membershipRequests.map((m) => ({
+        const participantArgs = membershipRequests.map(m => ({
             participantArgs: [
                 {
-                    participantJid: window
-                        .require('WAWebWidToJid')
-                        .widToUserJid(m),
-                },
-            ],
+                    participantJid: window.Store.WidToJid.widToUserJid(m)
+                }
+            ]
         }));
 
-        const groupJid = window
-            .require('WAWebWidToJid')
-            .widToGroupJid(groupWid);
+        const groupJid = window.Store.WidToJid.widToGroupJid(groupWid);
 
         const _getSleepTime = (sleep) => {
-            if (
-                !Array.isArray(sleep) ||
-                (sleep.length === 2 && sleep[0] === sleep[1])
-            ) {
+            if (!Array.isArray(sleep) || (sleep.length === 2 && sleep[0] === sleep[1])) {
                 return sleep;
             }
             if (sleep.length === 1) {
                 return sleep[0];
             }
-            sleep[1] - sleep[0] < 100 &&
-                (sleep[0] = sleep[1]) &&
-                (sleep[1] += 100);
-            return (
-                Math.floor(Math.random() * (sleep[1] - sleep[0] + 1)) + sleep[0]
-            );
+            sleep[1] - sleep[0] < 100 && (sleep[0] = sleep[1]) && (sleep[1] += 100);
+            return Math.floor(Math.random() * (sleep[1] - sleep[0] + 1)) + sleep[0];
         };
 
         const membReqResCodes = {
@@ -1604,101 +1136,63 @@ exports.LoadUtils = () => {
             408: 'ParticipantTemporarilyBlockedError',
             409: 'ParticipantConflictError',
             412: 'ParticipantParentLinkedGroupsResourceConstraintError',
-            500: 'ParticipantResourceConstraintError',
+            500: 'ParticipantResourceConstraintError'
         };
 
         try {
             for (const participant of participantArgs) {
-                response = await window
-                    .require('WASmaxGroupsMembershipRequestsActionRPC')
-                    .sendMembershipRequestsActionRPC({
-                        iqTo: groupJid,
-                        [toApprove ? 'approveArgs' : 'rejectArgs']: participant,
-                    });
+                response = await window.Store.MembershipRequestUtils.sendMembershipRequestsActionRPC({
+                    iqTo: groupJid,
+                    [toApprove ? 'approveArgs' : 'rejectArgs']: participant
+                });
 
-                if (
-                    response.name === 'MembershipRequestsActionResponseSuccess'
-                ) {
+                if (response.name === 'MembershipRequestsActionResponseSuccess') {
                     const value = toApprove
                         ? response.value.membershipRequestsActionApprove
                         : response.value.membershipRequestsActionReject;
                     if (value?.participant) {
-                        const [_] = value.participant.map((p) => {
+                        const [_] = value.participant.map(p => {
                             const error = toApprove
-                                ? value.participant[0]
-                                      .membershipRequestsActionAcceptParticipantMixins
-                                      ?.value.error
-                                : value.participant[0]
-                                      .membershipRequestsActionRejectParticipantMixins
-                                      ?.value.error;
+                                ? value.participant[0].membershipRequestsActionAcceptParticipantMixins?.value.error
+                                : value.participant[0].membershipRequestsActionRejectParticipantMixins?.value.error;
                             return {
-                                requesterId: window
-                                    .require('WAWebWidFactory')
-                                    .createWid(p.jid)._serialized,
+                                requesterId: window.Store.WidFactory.createWid(p.jid)._serialized,
                                 ...(error
-                                    ? {
-                                          error: +error,
-                                          message:
-                                              membReqResCodes[error] ||
-                                              membReqResCodes.default,
-                                      }
-                                    : {
-                                          message: `${toApprove ? 'Approved' : 'Rejected'} successfully`,
-                                      }),
+                                    ? { error: +error, message: membReqResCodes[error] || membReqResCodes.default }
+                                    : { message: `${toApprove ? 'Approved' : 'Rejected'} successfully` })
                             };
                         });
                         _ && result.push(_);
                     }
                 } else {
                     result.push({
-                        requesterId: window
-                            .require('WAWebJidToWid')
-                            .userJidToUserWid(
-                                participant.participantArgs[0].participantJid,
-                            )._serialized,
-                        message: 'ServerStatusCodeError',
+                        requesterId: window.Store.JidToWid.userJidToUserWid(participant.participantArgs[0].participantJid)._serialized,
+                        message: 'ServerStatusCodeError'
                     });
                 }
 
                 sleep &&
                     participantArgs.length > 1 &&
-                    participantArgs.indexOf(participant) !==
-                        participantArgs.length - 1 &&
-                    (await new Promise((resolve) =>
-                        setTimeout(resolve, _getSleepTime(sleep)),
-                    ));
+                    participantArgs.indexOf(participant) !== participantArgs.length - 1 &&
+                    (await new Promise((resolve) => setTimeout(resolve, _getSleepTime(sleep))));
             }
             return result;
-        } catch (ignoredError) {
+        } catch (err) {
             return [];
         }
     };
 
-    window.WWebJS.subscribeToUnsubscribeFromChannel = async (
-        channelId,
-        action,
-        options = {},
-    ) => {
-        const channel = await window.WWebJS.getChat(channelId, {
-            getAsModel: false,
-        });
+    window.WWebJS.subscribeToUnsubscribeFromChannel = async (channelId, action, options = {}) => {
+        const channel = await window.WWebJS.getChat(channelId, { getAsModel: false });
 
-        if (!channel || channel.newsletterMetadata.membershipType === 'owner')
-            return false;
-        options = {
-            eventSurface: 3,
-            deleteLocalModels: options.deleteLocalModels ?? true,
-        };
+        if (!channel || channel.newsletterMetadata.membershipType === 'owner') return false;
+        options = { eventSurface: 3, deleteLocalModels: options.deleteLocalModels ?? true };
 
         try {
             if (action === 'Subscribe') {
-                await window
-                    .require('WAWebNewsletterSubscribeAction')
-                    .subscribeToNewsletterAction(channel, options);
+                await window.Store.ChannelUtils.subscribeToNewsletterAction(channel, options);
             } else if (action === 'Unsubscribe') {
-                await window
-                    .require('WAWebNewsletterUnsubscribeAction')
-                    .unsubscribeFromNewsletterAction(channel, options);
+                await window.Store.ChannelUtils.unsubscribeFromNewsletterAction(channel, options);
             } else return false;
             return true;
         } catch (err) {
@@ -1708,71 +1202,49 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.pinUnpinMsgAction = async (msgId, action, duration) => {
-        const message =
-            window.require('WAWebCollections').Msg.get(msgId) ||
-            (
-                await window
-                    .require('WAWebCollections')
-                    .Msg.getMessagesById([msgId])
-            )?.messages?.[0];
+        const message = window.Store.Msg.get(msgId) || (await window.Store.Msg.getMessagesById([msgId]))?.messages?.[0];
         if (!message) return false;
 
         if (typeof duration !== 'number') return false;
 
-        const originalFunction = window.require(
-            'WAWebPinMsgConstants',
-        ).getPinExpiryDuration;
-        window.require('WAWebPinMsgConstants').getPinExpiryDuration = () =>
-            duration;
+        const originalFunction = window.require('WAWebPinMsgConstants').getPinExpiryDuration;
+        window.require('WAWebPinMsgConstants').getPinExpiryDuration = () => duration;
 
-        const response = await window
-            .require('WAWebSendPinMessageAction')
-            .sendPinInChatMsg(message, action, duration);
+        const response = await window.Store.PinnedMsgUtils.sendPinInChatMsg(message, action, duration);
 
-        window.require('WAWebPinMsgConstants').getPinExpiryDuration =
-            originalFunction;
+        window.require('WAWebPinMsgConstants').getPinExpiryDuration = originalFunction;
 
         return response.messageSendResult === 'OK';
     };
 
-    window.WWebJS.getStatusModel = (status) => {
+    window.WWebJS.getStatusModel = status => {
         const res = status.serialize();
         delete res._msgs;
         return res;
     };
 
     window.WWebJS.getAllStatuses = () => {
-        const statuses = window
-            .require('WAWebCollections')
-            .Status.getModelsArray();
-        return statuses.map((status) => window.WWebJS.getStatusModel(status));
+        const statuses = window.Store.Status.getModelsArray();
+        return statuses.map(status => window.WWebJS.getStatusModel(status));
     };
 
     window.WWebJS.enforceLidAndPnRetrieval = async (userId) => {
-        const wid = window.require('WAWebWidFactory').createWid(userId);
+        const wid = window.Store.WidFactory.createWid(userId);
         const isLid = wid.server === 'lid';
 
-        let lid = isLid
-            ? wid
-            : window.require('WAWebApiContact').getCurrentLid(wid);
-        let phone = isLid
-            ? window.require('WAWebApiContact').getPhoneNumber(wid)
-            : wid;
+        let lid = isLid ? wid : window.Store.LidUtils.getCurrentLid(wid);
+        let phone = isLid ? window.Store.LidUtils.getPhoneNumber(wid) : wid;
 
         if (!isLid && !lid) {
-            const queryResult = await window
-                .require('WAWebQueryExistsJob')
-                .queryWidExists(wid);
+            const queryResult = await window.Store.QueryExist(wid);
             if (!queryResult?.wid) return {};
-            lid = window.require('WAWebApiContact').getCurrentLid(wid);
+            lid = window.Store.LidUtils.getCurrentLid(wid);
         }
 
         if (isLid && !phone) {
-            const queryResult = await window
-                .require('WAWebQueryExistsJob')
-                .queryWidExists(wid);
+            const queryResult = await window.Store.QueryExist(wid);
             if (!queryResult?.wid) return {};
-            phone = window.require('WAWebApiContact').getPhoneNumber(wid);
+            phone = window.Store.LidUtils.getPhoneNumber(wid);
         }
 
         return { lid, phone };


### PR DESCRIPTION
## Resumo

Corrige compatibilidade com builds recentes do WhatsApp Web (2.3000.1043xxx, Julho 2026) que mudaram a API interna.

## O que mudou no WA Web

1. **Serialização de IDs**: WIDs e MsgKeys agora expõem o serializado como `$1` em vez de `_serialized`. Acessar `. _serialized` retorna `undefined`, causando crash em `getChatById` e outras funções.

2. **Sistema de módulos**: O novo WA Web expõe as APIs internas via `window.Store.*` em vez de `window.require('WAWeb*')`.

3. **Message loading**: O método antigo `WAWebChatLoadMessages.loadEarlierMsgs` não funciona mais — agora usa `WAWebDBMessageFindLocal`.

## O que foi feito

### Utils.js (injected code)
- **`widSerialized()`**: Nova helper que tenta `_serialized` → `$1` → `toString()` em fallback
- **`normalizeSerialized()`**: Recursivamente copia `$1` para `_serialized` em objetos serializados, mantendo compatibilidade com código node-side existente
- **Migração `window.Store.*`**: Todas as chamadas `window.require('WAWeb*')` substituídas por `window.Store.*`
- **`getMessageModel`**: Usa `widSerialized()` para o `msg.id.remote` e chama `normalizeSerialized()` no retorno
- **`getChatModel`**: Usa `widSerialized()` para chat.id e lastReceivedKey; envolve resolução de lastMessage em try-catch; chama `normalizeSerialized()` no retorno

### Chat.js (node-side)
- **`fetchMessages()`**: Reescrevido para usar `WAWebDBMessageFindLocal` com:
  - Suporte a `msgFindByDirection` (novo) e `msgFindBefore` (fallback)
  - Key conversion com suporte a `$1`/ `_serialized`
  - Deduplicação por msgId
  - Paginação robusta com batch loading

## Stack trace resolvido
\`
node:internal/process/promises:391
triggerUncaughtException(err, true /* fromPromise */);
^
r: r
    at #evaluate (.../puppeteer-core/.../ExecutionContext.js:391)
    at Client.getChatById (.../whatsapp-web.js/src/Client.js:1754)
\`

A causa raiz: `getChatById` → `window.WWebJS.getChat(chatId)` → `getChatModel` → `chat.id._serialized` retornava `undefined` porque o WA Web agora expõe como `chat.id.$1`.

## Issue relacionada
https://github.com/wwebjs/whatsapp-web.js/issues/201831