### PR TITLE
fix(util): tolerate concurrent exposeFunction registrations

### DIFF
--- a/src/util/Puppeteer.js
+++ b/src/util/Puppeteer.js
@@ -17,7 +17,17 @@ async function exposeFunctionIfAbsent(page, name, fn) {
     if (exist) {
         return;
     }
-    await page.exposeFunction(name, fn);
+    try {
+        await page.exposeFunction(name, fn);
+    } catch (err) {
+        // The existence check above and exposeFunction are two separate steps, so
+        // concurrent injections (e.g. during the post-authentication page reload)
+        // can both pass the check and the slower one throws "already exists".
+        // The binding is present either way, so that error is safe to ignore.
+        if (!/already exists/.test(err.message)) {
+            throw err;
+        }
+    }
 }
 
 module.exports = { exposeFunctionIfAbsent };


### PR DESCRIPTION
## Description

`exposeFunctionIfAbsent()` checks whether a binding exists and then calls `page.exposeFunction()` as two separate steps. When two injections run concurrently — which happens during the page reload right after QR authentication — both can pass the existence check, and the slower one crashes the whole app with:

```
Error: Failed to add page binding with name onQRChangedEvent: window['onQRChangedEvent'] already exists!
```

Since the binding exists either way, this PR catches that specific error and ignores it. Any other error is still thrown.

This is a small race-condition fix only — it does not address the `_serialized` → `$1` rename breakage (that is covered by #201850).

## Related Issue(s)

No dedicated open issue for this crash. For context: #201852 proposed a similar guard, but its source fork has since been deleted, so it can no longer be merged. The `exposeFunctionIfAbsent` helper itself was introduced in #3233.

## Testing Summary

### Test Details

- Reproduced in production: the server crashed with the error above during QR authentication (the client re-injects while the page reloads). With this fix applied via `patch-package`, QR authentication and subsequent reconnects complete cleanly; no `already exists` crashes since.
- `npm run lint` passes. `npm run format:check` reports a pre-existing warning for `index.d.ts` on `main`, which this PR does not touch (`prettier --check src/util/Puppeteer.js` passes).
- The mocha suite requires a live WhatsApp session (`WWEBJS_TEST_REMOTE_ID`), which I could not run.

### Environment

- Machine OS: Ubuntu 26.04 (Hetzner VPS); also verified on macOS 15
- Phone OS: iOS
- whatsapp-web.js: 1.34.7 (patch identical to this PR)
- WhatsApp Web: 2.3000.1043890899
- Node.js: 22 / Browser: Google Chrome 150 (stable), headless, `LocalAuth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
