### PR TITLE
fix(media): send comma-separated Accept header in fromUrl

### DIFF
--- a/src/structures/MessageMedia.js
+++ b/src/structures/MessageMedia.js
@@ -75,7 +75,7 @@ class MessageMedia {
 
         async function fetchData(url, options) {
             const reqOptions = Object.assign(
-                { headers: { accept: 'image/* video/* text/* audio/*' } },
+                { headers: { accept: 'image/*, video/*, text/*, audio/*' } },
                 options,
             );
             const response = await fetch(url, reqOptions);


### PR DESCRIPTION
## Description

`MessageMedia.fromUrl` builds the `Accept` request header as a **space-separated** list:

```js
{ headers: { accept: 'image/* video/* text/* audio/*' } }
```

[RFC 9110 §12.5.1](https://www.rfc-editor.org/rfc/rfc9110#name-accept) defines `Accept` as a **comma-separated** list of media ranges. With spaces, the entire string is parsed as one single (malformed) media range, so servers that validate the header see a request that accepts nothing they can serve.

This PR changes the separator to `, `.

A detail worth flagging: the failure is not always loud. `fetchData` reads the response body regardless of status code, and `mimetype` is derived from the URL path when it can be resolved. So a `406 Not Acceptable` comes back as a `MessageMedia` whose `mimetype` is `image/png` but whose `data` is the base64 of the error page — silently corrupt media rather than a thrown error. Fixing the header removes the trigger; the broader "don't treat non-2xx as media" question is left out of scope for this PR.

## Related Issue(s)

closes #201817

## Testing Summary

### Test Details

Since this code path does not touch the browser (`fromUrl` without `options.client` uses `node-fetch` directly), I verified it against a local HTTP server that parses `Accept` strictly per RFC 9110 and answers `406` when no media range matches `image/png`.

Reproduction script:

```js
const http = require('http');
const MessageMedia = require('./src/structures/MessageMedia');

const PNG = Buffer.from(
    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
    'base64',
);

function accepts(headerValue, mimetype) {
    const ranges = headerValue.split(',').map((r) => r.split(';')[0].trim());
    if (!ranges.every((r) => /^[\w.+-]+\/[\w.*+-]+$|^\*\/\*$/.test(r))) {
        return { ok: false, ranges };
    }
    const [type] = mimetype.split('/');
    return { ok: ranges.some((r) => r === '*/*' || r === `${type}/*` || r === mimetype), ranges };
}

const server = http.createServer((req, res) => {
    const result = accepts(req.headers.accept || '', 'image/png');
    console.log('  header recebido :', JSON.stringify(req.headers.accept));
    console.log('  media ranges    :', JSON.stringify(result.ranges));
    if (!result.ok) {
        res.writeHead(406, { 'Content-Type': 'text/plain' });
        return res.end('Not Acceptable');
    }
    res.writeHead(200, { 'Content-Type': 'image/png', 'Content-Length': PNG.length });
    res.end(PNG);
});

server.listen(0, async () => {
    const url = `http://127.0.0.1:${server.address().port}/pixel.png`;
    const media = await MessageMedia.fromUrl(url);
    const bytes = Buffer.from(media.data, 'base64');
    const isPng = bytes.subarray(1, 4).toString() === 'PNG';
    console.log('  mimetype        :', media.mimetype);
    console.log('  conteudo        :', isPng ? 'PNG valido' : JSON.stringify(bytes.toString().slice(0, 40)));
    server.close();
});
```

Before (current `main`):

```text
  header recebido : "image/* video/* text/* audio/*"
  media ranges    : ["image/* video/* text/* audio/*"]
  mimetype        : image/png
  conteudo        : "Not Acceptable"
```

After (this branch):

```text
  header recebido : "image/*, video/*, text/*, audio/*"
  media ranges    : ["image/*","video/*","text/*","audio/*"]
  mimetype        : image/png
  conteudo        : PNG valido
```

`npm run lint` passes. `npm test` was **not** run: the suite in `tests/` requires an authenticated WhatsApp Web session plus a second phone number, which I do not have available — and this change does not reach any code the suite exercises.

### Environment

- Machine OS: Ubuntu (Linux 7.0.0-28-generic)
- Phone OS: n/a — this change does not involve a paired device
- Library Version: 1.34.7
- WhatsApp Web Version: n/a — `fromUrl` runs outside the browser page in this code path
- Browser Type and Version: n/a
- Node Version: 22.23.2

## Type of Change

- [ ] **Dependency change** _(package changes such as removals, upgrades, or additions)_
- [x] **Bug fix** _(non-breaking change that fixes an issue)_
- [ ] **New feature** _(non-breaking change that adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to change)_
- [ ] **Non-code change** _(documentation, README, etc.)_

## Checklist

- [x] My code follows the style guidelines of this project.
- [ ] All new and existing tests pass (`npm test`). — see note above; `npm run lint` passes
- [x] Typings (e.g. `index.d.ts`) have been updated if necessary. — no typing surface changed
- [x] Usage examples (e.g. `example.js`) / documentation have been updated if applicable. — no public API change
