### PR TITLE
fix(remoteauth): pass the archive path to store.save

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -847,7 +847,10 @@ declare namespace WAWebJS {
             session: string;
         }) => Promise<boolean> | boolean;
         delete: (options: { session: string }) => Promise<any> | any;
-        save: (options: { session: string }) => Promise<any> | any;
+        save: (options: {
+            session: string;
+            path: string;
+        }) => Promise<any> | any;
         extract: (options: {
             session: string;
             path: string;

--- a/src/authStrategies/RemoteAuth.js
+++ b/src/authStrategies/RemoteAuth.js
@@ -18,7 +18,11 @@ const BaseAuthStrategy = require('./BaseAuthStrategy');
 /**
  * Remote-based authentication
  * @param {object} options - options
- * @param {object} options.store - Remote database store instance
+ * @param {object} options.store - Remote database store instance. `save` and
+ * `extract` both receive `{ session, path }`, where `session` is the storage
+ * key and `path` is the absolute path of the session archive on disk: the file
+ * to upload for `save`, the destination to download to for `extract`. Stores
+ * must not resolve the archive from `session` alone, as it is only a name.
  * @param {string} options.clientId - Client id to distinguish instances if you are using multiple, otherwise keep null if you are using only one instance
  * @param {string} options.dataPath - Change the default path for saving session files, default is: "./.wwebjs_auth/"
  * @param {number} options.backupSyncIntervalMs - Sets the time interval for periodic session backups. Accepts values starting from 60000ms {1 minute}
@@ -127,7 +131,14 @@ class RemoteAuth extends BaseAuthStrategy {
         }
         var self = this;
         this.backupSync = setInterval(async function () {
-            await self.storeRemoteSession();
+            try {
+                await self.storeRemoteSession();
+            } catch (err) {
+                /* A rejection here has no caller to await it, so it would
+                 * surface as an unhandled rejection and can take the process
+                 * down. Keep the interval alive and let the next tick retry. */
+                console.error('Failed to store remote session', err);
+            }
         }, this.backupSyncIntervalMs);
     }
 
@@ -140,6 +151,7 @@ class RemoteAuth extends BaseAuthStrategy {
             compressedSessionPath = await this.compressSession();
             await this.store.save({
                 session: this.sessionName,
+                path: compressedSessionPath,
             });
             if (options && options.emit)
                 this.client.emit(Events.REMOTE_SESSION_SAVED);


### PR DESCRIPTION
## Description

`RemoteAuth` hands `store.save()` only `{ session }`, which is a name — not a location. A store therefore has no way to find the archive it is supposed to upload. Every published store resolves it as `${session}.zip` relative to the **process CWD**, while `compressSession()` writes it to **`dataPath`**:

```js
// src/authStrategies/RemoteAuth.js
const outPath = path.join(this.dataPath, `${this.sessionName}.zip`);  // written here
...
await this.store.save({ session: this.sessionName });                 // read from CWD
```

Hence the reported failure right after `ready`:

```text
[Error: ENOENT: no such file or directory, open 'RemoteAuth-<id>.zip']
```

This is not a regression to revert. #201660 correctly stopped leaking the local filesystem path into the remote storage key (`sessions/Users/me/project/.wwebjs_auth/RemoteAuth-default.zip`), and that behaviour must stay. The real problem is older: **`session` was overloaded to mean both the storage key and the local file path.** `store.extract()` already avoids this — it receives `{ session, path }` and works correctly. `save()` is simply missing its half of that contract, and `index.d.ts` encodes the same asymmetry:

```ts
delete:  (options: { session: string }) => ...
save:    (options: { session: string }) => ...            // <- no path
extract: (options: { session: string; path: string }) => ...
```

This PR makes `save` symmetric with `extract`, so `session` stays purely the storage key and `path` carries the location.

### Second change: unhandled rejection on periodic backup

`storeRemoteSession()` runs from a `setInterval` callback with nothing awaiting it:

```js
this.backupSync = setInterval(async function () {
    await self.storeRemoteSession();
}, this.backupSyncIntervalMs);
```

A rejection there becomes an **unhandled rejection**, which is fatal on Node 15+ under the default `--unhandled-rejections=throw`. This is also why the ENOENT in the issue appears bare, with no stack and no apparent caller, after the client is already up. The interval callback now catches, logs (matching the existing pattern in `webCache/RemoteWebCache.js:31`), and lets the next tick retry instead of taking the process down.

### ⚠️ This needs a store-side counterpart

I want to be explicit, because it affects whether this alone closes the issue: **stores must read `options.path` for the fix to take effect.** `wwebjs-mongo` still does

```js
fs.createReadStream(`${options.session}.zip`)   // src/MongoStore.js
```

and its source has had no commit since 2022-07-11, so I would not assume the store ecosystem updates on its own here.

That leaves a decision I do not think a first-time contributor should make unilaterally, so I would rather ask: **do you want this PR to also carry a backward-compatibility shim** so unmodified stores keep working — e.g. `compressSession()` writing (or hard-linking) the archive to the CWD location legacy stores expect, cleaned up in the existing `finally`? I deliberately left it out to keep this diff minimal and the contract clean, but I am happy to add it in this PR. I can also open the one-line companion PR against `wwebjs-mongo` if that helps.

## Related Issue(s)

closes #201794

<!-- likely the same root cause, worth re-testing once stores adopt `options.path`: -->
relates to #201748

## Testing Summary

### Test Details

The suite in `tests/` needs an authenticated session and a second phone, so I verified `storeRemoteSession()` directly against two store stubs — one shaped like the published stores, one that uses `path`. No WhatsApp session is involved:

```js
const legacyStore = {
    sessionExists: async () => false,
    delete: async () => {}, extract: async () => {},
    save: async (options) => { await fs.promises.readFile(`${options.session}.zip`); },
};

const pathAwareStore = {
    sessionExists: async () => false,
    delete: async () => {}, extract: async () => {},
    save: async (options) => {
        if (!options.path) throw new Error('store received no `path` option');
        await fs.promises.readFile(options.path);
    },
};

// dataPath seeded with Default/{IndexedDB,Local Storage}, then:
auth.sessionName = 'RemoteAuth-test';
auth.userDataDir = path.join(dataPath, 'RemoteAuth-test');
await auth.storeRemoteSession();
```

Before (current `main`):

```text
  store legado       -> FALHOU: ENOENT ENOENT: no such file or directory, open 'RemoteAuth-test.zip'
  store com path     -> FALHOU:  store received no `path` option
```

After (this branch):

```text
  store legado       -> FALHOU: ENOENT ENOENT: no such file or directory, open 'RemoteAuth-test.zip'
  store com path     -> OK, sessao enviada
```

Note the first line is unchanged by design — that is the store-side gap described above, reproducing the exact error from the issue.

`npm run lint` passes. `npm test` was **not** run, for the session reason above.

### Environment

- Machine OS: Ubuntu (Linux 7.0.0-28-generic)
- Phone OS: n/a — verified below the browser layer, no paired device involved
- Library Version: 1.34.7
- WhatsApp Web Version: n/a — `storeRemoteSession()` runs outside the page
- Browser Type and Version: n/a
- Node Version: 22.23.2

## Type of Change

- [ ] **Dependency change** _(package changes such as removals, upgrades, or additions)_
- [x] **Bug fix** _(non-breaking change that fixes an issue)_
- [ ] **New feature** _(non-breaking change that adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to change)_
- [ ] **Non-code change** _(documentation, README, etc.)_

Not marked as breaking: `save` receives an **additional** option, so stores that ignore it behave exactly as they do today.

## Checklist

- [x] My code follows the style guidelines of this project.
- [ ] All new and existing tests pass (`npm test`). — see note above; `npm run lint` passes
- [x] Typings (e.g. `index.d.ts`) have been updated if necessary.
- [x] Usage examples (e.g. `example.js`) / documentation have been updated if applicable. — the store contract is now documented in the `RemoteAuth` JSDoc
