### PR TITLE
feat: expose call outcome on call_log messages

### DIFF
--- a/example.js
+++ b/example.js
@@ -67,6 +67,14 @@ client.on('ready', async () => {
 client.on('message', async (msg) => {
     console.log('MESSAGE RECEIVED', msg);
 
+    if (msg.type === 'call_log') {
+        // Call log messages carry the outcome of a call, e.g. 'AcceptedElsewhere'
+        // when the call was answered on one of your other linked devices
+        console.log(
+            `Call from ${msg.from} ended with outcome: ${msg.callOutcome}`,
+        );
+    }
+
     if (msg.body === '!ping reply') {
         // Send a new message as a reply to the current one
         msg.reply('pong');

--- a/index.d.ts
+++ b/index.d.ts
@@ -212,10 +212,7 @@ declare namespace WAWebJS {
         ): Promise<Message>;
 
         /** Send a reaction to a specific messageId */
-        sendReaction(
-            messageId: string,
-            reaction: string,
-        ): Promise<void>;
+        sendReaction(messageId: string, reaction: string): Promise<void>;
 
         /** Sends a channel admin invitation to a user, allowing them to become an admin of the channel */
         sendChannelAdminInvite(
@@ -1196,6 +1193,12 @@ declare namespace WAWebJS {
         isGif: boolean;
         /** Indicates if the message will disappear after it expires */
         isEphemeral: boolean;
+        /** Outcome of the call, for `call_log` messages (e.g. 'Completed', 'Missed', 'Rejected', 'AcceptedElsewhere') */
+        callOutcome?: string;
+        /** Duration of the call in seconds, for `call_log` messages */
+        callDuration?: number;
+        /** Indicates if the call was a video call, for `call_log` messages */
+        isVideoCall?: boolean;
         /** ID for the Chat that this message was sent to, except if the message was sent by the current user */
         from: string;
         /** Indicates if the message was sent by the current user */

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -342,6 +342,26 @@ class Message extends Base {
                 : [];
         }
 
+        if (this.type === MessageTypes.CALL_LOG) {
+            /**
+             * Outcome of the call, for `call_log` messages. Common values are
+             * 'Completed', 'Missed', 'Rejected', 'Cancelled', 'Failed' and
+             * 'AcceptedElsewhere' (the call was answered on another device)
+             * @type {string}
+             */
+            this.callOutcome = data.callOutcome;
+            /**
+             * Duration of the call in seconds, for `call_log` messages
+             * @type {number}
+             */
+            this.callDuration = data.callDuration;
+            /**
+             * Indicates if the call was a video call, for `call_log` messages
+             * @type {boolean}
+             */
+            this.isVideoCall = Boolean(data.isVideoCall);
+        }
+
         return super._patch(data);
     }
 

--- a/tests/callLog.js
+++ b/tests/callLog.js
@@ -1,0 +1,56 @@
+const chai = require('chai');
+const Message = require('../src/structures/Message');
+
+const expect = chai.expect;
+
+// Unit test: constructs a Message from a call_log payload and checks that the
+// call metadata is exposed. No live session needed.
+describe('Message call_log', function () {
+    const client = {};
+
+    function build(overrides) {
+        return new Message(client, {
+            id: {
+                id: 'ABCDEF0123456789',
+                _serialized: 'false_123@c.us_ABCDEF0123456789',
+                fromMe: false,
+                remote: '123@c.us',
+            },
+            type: 'call_log',
+            t: 1700000000,
+            from: '123@c.us',
+            to: '456@c.us',
+            ...overrides,
+        });
+    }
+
+    it('exposes the call outcome, duration and video flag', function () {
+        const msg = build({
+            callOutcome: 'AcceptedElsewhere',
+            callDuration: 0,
+            isVideoCall: false,
+        });
+        expect(msg.type).to.equal('call_log');
+        expect(msg.callOutcome).to.equal('AcceptedElsewhere');
+        expect(msg.callDuration).to.equal(0);
+        expect(msg.isVideoCall).to.equal(false);
+    });
+
+    it('reports a completed video call', function () {
+        const msg = build({
+            callOutcome: 'Completed',
+            callDuration: 42,
+            isVideoCall: true,
+        });
+        expect(msg.callOutcome).to.equal('Completed');
+        expect(msg.callDuration).to.equal(42);
+        expect(msg.isVideoCall).to.equal(true);
+    });
+
+    it('does not set call fields on non call_log messages', function () {
+        const msg = build({ type: 'chat', body: 'hi' });
+        expect(msg.callOutcome).to.equal(undefined);
+        expect(msg.callDuration).to.equal(undefined);
+        expect(msg.isVideoCall).to.equal(undefined);
+    });
+});


### PR DESCRIPTION
## What

Exposes the outcome of `call_log` messages on the `Message` structure: `message.callOutcome`, `message.callDuration` and `message.isVideoCall`.

## Why

There was no way to tell how a call ended. In particular, when an incoming call is answered on one of the account's other linked devices, `callOutcome` is `'AcceptedElsewhere'`, which lets a bot know it should not auto-answer. Other common values include `'Completed'`, `'Missed'`, `'Rejected'`, `'Cancelled'` and `'Failed'`.

Requested in the call PR discussion (#201825).

## How

`call_log` messages already carry the outcome in their serialized model; this just surfaces it (along with the duration and the video flag) on the `Message` structure. `call_log` messages are delivered through the existing `message` / `message_create` events, so no new event is needed.

## Usage

```js
client.on('message', (msg) => {
    if (msg.type === 'call_log' && msg.callOutcome === 'AcceptedElsewhere') {
        // The call was answered on another linked device
    }
});
```

## Tested

- Verified against a live session: an incoming call answered on another device produced a `call_log` message with `callOutcome: 'AcceptedElsewhere'`; a normal completed call read `'Completed'`.
- Unit tests added in `tests/callLog.js`.
