### PR TITLE
feat: play video and images into calls

### DIFF
--- a/example.js
+++ b/example.js
@@ -697,7 +697,24 @@ client.on('call', async (call) => {
         call.from,
         `[${call.fromMe ? 'Outgoing' : 'Incoming'}] Phone call from ${call.from}, type ${call.isGroup ? 'group' : ''} ${call.isVideo ? 'video' : 'audio'} call. ${rejectCalls ? 'This call was automatically rejected by the script.' : ''}`,
     );
+
+    // Instead of rejecting, a call can also be answered and an audio clip
+    // (e.g. a text-to-speech file you generated) can be played into it:
+    // await call.accept(); // answers with audio only, even for video calls
+    // await call.playAudio(MessageMedia.fromFilePath('./welcome.mp3'));
+    // await call.end();
 });
+
+// Placing an outgoing call and speaking once the other party answers:
+// const call = await client.call('1234567890', { waitForAnswer: true });
+// if (await call.isConnected()) {
+//     await call.playAudio(MessageMedia.fromFilePath('./message.mp3'));
+//     await call.end();
+// }
+
+// Checking for an ongoing call and hanging it up:
+// const activeCall = await client.getActiveCall();
+// if (activeCall) await activeCall.end();
 
 client.on('disconnected', (reason) => {
     console.log('Client was logged out', reason);

--- a/example.js
+++ b/example.js
@@ -712,6 +712,17 @@ client.on('call', async (call) => {
 //     await call.end();
 // }
 
+// Placing a video call and showing an image or playing a video clip into it
+// (requires Google Chrome, video is not supported on plain Chromium). The frame
+// orientation is fixed for the call; the resolution can be changed on the fly:
+// const videoCall = await client.call('1234567890', { video: true, orientation: 'portrait', waitForAnswer: true });
+// if (await videoCall.isConnected()) {
+//     await videoCall.showImage(MessageMedia.fromFilePath('./logo.png'));
+//     await videoCall.setVideoResolution(480);
+//     await videoCall.playVideo(MessageMedia.fromFilePath('./clip.mp4'), { loop: true });
+//     await videoCall.end();
+// }
+
 // Checking for an ongoing call and hanging it up:
 // const activeCall = await client.getActiveCall();
 // if (activeCall) await activeCall.end();

--- a/index.d.ts
+++ b/index.d.ts
@@ -212,10 +212,7 @@ declare namespace WAWebJS {
         ): Promise<Message>;
 
         /** Send a reaction to a specific messageId */
-        sendReaction(
-            messageId: string,
-            reaction: string,
-        ): Promise<void>;
+        sendReaction(messageId: string, reaction: string): Promise<void>;
 
         /** Sends a channel admin invitation to a user, allowing them to become an admin of the channel */
         sendChannelAdminInvite(
@@ -344,6 +341,19 @@ declare namespace WAWebJS {
 
         /** Generates a WhatsApp call link (video call or voice call) */
         createCallLink(startTime: Date, callType: string): Promise<string>;
+
+        /** Places an outgoing call to the provided chat or phone number */
+        call(
+            chatId: string,
+            options?: {
+                video?: boolean;
+                waitForAnswer?: boolean;
+                answerTimeout?: number;
+            },
+        ): Promise<Call>;
+
+        /** Gets the call that is currently ongoing (ringing, being placed or connected), if any */
+        getActiveCall(): Promise<Call | null>;
 
         /**
          * Sends a response to the scheduled event message, indicating whether a user is going to attend the event or not
@@ -2444,6 +2454,18 @@ declare namespace WAWebJS {
 
         /** Reject the call */
         reject: () => Promise<void>;
+
+        /** Accept the call (audio only by default, even for incoming video calls) */
+        accept: (options?: { video?: boolean }) => Promise<boolean>;
+
+        /** End an ongoing call */
+        end: () => Promise<boolean>;
+
+        /** Play an audio clip into the ongoing call so the other party can hear it */
+        playAudio: (media: MessageMedia | string) => Promise<number>;
+
+        /** Indicates whether the call is currently connected (the other party has answered) */
+        isConnected: () => Promise<boolean>;
     }
 
     /** Message type List */

--- a/index.d.ts
+++ b/index.d.ts
@@ -350,6 +350,8 @@ declare namespace WAWebJS {
                 waitForAnswer?: boolean;
                 answerTimeout?: number;
                 injectAudio?: boolean;
+                orientation?: 'landscape' | 'portrait' | 'auto';
+                resolution?: number;
             },
         ): Promise<Call>;
 
@@ -2460,6 +2462,8 @@ declare namespace WAWebJS {
         accept: (options?: {
             video?: boolean;
             injectAudio?: boolean;
+            orientation?: 'landscape' | 'portrait' | 'auto';
+            resolution?: number;
         }) => Promise<boolean>;
 
         /** End an ongoing call */
@@ -2467,6 +2471,18 @@ declare namespace WAWebJS {
 
         /** Play an audio clip into the ongoing call so the other party can hear it */
         playAudio: (media: MessageMedia | string) => Promise<number>;
+
+        /** Show a still image to the other party for the duration of a video call */
+        showImage: (media: MessageMedia | string) => Promise<boolean>;
+
+        /** Play a video clip into the ongoing video call so the other party can see it */
+        playVideo: (
+            media: MessageMedia | string,
+            options?: { loop?: boolean },
+        ) => Promise<number>;
+
+        /** Change the outgoing video resolution (the short side, in pixels) during a call */
+        setVideoResolution: (resolution: number) => Promise<boolean>;
 
         /** Indicates whether the call is currently connected (the other party has answered) */
         isConnected: () => Promise<boolean>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -349,6 +349,7 @@ declare namespace WAWebJS {
                 video?: boolean;
                 waitForAnswer?: boolean;
                 answerTimeout?: number;
+                injectAudio?: boolean;
             },
         ): Promise<Call>;
 
@@ -2456,7 +2457,10 @@ declare namespace WAWebJS {
         reject: () => Promise<void>;
 
         /** Accept the call (audio only by default, even for incoming video calls) */
-        accept: (options?: { video?: boolean }) => Promise<boolean>;
+        accept: (options?: {
+            video?: boolean;
+            injectAudio?: boolean;
+        }) => Promise<boolean>;
 
         /** End an ongoing call */
         end: () => Promise<boolean>;

--- a/src/Client.js
+++ b/src/Client.js
@@ -1172,7 +1172,18 @@ class Client extends EventEmitter {
                 if (!window._wwjsCallListener) {
                     window._wwjsCallListener = true;
                     WAWebCallCollection.on('change:activeCall', (call) => {
-                        emitCall(call);
+                        if (call) {
+                            emitCall(call);
+                        }
+                        // Restore the real microphone once the call is over so a
+                        // following normal call is not fed the injected stream.
+                        if (
+                            !call ||
+                            (typeof call.getState === 'function' &&
+                                call.getState() === 0)
+                        ) {
+                            window.WWebJS.teardownCallMediaStream?.();
+                        }
                     });
                 }
 
@@ -3325,22 +3336,25 @@ class Client extends EventEmitter {
      * @param {boolean} [options.video=false] Whether to place a video call instead of a voice call
      * @param {boolean} [options.waitForAnswer=false] If true, waits until the callee answers (or the timeout elapses) before resolving
      * @param {number} [options.answerTimeout=60000] Maximum time to wait for an answer, in milliseconds, when waitForAnswer is true
+     * @param {boolean} [options.injectAudio=true] Route the outgoing audio from injected clips (via Call.playAudio) instead of the real microphone. Set false to place a normal call
      * @returns {Promise<Call>} The placed call
      */
     async call(chatId, options = {}) {
         const callData = await this.pupPage.evaluate(
-            (id, isVideo, waitForAnswer, answerTimeout) => {
+            (id, isVideo, waitForAnswer, answerTimeout, injectAudio) => {
                 return window.WWebJS.startCall(
                     id,
                     isVideo,
                     waitForAnswer,
                     answerTimeout,
+                    injectAudio,
                 );
             },
             chatId,
             options.video ?? false,
             options.waitForAnswer ?? false,
             options.answerTimeout ?? 60000,
+            options.injectAudio ?? true,
         );
 
         return new Call(this, callData);

--- a/src/Client.js
+++ b/src/Client.js
@@ -499,6 +499,19 @@ class Client extends EventEmitter {
             // navigator.webdriver fix
             browserArgs.push('--disable-blink-features=AutomationControlled');
 
+            // Required for the calling feature: allow the audio graph to run
+            // without a user gesture and auto-grant the microphone permission.
+            const callArgs = [
+                '--autoplay-policy=no-user-gesture-required',
+                '--use-fake-ui-for-media-stream',
+            ];
+            for (const arg of callArgs) {
+                const flag = arg.split('=')[0];
+                if (!browserArgs.find((a) => a.startsWith(flag))) {
+                    browserArgs.push(arg);
+                }
+            }
+
             browser = await puppeteer.launch({
                 ...puppeteerOpts,
                 args: browserArgs,
@@ -1131,26 +1144,52 @@ class Client extends EventEmitter {
                 WAWebCallCollection &&
                 typeof WAWebCallCollection.on === 'function'
             ) {
+                const emitCall = (call) => {
+                    if (
+                        !call ||
+                        !call.id ||
+                        window._wwjsLastCallId === call.id
+                    ) {
+                        return;
+                    }
+                    window._wwjsLastCallId = call.id;
+                    window.onIncomingCall({
+                        id: call.id,
+                        peerJid: call.peerJid,
+                        isVideo: call.isVideo,
+                        isGroup: call.isGroup,
+                        canHandleLocally: call.canHandleLocally,
+                        outgoing: call.outgoing,
+                        webClientShouldHandle: call.webClientShouldHandle,
+                        participants: call.participants,
+                    });
+                };
+
+                // Newer WhatsApp Web surfaces calls through the collection's
+                // activeCall attribute instead of inserting them into the map.
+                // The changed call is passed as the handler argument; the
+                // lastActiveCall getter is not yet updated at this point.
+                if (!window._wwjsCallListener) {
+                    window._wwjsCallListener = true;
+                    WAWebCallCollection.on('change:activeCall', (call) => {
+                        emitCall(call);
+                    });
+                }
+
+                // Fallback for versions that still populate the internal map.
                 const mapKey = Object.keys(WAWebCallCollection).find(
                     (k) => WAWebCallCollection[k] instanceof Map,
                 );
-                const internalCallMap = WAWebCallCollection[mapKey];
-                const originalMapSet =
-                    internalCallMap.set.bind(internalCallMap);
+                if (mapKey) {
+                    const internalCallMap = WAWebCallCollection[mapKey];
+                    const originalMapSet =
+                        internalCallMap.set.bind(internalCallMap);
 
-                internalCallMap.set = function (key, value) {
-                    window.onIncomingCall({
-                        id: value.id,
-                        peerJid: value.peerJid,
-                        isVideo: value.isVideo,
-                        isGroup: value.isGroup,
-                        canHandleLocally: value.canHandleLocally,
-                        outgoing: value.outgoing,
-                        webClientShouldHandle: value.webClientShouldHandle,
-                        participants: value.participants,
-                    });
-                    return originalMapSet(key, value);
-                };
+                    internalCallMap.set = function (key, value) {
+                        emitCall(value);
+                        return originalMapSet(key, value);
+                    };
+                }
             }
             Chat.on('remove', async (chat) => {
                 window.onRemoveChatEvent(
@@ -3277,6 +3316,46 @@ class Client extends EventEmitter {
             startTime,
             callType,
         );
+    }
+
+    /**
+     * Places an outgoing call to the provided chat or phone number
+     * @param {string} chatId The chat ID ("@c.us" is automatically appended) or phone number to call
+     * @param {object} [options] Call options
+     * @param {boolean} [options.video=false] Whether to place a video call instead of a voice call
+     * @param {boolean} [options.waitForAnswer=false] If true, waits until the callee answers (or the timeout elapses) before resolving
+     * @param {number} [options.answerTimeout=60000] Maximum time to wait for an answer, in milliseconds, when waitForAnswer is true
+     * @returns {Promise<Call>} The placed call
+     */
+    async call(chatId, options = {}) {
+        const callData = await this.pupPage.evaluate(
+            (id, isVideo, waitForAnswer, answerTimeout) => {
+                return window.WWebJS.startCall(
+                    id,
+                    isVideo,
+                    waitForAnswer,
+                    answerTimeout,
+                );
+            },
+            chatId,
+            options.video ?? false,
+            options.waitForAnswer ?? false,
+            options.answerTimeout ?? 60000,
+        );
+
+        return new Call(this, callData);
+    }
+
+    /**
+     * Gets the call that is currently ongoing (ringing, being placed or connected), if any
+     * @returns {Promise<Call|null>} The current call, or null if there is no ongoing call
+     */
+    async getActiveCall() {
+        const callData = await this.pupPage.evaluate(() => {
+            return window.WWebJS.getActiveCall();
+        });
+
+        return callData ? new Call(this, callData) : null;
     }
 
     /**

--- a/src/Client.js
+++ b/src/Client.js
@@ -3337,17 +3337,20 @@ class Client extends EventEmitter {
      * @param {boolean} [options.waitForAnswer=false] If true, waits until the callee answers (or the timeout elapses) before resolving
      * @param {number} [options.answerTimeout=60000] Maximum time to wait for an answer, in milliseconds, when waitForAnswer is true
      * @param {boolean} [options.injectAudio=true] Route the outgoing audio from injected clips (via Call.playAudio) instead of the real microphone. Set false to place a normal call
+     * @param {string} [options.orientation='landscape'] Video frame orientation, either 'landscape', 'portrait' or 'auto' (follows the first source). Fixed for the whole call
+     * @param {number} [options.resolution=720] Video frame resolution (the short side, in pixels)
      * @returns {Promise<Call>} The placed call
      */
     async call(chatId, options = {}) {
         const callData = await this.pupPage.evaluate(
-            (id, isVideo, waitForAnswer, answerTimeout, injectAudio) => {
+            (id, isVideo, waitForAnswer, answerTimeout, injectAudio, video) => {
                 return window.WWebJS.startCall(
                     id,
                     isVideo,
                     waitForAnswer,
                     answerTimeout,
                     injectAudio,
+                    video,
                 );
             },
             chatId,
@@ -3355,6 +3358,10 @@ class Client extends EventEmitter {
             options.waitForAnswer ?? false,
             options.answerTimeout ?? 60000,
             options.injectAudio ?? true,
+            {
+                orientation: options.orientation,
+                resolution: options.resolution,
+            },
         );
 
         return new Call(this, callData);

--- a/src/structures/Call.js
+++ b/src/structures/Call.js
@@ -80,15 +80,17 @@ class Call extends Base {
      * Accept the call
      * @param {object} [options] Accept options
      * @param {boolean} [options.video=false] Whether to answer with video (requires a camera). Defaults to audio only, even for incoming video calls
+     * @param {boolean} [options.injectAudio=true] Route the outgoing audio from injected clips (via playAudio) instead of the real microphone. Set false to answer with the real microphone
      * @returns {Promise<boolean>}
      */
     async accept(options = {}) {
         return this.client.pupPage.evaluate(
-            (id, isVideo) => {
-                return window.WWebJS.acceptCall(id, isVideo);
+            (id, isVideo, injectAudio) => {
+                return window.WWebJS.acceptCall(id, isVideo, injectAudio);
             },
             this.id,
             options.video ?? false,
+            options.injectAudio ?? true,
         );
     }
 

--- a/src/structures/Call.js
+++ b/src/structures/Call.js
@@ -75,6 +75,54 @@ class Call extends Base {
             this.id,
         );
     }
+
+    /**
+     * Accept the call
+     * @param {object} [options] Accept options
+     * @param {boolean} [options.video=false] Whether to answer with video (requires a camera). Defaults to audio only, even for incoming video calls
+     * @returns {Promise<boolean>}
+     */
+    async accept(options = {}) {
+        return this.client.pupPage.evaluate(
+            (id, isVideo) => {
+                return window.WWebJS.acceptCall(id, isVideo);
+            },
+            this.id,
+            options.video ?? false,
+        );
+    }
+
+    /**
+     * End an ongoing call
+     * @returns {Promise<boolean>}
+     */
+    async end() {
+        return this.client.pupPage.evaluate((id) => {
+            return window.WWebJS.endCall(id);
+        }, this.id);
+    }
+
+    /**
+     * Play an audio clip into the ongoing call so the other party can hear it
+     * @param {MessageMedia|string} media A MessageMedia instance or a base64 encoded audio string
+     * @returns {Promise<number>} The duration of the played audio in seconds
+     */
+    async playAudio(media) {
+        const data = typeof media === 'string' ? media : media.data;
+        return this.client.pupPage.evaluate((base64) => {
+            return window.WWebJS.playCallAudio(base64);
+        }, data);
+    }
+
+    /**
+     * Indicates whether the call is currently connected (the other party has answered)
+     * @returns {Promise<boolean>}
+     */
+    async isConnected() {
+        return this.client.pupPage.evaluate((id) => {
+            return window.WWebJS.isCallConnected(id);
+        }, this.id);
+    }
 }
 
 module.exports = Call;

--- a/src/structures/Call.js
+++ b/src/structures/Call.js
@@ -81,16 +81,27 @@ class Call extends Base {
      * @param {object} [options] Accept options
      * @param {boolean} [options.video=false] Whether to answer with video (requires a camera). Defaults to audio only, even for incoming video calls
      * @param {boolean} [options.injectAudio=true] Route the outgoing audio from injected clips (via playAudio) instead of the real microphone. Set false to answer with the real microphone
+     * @param {string} [options.orientation='landscape'] Video frame orientation, either 'landscape', 'portrait' or 'auto' (follows the first source). Fixed for the whole call
+     * @param {number} [options.resolution=720] Video frame resolution (the short side, in pixels)
      * @returns {Promise<boolean>}
      */
     async accept(options = {}) {
         return this.client.pupPage.evaluate(
-            (id, isVideo, injectAudio) => {
-                return window.WWebJS.acceptCall(id, isVideo, injectAudio);
+            (id, isVideo, injectAudio, video) => {
+                return window.WWebJS.acceptCall(
+                    id,
+                    isVideo,
+                    injectAudio,
+                    video,
+                );
             },
             this.id,
             options.video ?? false,
             options.injectAudio ?? true,
+            {
+                orientation: options.orientation,
+                resolution: options.resolution,
+            },
         );
     }
 
@@ -114,6 +125,57 @@ class Call extends Base {
         return this.client.pupPage.evaluate((base64) => {
             return window.WWebJS.playCallAudio(base64);
         }, data);
+    }
+
+    /**
+     * Show a still image to the other party for the duration of a video call
+     * @param {MessageMedia|string} media A MessageMedia image or a base64 encoded image string
+     * @returns {Promise<boolean>}
+     */
+    async showImage(media) {
+        const data = typeof media === 'string' ? media : media.data;
+        const mimetype =
+            typeof media === 'string' ? 'image/jpeg' : media.mimetype;
+        return this.client.pupPage.evaluate(
+            (base64, type) => {
+                return window.WWebJS.showCallImage(base64, type);
+            },
+            data,
+            mimetype,
+        );
+    }
+
+    /**
+     * Play a video clip into the ongoing video call so the other party can see it
+     * @param {MessageMedia|string} media A MessageMedia instance or a base64 encoded video string
+     * @param {object} [options] Playback options
+     * @param {boolean} [options.loop=false] Whether to loop the clip; when false it stops on the last frame
+     * @returns {Promise<number>} The duration of the played video in seconds
+     */
+    async playVideo(media, options = {}) {
+        const data = typeof media === 'string' ? media : media.data;
+        const mimetype =
+            typeof media === 'string' ? 'video/mp4' : media.mimetype;
+        return this.client.pupPage.evaluate(
+            (base64, type, opts) => {
+                return window.WWebJS.playCallVideo(base64, type, opts);
+            },
+            data,
+            mimetype,
+            options,
+        );
+    }
+
+    /**
+     * Change the outgoing video resolution during a call. The orientation is
+     * fixed when the call starts and cannot be changed, but the resolution can
+     * @param {number} resolution The frame resolution (the short side, in pixels)
+     * @returns {Promise<boolean>}
+     */
+    async setVideoResolution(resolution) {
+        return this.client.pupPage.evaluate((px) => {
+            return window.WWebJS.setCallVideoResolution(px);
+        }, resolution);
     }
 
     /**

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1357,6 +1357,11 @@ exports.LoadUtils = () => {
 
     window.WWebJS.setupCallMediaStream = () => {
         const store = window.WWebJS;
+        // Route the outgoing microphone through our own graph only while an
+        // injected call is active, so ordinary calls keep using the real
+        // microphone (see teardownCallMediaStream).
+        store._callMediaActive = true;
+
         if (store._callMedia && store._callMedia.context.state !== 'closed') {
             return store._callMedia;
         }
@@ -1371,7 +1376,8 @@ exports.LoadUtils = () => {
 
         // WhatsApp acquires the microphone through this single entry point.
         // Patch it once so the outgoing audio track is fed from our own graph
-        // instead of a physical device. A fresh destination is handed out on
+        // instead of a physical device, but only while injection is active so
+        // normal calls are left untouched. A fresh destination is handed out on
         // every call because WhatsApp stops the track when the stream is
         // disposed, which would permanently silence a shared destination.
         const mediaModule = window.require('WAGetUserMedia');
@@ -1380,7 +1386,11 @@ exports.LoadUtils = () => {
             mediaModule._wwebjsPatched = true;
             mediaModule.getUserMedia = (constraints) => {
                 const media = window.WWebJS._callMedia;
-                if ((constraints && constraints.video) || !media) {
+                if (
+                    (constraints && constraints.video) ||
+                    !media ||
+                    !window.WWebJS._callMediaActive
+                ) {
                     return original(constraints);
                 }
                 const destination =
@@ -1392,6 +1402,23 @@ exports.LoadUtils = () => {
         }
 
         return store._callMedia;
+    };
+
+    window.WWebJS.teardownCallMediaStream = () => {
+        const media = window.WWebJS._callMedia;
+        window.WWebJS._callMediaActive = false;
+        if (!media) return;
+
+        // Detach the destinations handed out during the call so the next call
+        // starts from a clean graph and the real microphone is used again.
+        for (const destination of media.destinations) {
+            try {
+                media.master.disconnect(destination);
+            } catch {
+                // The destination was already disconnected by WhatsApp.
+            }
+        }
+        media.destinations = [];
     };
 
     window.WWebJS.playCallAudio = async (base64) => {
@@ -1417,8 +1444,14 @@ exports.LoadUtils = () => {
         });
     };
 
-    window.WWebJS.acceptCall = async (callId, isVideo = false) => {
-        window.WWebJS.setupCallMediaStream();
+    window.WWebJS.acceptCall = async (
+        callId,
+        isVideo = false,
+        injectAudio = true,
+    ) => {
+        if (injectAudio) {
+            window.WWebJS.setupCallMediaStream();
+        }
         const stack = await window.WWebJS.getCallStackInterface();
         await stack.acceptCall(callId, isVideo);
         return true;
@@ -1430,6 +1463,7 @@ exports.LoadUtils = () => {
             'WAWebWamEnumCallTermReason',
         );
         await stack.endCall(callId, CALL_TERM_REASON.ENDED_BY_USER);
+        window.WWebJS.teardownCallMediaStream();
         return true;
     };
 
@@ -1438,8 +1472,11 @@ exports.LoadUtils = () => {
         isVideo = false,
         waitForAnswer = false,
         timeout = 60000,
+        injectAudio = true,
     ) => {
-        window.WWebJS.setupCallMediaStream();
+        if (injectAudio) {
+            window.WWebJS.setupCallMediaStream();
+        }
 
         let wid;
         const target = String(chatId);

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1448,9 +1448,13 @@ exports.LoadUtils = () => {
         callId,
         isVideo = false,
         injectAudio = true,
+        video = {},
     ) => {
         if (injectAudio) {
             window.WWebJS.setupCallMediaStream();
+        }
+        if (isVideo) {
+            window.WWebJS.setupCallVideoStream(video);
         }
         const stack = await window.WWebJS.getCallStackInterface();
         await stack.acceptCall(callId, isVideo);
@@ -1486,9 +1490,13 @@ exports.LoadUtils = () => {
         waitForAnswer = false,
         timeout = 60000,
         injectAudio = true,
+        video = {},
     ) => {
         if (injectAudio) {
             window.WWebJS.setupCallMediaStream();
+        }
+        if (isVideo) {
+            window.WWebJS.setupCallVideoStream(video);
         }
 
         let wid;
@@ -1571,6 +1579,314 @@ exports.LoadUtils = () => {
             isGroup: call.isGroup,
             outgoing: call.outgoing,
         };
+    };
+
+    window.WWebJS.setupCallVideoStream = (options = {}) => {
+        const store = window.WWebJS;
+        window.WWebJS.setupCallMediaStream();
+        if (store._callVideo) {
+            if (options.orientation) {
+                window.WWebJS.setCallVideoOrientation(options.orientation);
+            }
+            if (options.resolution) {
+                window.WWebJS.setCallVideoResolution(options.resolution);
+            }
+            return store._callVideo;
+        }
+
+        const canvas = document.createElement('canvas');
+        const context = canvas.getContext('2d');
+
+        // orientation fixes the outgoing frame shape (WhatsApp locks it for the
+        // whole call); rotate counters the turn WhatsApp applies to a portrait
+        // frame; resolution is the short side of the frame in pixels.
+        const callVideo = {
+            canvas,
+            context,
+            source: null,
+            orientation: 'landscape',
+            resolution: 720,
+            rotate: 0,
+        };
+        store._callVideo = callVideo;
+        window.WWebJS.setCallVideoOrientation(
+            options.orientation || 'landscape',
+        );
+        if (options.resolution) {
+            window.WWebJS.setCallVideoResolution(options.resolution);
+        }
+
+        // Draw the current source (a still image or a playing video) onto the
+        // canvas on a fixed interval. captureStream() reads from the canvas, so
+        // this loop is what actually produces the outgoing frames. setInterval
+        // is used instead of requestAnimationFrame because the tab is often
+        // backgrounded, which throttles animation frames to a crawl.
+        callVideo.timer = setInterval(() => {
+            const video = window.WWebJS._callVideo;
+            // Stop a stale loop if the utils were re-injected (which resets
+            // window.WWebJS) and a newer stream took over.
+            if (video !== callVideo) {
+                clearInterval(callVideo.timer);
+                return;
+            }
+
+            const frameWidth = canvas.width;
+            const frameHeight = canvas.height;
+            context.fillStyle = '#000000';
+            context.fillRect(0, 0, frameWidth, frameHeight);
+
+            const source = video.source;
+            if (!source) {
+                return;
+            }
+
+            const element = source.element;
+            // Chrome occasionally pauses hidden media elements on its own;
+            // resume a clip that is supposed to be playing (a finished
+            // non-looping clip legitimately stays on its last frame).
+            if (source.type === 'video' && element.paused && !element.ended) {
+                element.play().catch(() => {});
+            }
+            const mediaWidth =
+                source.type === 'video'
+                    ? element.videoWidth
+                    : element.naturalWidth;
+            const mediaHeight =
+                source.type === 'video'
+                    ? element.videoHeight
+                    : element.naturalHeight;
+            if (!mediaWidth || !mediaHeight) {
+                return;
+            }
+
+            // When the frame is rotated a quarter turn, the media is fitted
+            // against the swapped dimensions. It is centred and letterboxed so
+            // it always shows in full, whatever its aspect ratio.
+            const turned = Math.abs(video.rotate) % 180 === 90;
+            const fitWidth = turned ? frameHeight : frameWidth;
+            const fitHeight = turned ? frameWidth : frameHeight;
+            const scale = Math.min(
+                fitWidth / mediaWidth,
+                fitHeight / mediaHeight,
+            );
+            const drawWidth = mediaWidth * scale;
+            const drawHeight = mediaHeight * scale;
+            context.save();
+            context.translate(frameWidth / 2, frameHeight / 2);
+            if (video.rotate) {
+                context.rotate((video.rotate * Math.PI) / 180);
+            }
+            context.drawImage(
+                element,
+                -drawWidth / 2,
+                -drawHeight / 2,
+                drawWidth,
+                drawHeight,
+            );
+            context.restore();
+        }, 40);
+
+        // The camera is acquired straight through navigator.mediaDevices (the
+        // microphone goes through WAGetUserMedia instead, see above). Patch it
+        // once so the outgoing video track is fed from our canvas. When audio is
+        // requested alongside the camera it is served from the same graph the
+        // microphone uses, so injected audio is heard on video calls too. A
+        // fresh stream is handed out every time because WhatsApp stops the track
+        // when the stream is disposed.
+        const devices = navigator.mediaDevices;
+        if (devices && !devices._wwebjsPatched) {
+            const original = devices.getUserMedia.bind(devices);
+            devices._wwebjsPatched = true;
+            devices.getUserMedia = (constraints) => {
+                const video = window.WWebJS._callVideo;
+                const media = window.WWebJS._callMedia;
+                if (
+                    !constraints ||
+                    (!constraints.video && !constraints.audio)
+                ) {
+                    return original(constraints);
+                }
+
+                const stream = new MediaStream();
+                if (constraints.video && video) {
+                    stream.addTrack(
+                        video.canvas.captureStream(30).getVideoTracks()[0],
+                    );
+                }
+                if (constraints.audio && media) {
+                    const destination =
+                        media.context.createMediaStreamDestination();
+                    media.master.connect(destination);
+                    media.destinations.push(destination);
+                    stream.addTrack(destination.stream.getAudioTracks()[0]);
+                }
+
+                if (!stream.getTracks().length) {
+                    return original(constraints);
+                }
+                return Promise.resolve(stream);
+            };
+        }
+
+        return store._callVideo;
+    };
+
+    // Fix the outgoing frame orientation for the call. A portrait frame is
+    // pre-rotated because WhatsApp turns a portrait camera to correct for a
+    // landscape-mounted sensor; screen.orientation is aligned to it so that
+    // correction is predictable regardless of the host environment. 'auto'
+    // follows the current source's aspect ratio.
+    window.WWebJS.setCallVideoOrientation = (orientation) => {
+        const video = window.WWebJS._callVideo;
+        if (!video) {
+            return;
+        }
+
+        let mode = orientation;
+        if (mode !== 'portrait' && mode !== 'landscape') {
+            const source = video.source;
+            const element = source && source.element;
+            const mediaWidth =
+                element &&
+                (source.type === 'video'
+                    ? element.videoWidth
+                    : element.naturalWidth);
+            const mediaHeight =
+                element &&
+                (source.type === 'video'
+                    ? element.videoHeight
+                    : element.naturalHeight);
+            mode =
+                mediaWidth && mediaHeight && mediaHeight > mediaWidth
+                    ? 'portrait'
+                    : 'landscape';
+        }
+
+        video.orientation = mode;
+        video.rotate = mode === 'portrait' ? -90 : 0;
+        try {
+            const type =
+                mode === 'portrait' ? 'portrait-primary' : 'landscape-primary';
+            Object.defineProperty(screen.orientation, 'type', {
+                get: () => type,
+                configurable: true,
+            });
+            Object.defineProperty(screen.orientation, 'angle', {
+                get: () => 0,
+                configurable: true,
+            });
+        } catch (ignoredError) {
+            // Some environments do not allow overriding screen.orientation.
+        }
+        window.WWebJS.resizeCallVideoCanvas();
+    };
+
+    window.WWebJS.setCallVideoResolution = (resolution) => {
+        const video = window.WWebJS._callVideo;
+        if (!video || !resolution) {
+            return false;
+        }
+        video.resolution = resolution;
+        window.WWebJS.resizeCallVideoCanvas();
+        return true;
+    };
+
+    // Size the canvas (and therefore the outgoing track) from the chosen
+    // orientation and resolution. The resolution is the short side; the long
+    // side follows a 16:9 frame. WhatsApp caps the encode around 720p, so there
+    // is nothing to gain from going much higher.
+    window.WWebJS.resizeCallVideoCanvas = () => {
+        const video = window.WWebJS._callVideo;
+        if (!video) {
+            return;
+        }
+        const target = Math.min(video.resolution || 720, 1080);
+        // Even dimensions keep the encoder happy.
+        const shortSide = Math.round(target / 2) * 2;
+        const longSide = Math.round((shortSide * 16) / 9 / 2) * 2;
+        const portrait = video.orientation === 'portrait';
+        const width = portrait ? shortSide : longSide;
+        const height = portrait ? longSide : shortSide;
+        if (video.canvas.width !== width || video.canvas.height !== height) {
+            video.canvas.width = width;
+            video.canvas.height = height;
+        }
+    };
+
+    window.WWebJS.showCallImage = async (base64, mimetype) => {
+        const video = window.WWebJS.setupCallVideoStream();
+
+        const image = new Image();
+        await new Promise((resolve, reject) => {
+            image.onload = resolve;
+            image.onerror = () => reject(new Error('Failed to load image'));
+            image.src = `data:${mimetype};base64,${base64}`;
+        });
+
+        window.WWebJS.disposeCallVideoSource();
+        video.source = { type: 'image', element: image };
+        return true;
+    };
+
+    window.WWebJS.playCallVideo = async (base64, mimetype, options = {}) => {
+        const video = window.WWebJS.setupCallVideoStream();
+
+        const binary = atob(base64);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+        const url = URL.createObjectURL(
+            new Blob([bytes.buffer], { type: mimetype }),
+        );
+
+        const element = document.createElement('video');
+        element.muted = true;
+        element.playsInline = true;
+        element.loop = options.loop === true;
+        element.src = url;
+        // Chrome keeps a detached media element paused, so the source video has
+        // to live in the document (kept off-screen) for playback to advance.
+        element.style.position = 'fixed';
+        element.style.top = '-9999px';
+        element.style.width = '1px';
+        element.style.height = '1px';
+        document.body.appendChild(element);
+
+        await new Promise((resolve, reject) => {
+            element.onloadedmetadata = resolve;
+            element.onerror = () => reject(new Error('Failed to load video'));
+        });
+
+        window.WWebJS.disposeCallVideoSource();
+        video.source = { type: 'video', element, url };
+
+        // A looping clip never ends, so resolve as soon as it starts playing;
+        // otherwise resolve when it finishes so clips can be chained. The last
+        // frame stays on screen until another source is set.
+        return new Promise((resolve) => {
+            if (element.loop) {
+                element.play().then(() => resolve(element.duration));
+            } else {
+                element.onended = () => resolve(element.duration);
+                element.play();
+            }
+        });
+    };
+
+    // Tear down the current outgoing video source. A playing clip keeps its
+    // element in the document, so it is removed before a new source is set to
+    // avoid piling up hidden video elements.
+    window.WWebJS.disposeCallVideoSource = () => {
+        const video = window.WWebJS._callVideo;
+        const source = video && video.source;
+        if (source && source.type === 'video') {
+            source.element.pause();
+            source.element.remove();
+            if (source.url) {
+                URL.revokeObjectURL(source.url);
+            }
+        }
     };
 
     window.WWebJS.cropAndResizeImage = async (media, options = {}) => {

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1320,6 +1320,13 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.rejectCall = async (peerJid, id) => {
+        const stack = await window.WWebJS.getCallStackInterface();
+        if (stack && typeof stack.rejectCall === 'function') {
+            await stack.rejectCall();
+            return;
+        }
+
+        // Fallback signaling stanza for older WhatsApp Web builds.
         let userId = window
             .require('WAWebUserPrefsMeUser')
             .getMaybeMePnUser()._serialized;
@@ -1340,6 +1347,181 @@ exports.LoadUtils = () => {
             ],
         );
         await window.require('WADeprecatedSendIq').deprecatedCastStanza(stanza);
+    };
+
+    window.WWebJS.getCallStackInterface = async () => {
+        return window
+            .require('WAWebVoipStackInterface')
+            .getVoipStackInterface();
+    };
+
+    window.WWebJS.setupCallMediaStream = () => {
+        const store = window.WWebJS;
+        if (store._callMedia && store._callMedia.context.state !== 'closed') {
+            return store._callMedia;
+        }
+
+        const AudioContextClass =
+            window.AudioContext || window.webkitAudioContext;
+        const context = new AudioContextClass();
+        const master = context.createGain();
+        master.gain.value = 1;
+
+        store._callMedia = { context, master, destinations: [] };
+
+        // WhatsApp acquires the microphone through this single entry point.
+        // Patch it once so the outgoing audio track is fed from our own graph
+        // instead of a physical device. A fresh destination is handed out on
+        // every call because WhatsApp stops the track when the stream is
+        // disposed, which would permanently silence a shared destination.
+        const mediaModule = window.require('WAGetUserMedia');
+        if (!mediaModule._wwebjsPatched) {
+            const original = mediaModule.getUserMedia;
+            mediaModule._wwebjsPatched = true;
+            mediaModule.getUserMedia = (constraints) => {
+                const media = window.WWebJS._callMedia;
+                if ((constraints && constraints.video) || !media) {
+                    return original(constraints);
+                }
+                const destination =
+                    media.context.createMediaStreamDestination();
+                media.master.connect(destination);
+                media.destinations.push(destination);
+                return Promise.resolve(destination.stream);
+            };
+        }
+
+        return store._callMedia;
+    };
+
+    window.WWebJS.playCallAudio = async (base64) => {
+        const { context, master } = window.WWebJS.setupCallMediaStream();
+        if (context.state === 'suspended') {
+            await context.resume();
+        }
+
+        const binary = atob(base64);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+
+        const buffer = await context.decodeAudioData(bytes.buffer);
+        const source = context.createBufferSource();
+        source.buffer = buffer;
+        source.connect(master);
+
+        return new Promise((resolve) => {
+            source.onended = () => resolve(buffer.duration);
+            source.start();
+        });
+    };
+
+    window.WWebJS.acceptCall = async (callId, isVideo = false) => {
+        window.WWebJS.setupCallMediaStream();
+        const stack = await window.WWebJS.getCallStackInterface();
+        await stack.acceptCall(callId, isVideo);
+        return true;
+    };
+
+    window.WWebJS.endCall = async (callId) => {
+        const stack = await window.WWebJS.getCallStackInterface();
+        const { CALL_TERM_REASON } = window.require(
+            'WAWebWamEnumCallTermReason',
+        );
+        await stack.endCall(callId, CALL_TERM_REASON.ENDED_BY_USER);
+        return true;
+    };
+
+    window.WWebJS.startCall = async (
+        chatId,
+        isVideo = false,
+        waitForAnswer = false,
+        timeout = 60000,
+    ) => {
+        window.WWebJS.setupCallMediaStream();
+
+        let wid;
+        const target = String(chatId);
+        if (target.includes('@')) {
+            wid = window.require('WAWebWidFactory').createWid(target);
+        } else {
+            const result = await window
+                .require('WAWebQueryExistsJob')
+                .queryPhoneExists('+' + target.replace(/\D/g, ''));
+            if (!result || !result.wid) {
+                throw new Error(
+                    'The provided phone number is not registered on WhatsApp',
+                );
+            }
+            wid = result.wid;
+        }
+
+        const { CALL_FROM_UI } = window.require('WAWebWamEnumCallFromUi');
+        await window
+            .require('WAWebVoipStartCall')
+            .startWAWebVoipCall(wid, isVideo, CALL_FROM_UI.CONVERSATION);
+
+        // The call is registered in the collection shortly after the offer is
+        // sent, so wait for it to become available before returning its data.
+        const collection = window.require('WAWebCallCollection');
+        let call = collection.lastActiveCall;
+        for (let i = 0; i < 30 && !call; i++) {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+            call = collection.lastActiveCall;
+        }
+
+        // Optionally block until the callee answers (or the timeout elapses).
+        if (call && waitForAnswer) {
+            const deadline = Date.now() + timeout;
+            while (Date.now() < deadline) {
+                if (
+                    collection.isInConnectedCall &&
+                    collection.lastActiveCall &&
+                    collection.lastActiveCall.id === call.id
+                ) {
+                    break;
+                }
+                await new Promise((resolve) => setTimeout(resolve, 200));
+            }
+        }
+
+        return call
+            ? {
+                  id: call.id,
+                  peerJid: call.peerJid?._serialized,
+                  isVideo: call.isVideo,
+                  isGroup: call.isGroup,
+                  outgoing: call.outgoing,
+              }
+            : null;
+    };
+
+    window.WWebJS.isCallConnected = (callId) => {
+        const collection = window.require('WAWebCallCollection');
+        return (
+            collection.isInConnectedCall === true &&
+            !!collection.lastActiveCall &&
+            collection.lastActiveCall.id === callId
+        );
+    };
+
+    window.WWebJS.getActiveCall = () => {
+        const call = window.require('WAWebCallCollection').lastActiveCall;
+        if (
+            !call ||
+            (typeof call.getState === 'function' && call.getState() === 0)
+        ) {
+            return null;
+        }
+        return {
+            id: call.id,
+            peerJid: call.peerJid?._serialized,
+            offerTime: call.offerTime,
+            isVideo: call.isVideo,
+            isGroup: call.isGroup,
+            outgoing: call.outgoing,
+        };
     };
 
     window.WWebJS.cropAndResizeImage = async (media, options = {}) => {

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -1467,6 +1467,19 @@ exports.LoadUtils = () => {
         return true;
     };
 
+    window.WWebJS.getOngoingCall = () => {
+        // lastActiveCall keeps pointing at the previous call even after it ends,
+        // so a call in the ended state (0) is treated as no ongoing call.
+        const call = window.require('WAWebCallCollection').lastActiveCall;
+        if (
+            !call ||
+            (typeof call.getState === 'function' && call.getState() === 0)
+        ) {
+            return null;
+        }
+        return call;
+    };
+
     window.WWebJS.startCall = async (
         chatId,
         isVideo = false,
@@ -1500,22 +1513,24 @@ exports.LoadUtils = () => {
             .startWAWebVoipCall(wid, isVideo, CALL_FROM_UI.CONVERSATION);
 
         // The call is registered in the collection shortly after the offer is
-        // sent, so wait for it to become available before returning its data.
+        // sent, so wait for the newly placed call to become available before
+        // returning its data.
         const collection = window.require('WAWebCallCollection');
-        let call = collection.lastActiveCall;
+        let call = null;
         for (let i = 0; i < 30 && !call; i++) {
             await new Promise((resolve) => setTimeout(resolve, 100));
-            call = collection.lastActiveCall;
+            call = window.WWebJS.getOngoingCall();
         }
 
         // Optionally block until the callee answers (or the timeout elapses).
         if (call && waitForAnswer) {
             const deadline = Date.now() + timeout;
             while (Date.now() < deadline) {
+                const current = window.WWebJS.getOngoingCall();
                 if (
                     collection.isInConnectedCall &&
-                    collection.lastActiveCall &&
-                    collection.lastActiveCall.id === call.id
+                    current &&
+                    current.id === call.id
                 ) {
                     break;
                 }
@@ -1544,11 +1559,8 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.getActiveCall = () => {
-        const call = window.require('WAWebCallCollection').lastActiveCall;
-        if (
-            !call ||
-            (typeof call.getState === 'function' && call.getState() === 0)
-        ) {
+        const call = window.WWebJS.getOngoingCall();
+        if (!call) {
             return null;
         }
         return {

--- a/tests/call.js
+++ b/tests/call.js
@@ -1,0 +1,160 @@
+const chai = require('chai');
+const sinon = require('sinon');
+
+const Call = require('../src/structures/Call');
+const Client = require('../src/Client');
+
+const expect = chai.expect;
+
+// These are unit tests: the injected browser functions run inside WhatsApp Web,
+// so the pupPage.evaluate calls are stubbed and only the API surface (the
+// arguments handed to the injected layer) is asserted. No live session needed.
+describe('Calls', function () {
+    describe('Call', function () {
+        const callData = {
+            id: 'call-id',
+            peerJid: 'peer@c.us',
+            offerTime: 1700000000,
+            isVideo: false,
+            isGroup: false,
+            outgoing: true,
+        };
+
+        let client;
+        let call;
+
+        beforeEach(function () {
+            client = { pupPage: { evaluate: sinon.stub().resolves(true) } };
+            call = new Call(client, callData);
+        });
+
+        it('exposes the call data', function () {
+            expect(call.id).to.equal('call-id');
+            expect(call.from).to.equal('peer@c.us');
+            expect(call.timestamp).to.equal(1700000000);
+            expect(call.isVideo).to.equal(false);
+            expect(call.isGroup).to.equal(false);
+            expect(call.fromMe).to.equal(true);
+        });
+
+        describe('accept', function () {
+            it('answers with audio and injection on by default', async function () {
+                await call.accept();
+                expect(client.pupPage.evaluate.calledOnce).to.equal(true);
+                const args = client.pupPage.evaluate.firstCall.args;
+                expect(args[0]).to.be.a('function');
+                expect(args.slice(1)).to.deep.equal(['call-id', false, true]);
+            });
+
+            it('answers with video when requested', async function () {
+                await call.accept({ video: true });
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['call-id', true, true]);
+            });
+
+            it('can disable audio injection to use the real microphone', async function () {
+                await call.accept({ injectAudio: false });
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['call-id', false, false]);
+            });
+        });
+
+        describe('reject', function () {
+            it('rejects using the peer jid and the call id', async function () {
+                await call.reject();
+                const args = client.pupPage.evaluate.firstCall.args;
+                expect(args[0]).to.be.a('function');
+                expect(args.slice(1)).to.deep.equal(['peer@c.us', 'call-id']);
+            });
+        });
+
+        describe('end', function () {
+            it('ends the call by id', async function () {
+                await call.end();
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['call-id']);
+            });
+        });
+
+        describe('playAudio', function () {
+            it('accepts a base64 string', async function () {
+                await call.playAudio('BASE64DATA');
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['BASE64DATA']);
+            });
+
+            it('accepts a MessageMedia and forwards its data', async function () {
+                await call.playAudio({
+                    mimetype: 'audio/ogg',
+                    data: 'MEDIA64',
+                });
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['MEDIA64']);
+            });
+        });
+
+        describe('isConnected', function () {
+            it('returns the resolved connection state', async function () {
+                client.pupPage.evaluate.resolves(true);
+                const result = await call.isConnected();
+                expect(result).to.equal(true);
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['call-id']);
+            });
+        });
+    });
+
+    describe('Client.call', function () {
+        let client;
+
+        beforeEach(function () {
+            client = {
+                pupPage: {
+                    evaluate: sinon.stub().resolves({
+                        id: 'new-call',
+                        peerJid: 'peer@c.us',
+                        isVideo: false,
+                        isGroup: false,
+                        outgoing: true,
+                    }),
+                },
+            };
+        });
+
+        it('places a voice call with injection on by default', async function () {
+            const result = await Client.prototype.call.call(
+                client,
+                '15551234567',
+            );
+            expect(result).to.be.instanceOf(Call);
+            expect(result.id).to.equal('new-call');
+            const args = client.pupPage.evaluate.firstCall.args;
+            expect(args[0]).to.be.a('function');
+            expect(args.slice(1)).to.deep.equal([
+                '15551234567',
+                false,
+                false,
+                60000,
+                true,
+            ]);
+        });
+
+        it('forwards video, waitForAnswer, answerTimeout and injectAudio', async function () {
+            await Client.prototype.call.call(client, '15551234567', {
+                video: true,
+                waitForAnswer: true,
+                answerTimeout: 1000,
+                injectAudio: false,
+            });
+            expect(
+                client.pupPage.evaluate.firstCall.args.slice(1),
+            ).to.deep.equal(['15551234567', true, true, 1000, false]);
+        });
+    });
+});

--- a/tests/call.js
+++ b/tests/call.js
@@ -6,6 +6,8 @@ const Client = require('../src/Client');
 
 const expect = chai.expect;
 
+const noVideo = { orientation: undefined, resolution: undefined };
+
 // These are unit tests: the injected browser functions run inside WhatsApp Web,
 // so the pupPage.evaluate calls are stubbed and only the API surface (the
 // arguments handed to the injected layer) is asserted. No live session needed.
@@ -43,21 +45,42 @@ describe('Calls', function () {
                 expect(client.pupPage.evaluate.calledOnce).to.equal(true);
                 const args = client.pupPage.evaluate.firstCall.args;
                 expect(args[0]).to.be.a('function');
-                expect(args.slice(1)).to.deep.equal(['call-id', false, true]);
+                expect(args.slice(1)).to.deep.equal([
+                    'call-id',
+                    false,
+                    true,
+                    noVideo,
+                ]);
             });
 
             it('answers with video when requested', async function () {
                 await call.accept({ video: true });
                 expect(
                     client.pupPage.evaluate.firstCall.args.slice(1),
-                ).to.deep.equal(['call-id', true, true]);
+                ).to.deep.equal(['call-id', true, true, noVideo]);
             });
 
             it('can disable audio injection to use the real microphone', async function () {
                 await call.accept({ injectAudio: false });
                 expect(
                     client.pupPage.evaluate.firstCall.args.slice(1),
-                ).to.deep.equal(['call-id', false, false]);
+                ).to.deep.equal(['call-id', false, false, noVideo]);
+            });
+
+            it('forwards the video orientation and resolution', async function () {
+                await call.accept({
+                    video: true,
+                    orientation: 'portrait',
+                    resolution: 480,
+                });
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal([
+                    'call-id',
+                    true,
+                    true,
+                    { orientation: 'portrait', resolution: 480 },
+                ]);
             });
         });
 
@@ -95,6 +118,40 @@ describe('Calls', function () {
                 expect(
                     client.pupPage.evaluate.firstCall.args.slice(1),
                 ).to.deep.equal(['MEDIA64']);
+            });
+        });
+
+        describe('showImage', function () {
+            it('defaults the mimetype for a base64 string', async function () {
+                await call.showImage('IMG64');
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['IMG64', 'image/jpeg']);
+            });
+
+            it('forwards a MessageMedia mimetype', async function () {
+                await call.showImage({ mimetype: 'image/png', data: 'PNG64' });
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['PNG64', 'image/png']);
+            });
+        });
+
+        describe('playVideo', function () {
+            it('defaults the mimetype and passes the options', async function () {
+                await call.playVideo('VID64', { loop: true });
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal(['VID64', 'video/mp4', { loop: true }]);
+            });
+        });
+
+        describe('setVideoResolution', function () {
+            it('forwards the resolution', async function () {
+                await call.setVideoResolution(720);
+                expect(
+                    client.pupPage.evaluate.firstCall.args.slice(1),
+                ).to.deep.equal([720]);
             });
         });
 
@@ -142,19 +199,29 @@ describe('Calls', function () {
                 false,
                 60000,
                 true,
+                noVideo,
             ]);
         });
 
-        it('forwards video, waitForAnswer, answerTimeout and injectAudio', async function () {
+        it('forwards video, waitForAnswer, answerTimeout, injectAudio and video options', async function () {
             await Client.prototype.call.call(client, '15551234567', {
                 video: true,
                 waitForAnswer: true,
                 answerTimeout: 1000,
                 injectAudio: false,
+                orientation: 'portrait',
+                resolution: 480,
             });
             expect(
                 client.pupPage.evaluate.firstCall.args.slice(1),
-            ).to.deep.equal(['15551234567', true, true, 1000, false]);
+            ).to.deep.equal([
+                '15551234567',
+                true,
+                true,
+                1000,
+                false,
+                { orientation: 'portrait', resolution: 480 },
+            ]);
         });
     });
 });


### PR DESCRIPTION
## Description

Builds on #201825 (call answering and audio injection) and adds video to calls: show a still image or play a video clip to the other party, in landscape or portrait, at a chosen resolution.

New `Call` methods:
- `showImage(media)` shows a still image to the other party for the duration of the call
- `playVideo(media, { loop })` plays a video clip into the call; resolves when it finishes, or immediately when looping
- `setVideoResolution(px)` changes the outgoing video resolution mid-call

New options on `Client.call` / `Call.accept`:
- `orientation`: `'landscape'` (default), `'portrait'`, or `'auto'` (follows the first source). Fixed for the whole call.
- `resolution`: the short side of the frame in pixels (default 720).

Injected audio (`playAudio` from #201825) works during video calls too, so you can show video and speak at the same time.

## How

The outgoing camera is acquired through `navigator.mediaDevices.getUserMedia`, which is patched to serve a canvas-backed stream instead of a physical camera. A draw loop paints the current source (a still image or a looping video) onto the canvas, and `canvas.captureStream()` produces the outgoing frames. No camera is required and it works headless.

## Notes

- Stacked on #201825. The audio commits shown here belong to that PR; once it merges this branch will be rebased so the diff shows only the video changes.
- Requires Google Chrome (H.264), as already documented for "Send media (video)".

## Testing Summary

Verified live end-to-end against a real phone: showing a still image, playing a looping portrait video, injected audio playing over the video at the same time, and a mid-call resolution change. Unit tests for the call API are in `tests/call.js`.
